### PR TITLE
Set font color on annotation class to override github dark mode color

### DIFF
--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -69,6 +69,7 @@ body ._JX {
 
   &_annotation {
     max-width: 600px;
+    color: #24292f;
     border: 1px solid #dde4e6;
     border-radius: 3px;
     background-color: white;


### PR DESCRIPTION
Without this fix the annotation box is hard to read in dark mode, and unreadable in high contrast dark mode
Related to (but not a fix for) #22 