### PR TITLE
Implement an inline badge feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Node.js",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,44 +1,44 @@
 module.exports = {
-  "env": {
-    "browser": true,
-    "es6": true,
-    "commonjs": true
+  'env': {
+    'browser': true,
+    'es6': true,
+    'commonjs': true
   },
-  "globals": {
-    "chrome": true
+  'globals': {
+    'chrome': true
   },
-  "extends": "eslint:recommended",
-  "parser": "babel-eslint",
-  "plugins": [
-    "react"
+  'extends': 'eslint:recommended',
+  'parser': 'babel-eslint',
+  'plugins': [
+    'react'
   ],
-  "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true,
-      "experimentalObjectRestSpread": true,
+  'parserOptions': {
+    'ecmaFeatures': {
+      'jsx': true,
+      'experimentalObjectRestSpread': true,
     },
-    "sourceType": "module"
+    'sourceType': 'module'
   },
-  "rules": {
-    "react/jsx-uses-vars": 1,
-    "no-console": "off",
-    "prefer-const": "error",
-    "indent": [
-      "error",
+  'rules': {
+    'react/jsx-uses-vars': 1,
+    'no-console': 'off',
+    'prefer-const': 'error',
+    'indent': [
+      'error',
       2
     ],
-    "linebreak-style": [
-      "error",
-      "unix"
+    'linebreak-style': [
+      'error',
+      'unix'
     ],
-    "quotes": [
-      "error",
-      "single",
-      {"allowTemplateLiterals": true}
+    'quotes': [
+      'error',
+      'single',
+      {'allowTemplateLiterals': true}
     ],
-    "semi": [
-      "error",
-      "always"
+    'semi': [
+      'error',
+      'always'
     ]
   }
 };

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Open this with VScode and build the devcontainer
 
 ### Building/Running local version
 
-You can build the plugin with `npx webpack-cli` and then install your local version of the plugin following this guide https://developer.chrome.com/docs/extensions/get-started/tutorial/hello-world
-
+```sh
+npm install
+npx webpack-cli
+```
+Then install your local version of the plugin following this guide https://developer.chrome.com/docs/extensions/get-started/tutorial/hello-world
 

--- a/README.md
+++ b/README.md
@@ -20,3 +20,16 @@ you can add new domains by clicking on the extension icon or in the option menu.
 - Comments
 - Pin a ticket on the screen by dragging the title
 - Copy issue key and title to clipboard
+
+
+# Development
+
+## In devcontainer
+
+Open this with VScode and build the devcontainer
+
+### Building/Running local version
+
+You can build the plugin with `npx webpack-cli` and then install your local version of the plugin following this guide https://developer.chrome.com/docs/extensions/get-started/tutorial/hello-world
+
+

--- a/README.md
+++ b/README.md
@@ -32,7 +32,21 @@ Open this with VScode and build the devcontainer
 
 ```sh
 npm install
-npx webpack-cli
+npx webpack-cli build --mode development
 ```
+
+Or if you want to continuously rebuild:
+
+```sh
+npx webpack-cli watch --mode development
+```
+
 Then install your local version of the plugin following this guide https://developer.chrome.com/docs/extensions/get-started/tutorial/hello-world
 
+### Building for release/production
+
+This will be much slower.
+
+```sh
+npx webpack-cli build --mode production
+```

--- a/jira-plugin/options/config.js
+++ b/jira-plugin/options/config.js
@@ -3,6 +3,7 @@ export default {
     'https://github.com/'
   ],
   instanceUrl: '',
+  inlineBadge: false,
   v15upgrade: false
 };
 

--- a/jira-plugin/options/options.jsx
+++ b/jira-plugin/options/options.jsx
@@ -1,4 +1,4 @@
-/*global chrome */
+///*global chrome */
 import defaultConfig from 'options/config';
 import ReactDOM from 'react-dom';
 import {storageGet, storageSet, permissionsRequest} from 'src/chrome';
@@ -14,6 +14,7 @@ window.onerror = function (msg, file, line, column, error) {
 
 async function saveOptions() {
   const status = document.getElementById('status');
+  const inlineBadge = document.getElementById('inlinebadge').checked ? true : false;
   const domains = document.getElementById('domains')
     .value
     .split(',')
@@ -47,7 +48,7 @@ async function saveOptions() {
   }
 
   if (granted) {
-    await storageSet({instanceUrl, domains, v15upgrade: true});
+    await storageSet({instanceUrl, domains, inlineBadge, v15upgrade: true});
     resetDeclarativeMapping();
     status.innerHTML = '<br />Options <strong>saved.</strong>';
     setTimeout(function () {
@@ -76,7 +77,7 @@ function ConfigPage(props) {
             <label id="upgradeWarning" className='upgradeWarning'>If you recently upgraded the extension make sure to
               click Save to activate
               the new reduced permissions !
-              <br/><br/></label>);
+            <br/><br/></label>);
         }
       })()}
       <label>
@@ -96,8 +97,14 @@ function ConfigPage(props) {
         <br/>
         <textarea id="domains" defaultValue={props.domains && props.domains.join(', ')} placeholder="1 site per line"/>
         <br/>
-        You can also add new domains at any time by clicking on the extension icon !
+        You can also add new domains at any time by clicking on the extension icon!
       </label>
+      <br/>
+      <label>
+        <input id="inlinebadge" type="checkbox" defaultChecked={props.inlineBadge}/>
+        Generate inline story badges (experimental)
+      </label>
+      <br/>
       <div id='status'></div>
       <br/>
       <button onClick={saveOptions} id="save">Save</button>

--- a/jira-plugin/options/options.scss
+++ b/jira-plugin/options/options.scss
@@ -1,8 +1,12 @@
-  input, textarea {
+input[type=text], textarea {
   width: 400px;
   margin: 0px;
   margin-top: 10px;
   padding: 5px;
+}
+
+input[type=checkbox]{
+  margin-right: 1em;
 }
 
 textarea {

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -1,4 +1,4 @@
-/*global chrome */
+///*global chrome */
 import defaultConfig from 'options/config.js';
 import {storageGet, storageSet, permissionsRequest, promisifyChrome} from 'src/chrome';
 import {contentScript, resetDeclarativeMapping} from 'options/declarative';
@@ -13,11 +13,11 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     $.get(request.url).then(result => {
       sendResponse({
         result
-      })
+      });
     }).catch(error => {
       sendResponse({
         error
-      })
+      });
     });
     return SEND_RESPONSE_IS_ASYNC;
   }
@@ -72,7 +72,7 @@ async function browserOnClicked (tab) {
 
   chrome.browserAction.onClicked.addListener(tab => {
     browserOnClicked(tab).catch( (err) => {
-      console.log("Error: ", err)
+      console.log('Error: ', err);
     });
   });
 })();

--- a/jira-plugin/src/chrome.js
+++ b/jira-plugin/src/chrome.js
@@ -1,4 +1,4 @@
-/*global chrome */
+///*global chrome */
 /**
  * transform chrome callback style functions to return promises
  * @param context

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -123,7 +123,7 @@ async function mainAsyncLocal() {
 
   if( config.inlineBadge ){
     console.log('Will badgify JIRA tickets starting with ',jiraProjectKeys );
-    await renderJiraBadges(jiraProjectKeys);
+    await renderJiraBadges(jiraProjectKeys, INSTANCE_URL);
   }
 
   const container = $('<div class="_JX_container">');

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -123,7 +123,7 @@ async function mainAsyncLocal() {
 
   if( config.inlineBadge ){
     console.log('Will badgify JIRA tickets starting with ',jiraProjectKeys );
-    await renderJiraBadges(jiraProjectKeys, INSTANCE_URL);
+    await renderJiraBadges(jiraProjectKeys, INSTANCE_URL, get);
   }
 
   const container = $('<div class="_JX_container">');

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -1,4 +1,4 @@
-/*global chrome */
+///*global chrome */
 import size from 'lodash/size';
 import debounce from 'lodash/debounce';
 import template from 'lodash/template';
@@ -62,7 +62,7 @@ storageGet({'ui_tips_shown': []}).then(function ({ui_tips_shown}) {
 });
 
 async function get(url) {
-  var response = await sendMessage({action: "get", url: url});
+  var response = await sendMessage({action: 'get', url: url});
   if (response.result) {
     return response.result;
   } else if (response.error) {
@@ -126,12 +126,12 @@ async function mainAsyncLocal() {
   }, container);
   
   new clipboard('._JX_title_copy', {
-    text: function (trigger) {
+    text: function () {
       return document.getElementById('_JX_title_link').text;
     }
   })
-  .on('success', e => { snackBar('Copied!');})
-  .on('error', e => { snackBar('There was an error!');});
+    .on('success', () => { snackBar('Copied!');})
+    .on('error', (e) => { snackBar('There was an error!'); console.error(e);});
 
   $(document.body).on('click', '._JX_thumb', function previewThumb(e) {
     const currentTarget = $(e.currentTarget);
@@ -230,7 +230,7 @@ async function mainAsyncLocal() {
 
       if (size(keys)) {
         clearTimeout(hideTimeOut);
-        const key = keys[0].replace(" ", "-");
+        const key = keys[0].replace(' ', '-');
         (async function (cancelToken) {
           const issueData = await getIssueMetaData(key);
           let pullRequests = [];
@@ -239,7 +239,7 @@ async function mainAsyncLocal() {
               getPullRequestData(issueData.id, 'github'),
               getPullRequestData(issueData.id, 'githube'),
             ]);
-            pullRequests = githubPrs.detail[0].pullRequests.concat(githubEnterprisePrs.detail[0].pullRequests)
+            pullRequests = githubPrs.detail[0].pullRequests.concat(githubEnterprisePrs.detail[0].pullRequests);
           } catch (ex) {
             // probably no access
           }

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -1,3 +1,7 @@
+span.jira-hotlink-badge{
+  background-color: #14892c;
+}
+
 body ._JX {
   &_container {
     position: absolute;

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -1,5 +1,32 @@
 span.jira-hotlink-badge{
-  background-color: #14892c;
+  background-color: #f2f8fa;
+  border: solid 2px;
+  padding: 5px 10px;
+  border-color:  #dde4e6;
+  border-radius: 5px;
+  display: inline-block;
+  a{
+    font-weight: bold;
+  }
+  span{
+    margin-left: 10px;
+  }
+  span.status{
+    font-weight: bold;
+    background-color: white;
+    padding: 3px 7px;
+    border-radius: 3px;
+  }
+  span.status.blue-gray{
+    color: lightblue;
+  }
+  span.status.yellow{
+    color: darkorange;
+  }
+  span.status.green{
+    color: #14892c;
+  }
+  
 }
 
 body ._JX {

--- a/jira-plugin/src/jirabadges.js
+++ b/jira-plugin/src/jirabadges.js
@@ -1,8 +1,10 @@
-export async function renderJiraBadges(projectKeys){
+export async function renderJiraBadges(projectKeys, jiraUrl){
   if( ! projectKeys.length > 0 ){
     console.log('No project keys. Doing nothing');
     return;
   }
+
+  const $ = require('jquery');
 
   const re = new RegExp('\\b(?:' + projectKeys.join('|') + ')-\\d+\\b', 'g');
 
@@ -24,11 +26,16 @@ export async function renderJiraBadges(projectKeys){
       }
 
       // Time to build a replacement for the match
+      const key = match[0];
       const span = document.createElement('span');
-      span.className = 'jira-hotlink';
+      span.className = 'jira-hotlink-badge';
       span.append(nodeValue.substring(match.index, match.index + match[0].length ));
+
+      const jspan = $('<span class="jira-hotlink-badge"><a href="' + jiraUrl + '/browse/' + key + '">'+ key +'</a></span>');
+
       issueKeys.push(match[0]);
       fragments.push(span);
+      fragments.push(jspan.get(0));
       // We have progressed in the original string
       last_end = match.index + match[0].length;
     }
@@ -92,7 +99,13 @@ export async function renderJiraBadges(projectKeys){
   console.log('REPLACEMENTS: ', replacements);
 
   const jiraKeys = replacements.flatMap( r => { return r.issueKeys; } );
-  console.log('Must get data about ', jiraKeys); 
+  console.log('Must get data about ', jiraKeys);
+
+  let r;
+  for(r of replacements){
+    console.log(r);
+    r.replace.replaceWith.apply(r.replace, r.with);
+  }
 
   return null;
 }

--- a/jira-plugin/src/jirabadges.js
+++ b/jira-plugin/src/jirabadges.js
@@ -1,0 +1,98 @@
+export async function renderJiraBadges(projectKeys){
+  if( ! projectKeys.length > 0 ){
+    console.log('No project keys. Doing nothing');
+    return;
+  }
+
+  const re = new RegExp('\\b(?:' + projectKeys.join('|') + ')-\\d+\\b', 'g');
+
+  const replacementsOf = (textNode) => {
+    const nodeValue = textNode.nodeValue;
+    // A collection of new nodes to replace the original with
+    var fragments = [];
+    var issueKeys = [];
+
+    // Last end will iterate in the original nodeValue
+    var last_end = 0;
+
+    let match;
+    while ((match = re.exec(nodeValue)) !== null) {
+      // We matched after the last end of the previous match
+      if( last_end != match.index){
+        // Save the bit of string as a plain fragment.
+        fragments.push(document.createTextNode(nodeValue.substring(last_end, match.index )));
+      }
+
+      // Time to build a replacement for the match
+      const span = document.createElement('span');
+      span.className = 'jira-hotlink';
+      span.append(nodeValue.substring(match.index, match.index + match[0].length ));
+      issueKeys.push(match[0]);
+      fragments.push(span);
+      // We have progressed in the original string
+      last_end = match.index + match[0].length;
+    }
+
+    // Have we matched anything and is there any leftover string?
+    if( last_end > 0 && last_end < nodeValue.length ){
+      fragments.push(document.createTextNode(nodeValue.substring(last_end,nodeValue.length)));
+    }
+
+    if( fragments.length > 0 ){
+      return { replace: textNode , with: fragments , issueKeys };
+    }
+
+    // No replacement
+    return null;
+  };
+
+  // The scanning.
+  const ignore_elements = {
+    'STYLE': true,
+    'SCRIPT': true,
+    'NOSCRIPT': true,
+    'IFRAME' : true,
+    'OBJECT': true,
+    'INPUT': true,
+    'FORM': true,
+    'TEXTAREA': true,
+    'HEAD': true,
+    'LINK': true,
+    'A': true,
+  };
+
+  console.log('Rendering JIRA badges');
+  // Scan all elements in the page.
+  var elements = document.createNodeIterator(
+    document.body,
+    NodeFilter.SHOW_ELEMENT,
+    (e) => {
+      // return NodeFilter.FILTER_ACCEPT;
+      return ignore_elements[( e.tagName  || '' ).toUpperCase()]  ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+    }
+  );
+
+  // Holds a collection of { replace: <node> , with: [ replacementNodes... ], issueKeys: [ keys.. ] }
+  const replacements = [];
+  let element;
+  while ((element = elements.nextNode() )) {
+    // Find only the texts of this element
+    var texts = document.createNodeIterator(element, NodeFilter.SHOW_TEXT, (node) => {
+      // Only consider direct children, so we don't go over text nodes multiple times.
+      return node.parentNode === element ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+    });
+    let text;
+    while ((text = texts.nextNode())) {
+      const r = replacementsOf(text);
+      if( r != null ){
+        replacements.push(r);
+      }
+    }
+  }
+  console.log('REPLACEMENTS: ', replacements);
+
+  const jiraKeys = replacements.flatMap( r => { return r.issueKeys; } );
+  console.log('Must get data about ', jiraKeys); 
+
+  return null;
+}

--- a/jira-plugin/src/snack.js
+++ b/jira-plugin/src/snack.js
@@ -1,4 +1,4 @@
-/*global chrome */
+///*global chrome */
 import {waitForDocument} from 'src/utils';
 
 waitForDocument(() => require('src/snack.scss'));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
           'style-loader',
           'css-loader',
           {
-            loader: "sass-loader",
+            loader: 'sass-loader',
             options: {
               sourceMap: true
             },


### PR DESCRIPTION
Hi, following the discussion there: https://github.com/helmus/Jira-Hot-Linker/issues/30, 

here's a feature that generates inline badges for detected JIRA keys in the text of the page (if the plugin is active on the page).

This is optional and switched off by default.

Here's a screenshot of what it does:

![image](https://github.com/helmus/Jira-Hot-Linker/assets/103262/8377946d-121f-431b-a05b-5d98f7dba868)

Thanks for reviewing!