### PR TITLE
Refine quick actions dropdown and sprint actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 jira-plugin/build/
 jira-plugin/options/build/
 jira-plugin/assets/
+Screenshot*

--- a/jira-plugin/manifest.json
+++ b/jira-plugin/manifest.json
@@ -27,7 +27,8 @@
     "storage"
   ],
   "options_ui": {
-    "page": "options/options.html"
+    "page": "options/options.html",
+    "open_in_tab": true
   },
   "action": {
     "default_title": "Click to always search for tickets on this page"

--- a/jira-plugin/manifest.json
+++ b/jira-plugin/manifest.json
@@ -32,9 +32,13 @@
   "action": {
     "default_title": "Click to always search for tickets on this page"
   },
-  "content_security_policy": {},
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; base-uri 'self'"
+  },
   "host_permissions": [
-    "https://github.com/",
+    "https://github.com/*"
+  ],
+  "optional_host_permissions": [
     "*://*/*"
   ]
 }

--- a/jira-plugin/options/config.js
+++ b/jira-plugin/options/config.js
@@ -4,6 +4,7 @@ export default {
   ],
   instanceUrl: '',
   v15upgrade: false,
+  customFields: [],
   displayFields: {
     issueType: true,
     status: true,
@@ -12,7 +13,6 @@ export default {
     fixVersions: true,
     affects: true,
     labels: true,
-    account: true,
     epicParent: true,
     attachments: true,
     comments: true,
@@ -22,4 +22,3 @@ export default {
     pullRequests: true
   }
 };
-

--- a/jira-plugin/options/config.js
+++ b/jira-plugin/options/config.js
@@ -3,6 +3,23 @@ export default {
     'https://github.com/'
   ],
   instanceUrl: '',
-  v15upgrade: false
+  v15upgrade: false,
+  displayFields: {
+    issueType: true,
+    status: true,
+    priority: true,
+    sprint: true,
+    fixVersions: true,
+    affects: true,
+    labels: true,
+    account: true,
+    epicParent: true,
+    attachments: true,
+    comments: true,
+    description: true,
+    reporter: true,
+    assignee: true,
+    pullRequests: true
+  }
 };
 

--- a/jira-plugin/options/options.html
+++ b/jira-plugin/options/options.html
@@ -4,9 +4,12 @@
     <title>Jira Hotlinker Options</title>
     <style type="text/css">
         body {
-            min-height: 200px;
-            min-width: 200px;
-            padding: 10px;
+            background: radial-gradient(circle at top, #f7efe3 0%, #eef3fb 46%, #f5f7fb 100%);
+            box-sizing: border-box;
+            margin: 0;
+            min-height: 100vh;
+            min-width: 320px;
+            padding: 0;
         }
     </style>
 </head>

--- a/jira-plugin/options/options.jsx
+++ b/jira-plugin/options/options.jsx
@@ -1,6 +1,7 @@
 /*global chrome */
-import defaultConfig from 'options/config';
+import React, {useEffect, useState} from 'react';
 import ReactDOM from 'react-dom';
+import defaultConfig from 'options/config';
 import {storageGet, storageSet, permissionsRequest} from 'src/chrome';
 import {hasPathSlash, resetDeclarativeMapping, toMatchUrl} from 'options/declarative';
 
@@ -20,7 +21,6 @@ const FIELD_OPTIONS = [
   {key: 'fixVersions', label: 'Fix Version'},
   {key: 'affects', label: 'Affects Version'},
   {key: 'labels', label: 'Labels'},
-  {key: 'account', label: 'Account'},
   {key: 'epicParent', label: 'Epic/Parent'},
   {key: 'attachments', label: 'Attachments'},
   {key: 'comments', label: 'Comments'},
@@ -30,135 +30,407 @@ const FIELD_OPTIONS = [
   {key: 'pullRequests', label: 'Related Pull Requests'}
 ];
 
-function getDisplayFieldValuesFromForm() {
-  const values = {};
-  FIELD_OPTIONS.forEach(({key}) => {
-    const node = document.getElementById(`displayField_${key}`);
-    values[key] = !!(node && node.checked);
-  });
-  return values;
+const FIELD_GROUPS = [
+  {
+    title: 'Top bar - row 1',
+    description: 'Issue identity and triage context shown in the first summary row.',
+    keys: ['issueType', 'status', 'priority', 'epicParent']
+  },
+  {
+    title: 'Top bar - row 2',
+    description: 'Planning and release context shown in the second summary row.',
+    keys: ['sprint', 'affects', 'fixVersions']
+  },
+  {
+    title: 'Top bar - row 3',
+    description: 'Metadata chips shown in the third summary row.',
+    keys: ['labels']
+  },
+  {
+    title: 'Description block',
+    description: 'Rich issue description shown below the summary rows.',
+    keys: ['description']
+  },
+  {
+    title: 'Attachments block',
+    description: 'Image previews and attachment indicators in the body area.',
+    keys: ['attachments']
+  },
+  {
+    title: 'Comments block',
+    description: 'Rendered Jira comments in the body area.',
+    keys: ['comments']
+  },
+  {
+    title: 'People',
+    description: 'Reporter and assignee avatars shown in the title area.',
+    keys: ['reporter', 'assignee']
+  },
+  {
+    title: 'Related development',
+    description: 'Pull request summary table appended beneath the issue content.',
+    keys: ['pullRequests']
+  }
+];
+
+function normalizeInstanceUrl(instanceUrl) {
+  let normalized = String(instanceUrl || '').trim();
+  if (!normalized) {
+    return '';
+  }
+  if (!hasPathSlash.test(normalized)) {
+    normalized += '/';
+  }
+  if (normalized.indexOf('://') === -1) {
+    normalized = 'https://' + normalized;
+  }
+  return normalized;
 }
 
-async function saveOptions() {
-  const status = document.getElementById('status');
-  const setStatus = (message) => {
-    status.textContent = message;
-  };
-  const domains = document.getElementById('domains')
-    .value
-    .split(',')
-    .map(x => x.trim())
-    .filter(x => !!x);
-  let instanceUrl = document.getElementById('instanceUrl').value.trim();
-
-  if (!instanceUrl) {
-    setStatus('You must provide your Jira instance URL.');
-    return;
+function normalizeCustomFields(customFields) {
+  if (!Array.isArray(customFields)) {
+    return [];
   }
-  if (!hasPathSlash.test(instanceUrl)) {
-    instanceUrl = instanceUrl + '/';
-  }
-  if (instanceUrl.indexOf('://') === -1) {
-    instanceUrl = 'https://' + instanceUrl;
-  }
-  document.getElementById('instanceUrl').value = instanceUrl;
-  const permissionDomains = domains.concat([instanceUrl]);
-  const currentInstanceUrl = await storageGet(defaultConfig);
-  if (!currentInstanceUrl.instanceUrl) {
-    domains.push(instanceUrl);
-  }
-
-  let granted;
-  try {
-    granted = await permissionsRequest({'origins': permissionDomains.map(toMatchUrl)});
-  } catch (ex) {
-    setStatus(ex.message);
-    return;
-  }
-
-  if (granted) {
-    await storageSet({
-      instanceUrl,
-      domains,
-      v15upgrade: true,
-      displayFields: getDisplayFieldValuesFromForm()
+  const seen = {};
+  return customFields
+    .map(field => ({
+      fieldId: String(field && field.fieldId || '').trim(),
+      row: Math.min(3, Math.max(1, Number(field && field.row) || 3))
+    }))
+    .filter(field => {
+      if (!field.fieldId || seen[field.fieldId]) {
+        return false;
+      }
+      seen[field.fieldId] = true;
+      return true;
     });
-    resetDeclarativeMapping();
-    setStatus('Options saved.');
-    setTimeout(function () {
-      status.textContent = '';
-    }, 2000);
-  } else {
-    setStatus('Options not saved.');
-    return;
+}
+
+async function fetchFieldCatalog(instanceUrl) {
+  if (!instanceUrl) {
+    return {};
   }
-  document.getElementById('domains').value = domains && domains.join(', ');
-  document.getElementById('upgradeWarning').style.display = 'none';
+  try {
+    const response = await fetch(instanceUrl + 'rest/api/2/field', {
+      credentials: 'include'
+    });
+    if (!response.ok) {
+      return {};
+    }
+    const fields = await response.json();
+    if (!Array.isArray(fields)) {
+      return {};
+    }
+    return fields.reduce((acc, field) => {
+      if (field && field.id) {
+        acc[field.id] = field.name || field.id;
+      }
+      return acc;
+    }, {});
+  } catch (ex) {
+    return {};
+  }
+}
+
+function getCustomFieldError(fieldId, fieldCatalog) {
+  const trimmed = String(fieldId || '').trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (!/^customfield_\d+$/i.test(trimmed)) {
+    return 'Use a Jira custom field ID in the form customfield_12345.';
+  }
+  if (Object.keys(fieldCatalog).length && !fieldCatalog[trimmed]) {
+    return 'This field ID was not found in Jira.';
+  }
+  return '';
 }
 
 async function main() {
   ReactDOM.render(
-    ConfigPage(await storageGet(defaultConfig)), document.getElementById('container')
+    <ConfigPage {...await storageGet(defaultConfig)} />,
+    document.getElementById('container')
   );
 }
 
 function ConfigPage(props) {
-  const displayFields = {
+  const [instanceUrl, setInstanceUrl] = useState(props.instanceUrl || '');
+  const [domainsText, setDomainsText] = useState((props.domains || []).join(', '));
+  const [displayFields, setDisplayFields] = useState({
     ...defaultConfig.displayFields,
     ...(props.displayFields || {})
+  });
+  const [customFields, setCustomFields] = useState(normalizeCustomFields(props.customFields));
+  const [fieldCatalog, setFieldCatalog] = useState({});
+  const [status, setStatus] = useState('');
+  const [statusTone, setStatusTone] = useState('neutral');
+  const [isSaving, setIsSaving] = useState(false);
+  const customFieldErrors = customFields.map(field => getCustomFieldError(field.fieldId, fieldCatalog));
+  const hasInvalidCustomFields = customFieldErrors.some(Boolean);
+
+  useEffect(() => {
+    let cancelled = false;
+    const normalizedInstanceUrl = normalizeInstanceUrl(instanceUrl || props.instanceUrl);
+    fetchFieldCatalog(normalizedInstanceUrl).then(catalog => {
+      if (!cancelled) {
+        setFieldCatalog(catalog);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [instanceUrl, props.instanceUrl]);
+
+  const setDisplayFieldValue = (key, checked) => {
+    setDisplayFields(current => ({
+      ...current,
+      [key]: checked
+    }));
   };
+
+  const updateCustomField = (index, patch) => {
+    setCustomFields(current => current.map((field, fieldIndex) => {
+      if (fieldIndex !== index) {
+        return field;
+      }
+      return {
+        ...field,
+        ...patch
+      };
+    }));
+  };
+
+  const addCustomField = () => {
+    setCustomFields(current => current.concat({fieldId: '', row: 3}));
+  };
+
+  const removeCustomField = (index) => {
+    setCustomFields(current => current.filter((field, fieldIndex) => fieldIndex !== index));
+  };
+
+  const saveOptions = async () => {
+    const domains = domainsText
+      .split(',')
+      .map(x => x.trim())
+      .filter(x => !!x);
+    const normalizedInstanceUrl = normalizeInstanceUrl(instanceUrl);
+
+    if (!normalizedInstanceUrl) {
+      setStatusTone('error');
+      setStatus('You must provide your Jira instance URL.');
+      return;
+    }
+
+    setInstanceUrl(normalizedInstanceUrl);
+
+    const permissionDomains = domains.concat([normalizedInstanceUrl]);
+    const currentInstanceUrl = await storageGet(defaultConfig);
+    if (!currentInstanceUrl.instanceUrl) {
+      domains.push(normalizedInstanceUrl);
+    }
+
+    setIsSaving(true);
+    setStatusTone('neutral');
+    setStatus('Saving changes...');
+
+    let granted;
+    try {
+      granted = await permissionsRequest({'origins': permissionDomains.map(toMatchUrl)});
+    } catch (ex) {
+      setIsSaving(false);
+      setStatusTone('error');
+      setStatus(ex.message);
+      return;
+    }
+
+    if (!granted) {
+      setIsSaving(false);
+      setStatusTone('error');
+      setStatus('Options not saved.');
+      return;
+    }
+
+    await storageSet({
+      instanceUrl: normalizedInstanceUrl,
+      domains,
+      v15upgrade: true,
+      displayFields,
+      customFields: normalizeCustomFields(customFields)
+    });
+    resetDeclarativeMapping();
+    setDomainsText(domains.join(', '));
+    setIsSaving(false);
+    setStatusTone('success');
+    setStatus('Options saved successfully.');
+    setTimeout(() => {
+      setStatusTone('neutral');
+      setStatus('');
+    }, 2500);
+  };
+
   return (
-    <div>
-      {(() => {
-        if (!props.v15upgrade) {
-          return (
-            <label id="upgradeWarning" className='upgradeWarning'>If you recently upgraded the extension make sure to
-              click Save to activate
-              the new reduced permissions !
-              <br/><br/></label>);
-        }
-      })()}
-      <label>
-        Your full Jira instance url: <br/>
-        <input
-          id="instanceUrl"
-          type="text"
-          defaultValue={props.instanceUrl}
-          placeholder="https://your-company.atlassian.net/"/>
-      </label>
-      <br/>
-      <label>
-        Locations where the plugin should be activated, comma separated: <br/>
-        This can be a domain a url or any valid {' '}
-        <strong><a href='https://developer.chrome.com/extensions/match_patterns'>match pattern</a>
-        </strong>.
-        <br/>
-        <textarea id="domains" defaultValue={props.domains && props.domains.join(', ')} placeholder="1 site per line"/>
-        <br/>
-        You can also add new domains at any time by clicking on the extension icon !
-      </label>
-      <div id='status'></div>
-      <br/>
-      <label>
-        Tooltip fields to show:
-      </label>
-      <div className='displayFields'>
-        {FIELD_OPTIONS.map(({key, label}) => (
-          <label key={key} className='displayFieldOption'>
+    <div className='optionsPage'>
+      <header className='heroCard'>
+        <div>
+          <div className='eyebrow'>Jira HotLinker</div>
+          <h1 className='heroTitle'>Extension Options</h1>
+          <p className='heroCopy'>
+            Configure where the extension runs, which built-in ticket fields are visible in the hover card,
+            and any Jira custom fields you want surfaced in rows 1, 2, or 3.
+          </p>
+        </div>
+        <div className='heroMeta'>
+          <div className={'statusPill' + (status ? ' statusPillActive' : '')}>
+            {status || (hasInvalidCustomFields ? 'Fix invalid custom field IDs before saving.' : 'Changes are local until you save them.')}
+          </div>
+          {!props.v15upgrade && (
+            <div className='upgradeNotice'>
+              After upgrading the extension, click Save once to refresh its permissions.
+            </div>
+          )}
+        </div>
+      </header>
+
+      <div className='settingsGrid'>
+        <section className='settingsCard settingsCardWide'>
+          <div className='sectionHeading'>
+            <div>
+              <h2>Connection</h2>
+              <p>Tell the extension which Jira instance to query and where it should activate.</p>
+            </div>
+          </div>
+
+          <label className='formField'>
+            <span className='fieldLabel'>Jira instance URL</span>
             <input
-              id={`displayField_${key}`}
-              type='checkbox'
-              defaultChecked={!!displayFields[key]}
-            />
-            <span>{label}</span>
+              id='instanceUrl'
+              type='text'
+              value={instanceUrl}
+              onChange={event => setInstanceUrl(event.target.value)}
+              placeholder='https://your-company.atlassian.net/'/>
+            <span className='fieldHelp'>Used for issue metadata, field discovery, and link targets.</span>
           </label>
-        ))}
+
+          <label className='formField'>
+            <span className='fieldLabel'>Allowed pages</span>
+            <textarea
+              id='domains'
+              value={domainsText}
+              onChange={event => setDomainsText(event.target.value)}
+              placeholder='github.com, outlook.office.com'/>
+            <span className='fieldHelp'>
+              Comma-separated domains, URLs, or valid <a href='https://developer.chrome.com/extensions/match_patterns'>match patterns</a>.
+              You can also add a page directly from the extension icon.
+            </span>
+          </label>
+        </section>
+
+        <section className='settingsCard settingsCardWide'>
+          <div className='sectionHeading'>
+            <div>
+              <h2>Tooltip Layout</h2>
+              <p>Choose which built-in Jira fields appear in each part of the hover card.</p>
+            </div>
+          </div>
+          <div className='fieldLayoutGroups'>
+            {FIELD_GROUPS.map(group => (
+              <div key={group.title} className='fieldGroupCard'>
+                <div className='fieldGroupHeader'>
+                  <h3>{group.title}</h3>
+                  <p>{group.description}</p>
+                </div>
+                <div className='displayFields'>
+                  {group.keys.map(key => {
+                    const option = FIELD_OPTIONS.find(field => field.key === key);
+                    return (
+                      <label key={key} className='displayFieldOption'>
+                        <input
+                          id={'displayField_' + key}
+                          type='checkbox'
+                          checked={!!displayFields[key]}
+                          onChange={event => setDisplayFieldValue(key, event.target.checked)}
+                        />
+                        <span>{option ? option.label : key}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className='settingsCard settingsCardWide'>
+          <div className='sectionHeading sectionHeadingSplit'>
+            <div>
+              <h2>Custom Fields</h2>
+              <p>Add Jira field IDs and choose where each one appears in the hover summary.</p>
+            </div>
+            <button type='button' className='secondaryButton' onClick={addCustomField}>Add another field</button>
+          </div>
+
+          {customFields.length === 0 ? (
+            <div className='emptyState'>
+              No custom fields configured yet. Add one if you want to surface plugin-provided Jira data in the hover card.
+            </div>
+          ) : (
+            <div className='customFieldsSection'>
+              {customFields.map((field, index) => (
+                <div key={index} className='customFieldRow'>
+                  <div className='customFieldHeader'>Custom field {index + 1}</div>
+                  <label className='customFieldLabel'>
+                    <span className='fieldLabel'>Field ID</span>
+                    <input
+                      type='text'
+                      value={field.fieldId}
+                      onChange={event => updateCustomField(index, {fieldId: event.target.value})}
+                      placeholder='customfield_12345'/>
+                  </label>
+                  <label className='customFieldLabel'>
+                    <span className='fieldLabel'>Location</span>
+                    <select
+                      value={field.row}
+                      onChange={event => updateCustomField(index, {row: Number(event.target.value)})}>
+                      <option value={1}>Top bar - row 1</option>
+                      <option value={2}>Top bar - row 2</option>
+                      <option value={3}>Top bar - row 3</option>
+                    </select>
+                  </label>
+                  <div className={'customFieldMeta' + (customFieldErrors[index] ? ' customFieldMetaError' : '')}>
+                    {customFieldErrors[index]
+                      ? customFieldErrors[index]
+                      : field.fieldId
+                        ? `Resolved field name: ${fieldCatalog[field.fieldId] || 'Waiting for Jira field metadata.'}`
+                        : 'The field name will appear here after Jira returns metadata for this ID.'}
+                  </div>
+                  <button type='button' className='ghostButton customFieldRemove' onClick={() => removeCustomField(index)}>
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
       </div>
-      <br/>
-      <button onClick={saveOptions} id="save">Save</button>
+
+      <footer className='actionBar'>
+        <div className='actionCopy'>
+          <strong>Save changes</strong>
+          <span>Applies the current Jira URL, allowed pages, built-in tooltip fields, and configured custom fields.</span>
+        </div>
+        <div className='actionControls'>
+          {(status || hasInvalidCustomFields) && (
+            <div className={'saveNotice saveNotice' + ((hasInvalidCustomFields && !status) ? 'Error' : statusTone.charAt(0).toUpperCase() + statusTone.slice(1))}>
+              {status || 'Fix invalid custom field IDs before saving.'}
+            </div>
+          )}
+          <button onClick={saveOptions} id='save' className='primaryButton' disabled={isSaving || hasInvalidCustomFields}>
+            {isSaving ? 'Saving...' : 'Save changes'}
+          </button>
+        </div>
+      </footer>
     </div>
   );
 }
 
 document.addEventListener('DOMContentLoaded', main);
-

--- a/jira-plugin/options/options.jsx
+++ b/jira-plugin/options/options.jsx
@@ -9,11 +9,41 @@ import 'options/options.scss';
 const errorText = document.createElement('div');
 document.body.appendChild(errorText);
 window.onerror = function (msg, file, line, column, error) {
-  errorText.innerHTML = error.stack;
+  errorText.textContent = (error && error.stack) ? error.stack : String(msg || 'Unknown error');
 };
+
+const FIELD_OPTIONS = [
+  {key: 'issueType', label: 'Issue Type'},
+  {key: 'status', label: 'Status'},
+  {key: 'priority', label: 'Priority'},
+  {key: 'sprint', label: 'Sprint'},
+  {key: 'fixVersions', label: 'Fix Version'},
+  {key: 'affects', label: 'Affects Version'},
+  {key: 'labels', label: 'Labels'},
+  {key: 'account', label: 'Account'},
+  {key: 'epicParent', label: 'Epic/Parent'},
+  {key: 'attachments', label: 'Attachments'},
+  {key: 'comments', label: 'Comments'},
+  {key: 'description', label: 'Description'},
+  {key: 'reporter', label: 'Reporter'},
+  {key: 'assignee', label: 'Assignee'},
+  {key: 'pullRequests', label: 'Related Pull Requests'}
+];
+
+function getDisplayFieldValuesFromForm() {
+  const values = {};
+  FIELD_OPTIONS.forEach(({key}) => {
+    const node = document.getElementById(`displayField_${key}`);
+    values[key] = !!(node && node.checked);
+  });
+  return values;
+}
 
 async function saveOptions() {
   const status = document.getElementById('status');
+  const setStatus = (message) => {
+    status.textContent = message;
+  };
   const domains = document.getElementById('domains')
     .value
     .split(',')
@@ -22,7 +52,7 @@ async function saveOptions() {
   let instanceUrl = document.getElementById('instanceUrl').value.trim();
 
   if (!instanceUrl) {
-    status.innerHTML = '<br /><strong>You must provide your jira instance url.</strong>';
+    setStatus('You must provide your Jira instance URL.');
     return;
   }
   if (!hasPathSlash.test(instanceUrl)) {
@@ -42,19 +72,24 @@ async function saveOptions() {
   try {
     granted = await permissionsRequest({'origins': permissionDomains.map(toMatchUrl)});
   } catch (ex) {
-    status.innerHTML = `<br /><strong>${ex.message}</strong>`;
+    setStatus(ex.message);
     return;
   }
 
   if (granted) {
-    await storageSet({instanceUrl, domains, v15upgrade: true});
+    await storageSet({
+      instanceUrl,
+      domains,
+      v15upgrade: true,
+      displayFields: getDisplayFieldValuesFromForm()
+    });
     resetDeclarativeMapping();
-    status.innerHTML = '<br />Options <strong>saved.</strong>';
+    setStatus('Options saved.');
     setTimeout(function () {
       status.textContent = '';
     }, 2000);
   } else {
-    status.innerHTML = '<br /> Options <strong>Not</strong> saved.';
+    setStatus('Options not saved.');
     return;
   }
   document.getElementById('domains').value = domains && domains.join(', ');
@@ -68,6 +103,10 @@ async function main() {
 }
 
 function ConfigPage(props) {
+  const displayFields = {
+    ...defaultConfig.displayFields,
+    ...(props.displayFields || {})
+  };
   return (
     <div>
       {(() => {
@@ -99,6 +138,22 @@ function ConfigPage(props) {
         You can also add new domains at any time by clicking on the extension icon !
       </label>
       <div id='status'></div>
+      <br/>
+      <label>
+        Tooltip fields to show:
+      </label>
+      <div className='displayFields'>
+        {FIELD_OPTIONS.map(({key, label}) => (
+          <label key={key} className='displayFieldOption'>
+            <input
+              id={`displayField_${key}`}
+              type='checkbox'
+              defaultChecked={!!displayFields[key]}
+            />
+            <span>{label}</span>
+          </label>
+        ))}
+      </div>
       <br/>
       <button onClick={saveOptions} id="save">Save</button>
     </div>

--- a/jira-plugin/options/options.scss
+++ b/jira-plugin/options/options.scss
@@ -1,44 +1,437 @@
-  input, textarea {
-  width: 400px;
-  margin: 0px;
-  margin-top: 10px;
-  padding: 5px;
+:root {
+  color: #182230;
+  font-family: 'Segoe UI Variable Text', 'Aptos', 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+}
+
+#container {
+  max-width: 1160px;
+  margin: 0 auto;
+}
+
+.optionsPage {
+  padding: 32px;
+}
+
+.heroCard,
+.settingsCard,
+.actionBar {
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid #d8e0e8;
+  border-radius: 24px;
+  box-shadow: 0 18px 42px rgba(21, 39, 57, 0.08);
+}
+
+.heroCard {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.8fr);
+  gap: 24px;
+  padding: 28px;
+  margin-bottom: 24px;
+  background: linear-gradient(135deg, rgba(255, 250, 240, 0.98), rgba(236, 244, 255, 0.98));
+}
+
+.eyebrow {
+  color: #8b5e34;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.heroTitle {
+  font-size: 34px;
+  line-height: 1.05;
+  margin: 0 0 12px;
+}
+
+.heroCopy {
+  color: #4e5f73;
+  font-size: 15px;
+  line-height: 1.6;
+  margin: 0;
+  max-width: 700px;
+}
+
+.heroMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: flex-start;
+}
+
+.statusPill {
+  align-items: center;
+  background: rgba(24, 34, 48, 0.06);
+  border-radius: 999px;
+  color: #4e5f73;
+  display: inline-flex;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  padding: 10px 14px;
+}
+
+.statusPillActive {
+  background: #dff5e5;
+  color: #135c2b;
+}
+
+.upgradeNotice {
+  background: rgba(255, 240, 204, 0.8);
+  border: 1px solid #f2d38a;
+  border-radius: 16px;
+  color: #6f4c13;
+  font-size: 13px;
+  line-height: 1.5;
+  padding: 14px 16px;
+}
+
+.settingsGrid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.settingsCard {
+  padding: 24px;
+}
+
+.settingsCardWide {
+  grid-column: 1 / -1;
+}
+
+.sectionHeading {
+  margin-bottom: 18px;
+}
+
+.sectionHeading h2 {
+  font-size: 22px;
+  margin: 0 0 6px;
+}
+
+.sectionHeading p {
+  color: #5b6b7f;
+  font-size: 14px;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.sectionHeadingSplit {
+  align-items: start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.formField,
+.customFieldLabel {
+  display: block;
+  width: 100%;
+}
+
+.formField + .formField {
+  margin-top: 18px;
+}
+
+.fieldLabel {
+  color: #213548;
+  display: block;
+  font-size: 13px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.fieldHelp {
+  color: #66778c;
+  display: block;
+  font-size: 13px;
+  line-height: 1.55;
+  margin-top: 8px;
+}
+
+input,
+textarea,
+select {
+  background: #ffffff;
+  border: 1px solid #c8d3df;
+  border-radius: 14px;
+  box-sizing: border-box;
+  color: #182230;
+  font: inherit;
+  margin: 0;
+  min-height: 52px;
+  padding: 12px 14px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+  width: 100%;
+}
+
+select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='none' stroke='%23455a72' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.6' d='M1 1.5l5 5 5-5'/%3E%3C/svg%3E");
+  background-position: right 16px center;
+  background-repeat: no-repeat;
+  background-size: 12px 8px;
+  padding-right: 42px;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: #2f80ed;
+  box-shadow: 0 0 0 4px rgba(47, 128, 237, 0.14);
+  outline: none;
 }
 
 textarea {
-  $base: 20px;
-  $lineColor: #e2e2e2;
-  border-color: $lineColor;
-  line-height: $base + 1;
-  padding: 1px 5px;
-  height: 20 * 7 + 6px;
+  min-height: 150px;
+  resize: vertical;
 }
 
-label {
-  display: block;
-  width: 400px;
+.fieldLayoutGroups {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.upgradeWarning {
-  color: #dd445c;
+.fieldGroupCard {
+  background: #f7f9fc;
+  border: 1px solid #dae3ec;
+  border-radius: 18px;
+  padding: 16px;
+}
+
+.fieldGroupHeader {
+  margin-bottom: 12px;
+}
+
+.fieldGroupHeader h3 {
+  font-size: 16px;
+  margin: 0 0 4px;
+}
+
+.fieldGroupHeader p {
+  color: #66778c;
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0;
 }
 
 .displayFields {
   display: grid;
-  grid-template-columns: repeat(2, minmax(180px, 1fr));
-  gap: 6px 18px;
-  max-width: 640px;
-  margin-top: 8px;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .displayFieldOption {
   align-items: center;
+  background: #f6f8fb;
+  border: 1px solid #d9e1ea;
+  border-radius: 16px;
+  cursor: pointer;
   display: flex;
-  gap: 8px;
+  gap: 10px;
+  min-height: 48px;
+  padding: 0 14px;
+  transition: transform 0.15s ease, border-color 0.15s ease, background 0.15s ease;
   width: auto;
+}
+
+.displayFieldOption:hover {
+  background: #eef4ff;
+  border-color: #b8c9f0;
+  transform: translateY(-1px);
 }
 
 .displayFieldOption input {
   margin: 0;
   width: auto;
+}
+
+.customFieldsSection {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.customFieldRow {
+  align-items: start;
+  background: #f7f9fc;
+  border: 1px solid #dae3ec;
+  border-radius: 18px;
+  display: grid;
+  gap: 12px 14px;
+  grid-template-columns: minmax(240px, 1.5fr) 180px auto;
+  padding: 16px;
+}
+
+.customFieldHeader {
+  color: #5a6a7e;
+  font-size: 12px;
+  font-weight: 700;
+  grid-column: 1 / -1;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.customFieldMeta {
+  grid-column: 1 / 3;
+  color: #64758a;
+  font-size: 13px;
+  line-height: 1.55;
+  margin-top: 2px;
+}
+
+.customFieldMetaError {
+  color: #9d2335;
+}
+
+.customFieldRemove {
+  align-self: center;
+  grid-column: 3;
+  grid-row: 2;
+}
+
+.emptyState {
+  background: linear-gradient(180deg, #fffdf7, #fff7e8);
+  border: 1px dashed #e0c98f;
+  border-radius: 18px;
+  color: #6b5520;
+  font-size: 14px;
+  line-height: 1.6;
+  padding: 18px;
+}
+
+button {
+  appearance: none;
+  border: none;
+  border-radius: 14px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  line-height: 1;
+  padding: 13px 16px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+.primaryButton {
+  background: linear-gradient(135deg, #1f7a5d, #15513f);
+  box-shadow: 0 12px 28px rgba(21, 81, 63, 0.2);
+  color: #ffffff;
+}
+
+.secondaryButton {
+  background: #edf4ff;
+  border: 1px solid #c4d7f7;
+  color: #244f92;
+}
+
+.ghostButton {
+  background: #ffffff;
+  border: 1px solid #d6dee8;
+  color: #415466;
+}
+
+.actionBar {
+  align-items: center;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  margin-top: 22px;
+  padding: 18px 22px;
+  position: sticky;
+  bottom: 20px;
+}
+
+.actionCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.actionCopy strong {
+  font-size: 15px;
+}
+
+.actionCopy span {
+  color: #5f6f83;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+@media (max-width: 960px) {
+  .optionsPage {
+    padding: 18px;
+  }
+
+  .heroCard,
+  .settingsGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .fieldLayoutGroups,
+  .displayFields {
+    grid-template-columns: 1fr;
+  }
+
+  .customFieldRow {
+    grid-template-columns: 1fr;
+  }
+
+  .customFieldMeta,
+  .customFieldRemove {
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .sectionHeadingSplit,
+  .actionBar,
+  .actionControls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
+
+.actionControls {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
+.saveNotice {
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.4;
+  padding: 10px 14px;
+}
+
+.saveNoticeNeutral {
+  background: rgba(24, 34, 48, 0.06);
+  color: #4e5f73;
+}
+
+.saveNoticeSuccess {
+  background: #dff5e5;
+  color: #135c2b;
+}
+
+.saveNoticeError {
+  background: #fde7ea;
+  color: #9d2335;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.78;
+  transform: none;
 }

--- a/jira-plugin/options/options.scss
+++ b/jira-plugin/options/options.scss
@@ -22,3 +22,23 @@ label {
 .upgradeWarning {
   color: #dd445c;
 }
+
+.displayFields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(180px, 1fr));
+  gap: 6px 18px;
+  max-width: 640px;
+  margin-top: 8px;
+}
+
+.displayFieldOption {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  width: auto;
+}
+
+.displayFieldOption input {
+  margin: 0;
+  width: auto;
+}

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -1,7 +1,7 @@
 <div class="_JX_annotation">
     <div class="_JX_title">
         <img class="_JX_title_user" title="{{reporter.displayName}}" src="{{reporter.avatarUrls.48x48}}">
-        <a id="_JX_title_link" href="{{url}}">{{urlTitle}}</a>
+        <a id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}">{{urlTitle}}</a>
         <button class="_JX_title_copy">
             <svg width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><path d="M10 19h8V8h-8v11zM8 7.992C8 6.892 8.902 6 10.009 6h7.982C19.101 6 20 6.893 20 7.992v11.016c0 1.1-.902 1.992-2.009 1.992H10.01A2.001 2.001 0 0 1 8 19.008V7.992z"></path><path d="M5 16V4.992C5 3.892 5.902 3 7.009 3H15v13H5zm2 0h8V5H7v11z"></path></g></svg>
         </button>
@@ -13,16 +13,16 @@
         <span class="_JX_field_chip">
             {{#status.iconUrl}}<img class="_JX_status_icon" src="{{status.iconUrl}}">{{/status.iconUrl}}{{statusText}}
         </span>
+        <span class="_JX_field_chip">{{sprintText}}</span>
+        <span class="_JX_field_chip">{{fixVersionText}}</span>
+        {{#attachmentChips}}
+        <span class="_JX_field_chip">{{icon}} {{count}}</span>
+        {{/attachmentChips}}
         {{#hasComments}}
         <a class="_JX_field_chip _JX_field_chip_link" target="_blank" href="{{commentUrl}}">
             💬 {{commentsTotal}}
         </a>
         {{/hasComments}}
-        <span class="_JX_field_chip">{{fixVersionText}}</span>
-        <span class="_JX_field_chip">{{sprintText}}</span>
-        {{#attachmentChips}}
-        <span class="_JX_field_chip">{{icon}} {{count}}</span>
-        {{/attachmentChips}}
     </div>
 
     {{#hasBodyContent}}
@@ -35,9 +35,9 @@
         {{#previewAttachments.length}}
         <div class="_JX_description_attachments">
             {{#previewAttachments}}
-            <div data-mime-type="{{mimeType}}" data-url="{{content}}" class="_JX_thumb">
+            <div data-mime-type="{{mimeType}}" data-url="{{content}}" data-preview-src="{{content}}" class="_JX_thumb">
                 <a href="{{content}}" target="_blank">
-                    <img title="{{filename}}" src="{{thumbnail}}">
+                    <img class="_JX_previewable" data-jx-preview-src="{{content}}" title="{{filename}}" src="{{thumbnail}}">
                     <div class="_JX_thumb_filename">{{filename}}</div>
                     <img class="_JX_file_loader" src="{{loaderGifUrl}}">
                 </a>
@@ -45,6 +45,18 @@
             {{/previewAttachments}}
         </div>
         {{/previewAttachments.length}}
+        {{#commentsForDisplay.length}}
+        <div class="_JX_comments">
+            {{#commentsForDisplay}}
+            <div class="_JX_comment">
+                <div class="_JX_comment_meta">
+                    <span class="_JX_comment_author">{{author}}</span> | <span class="_JX_comment_time">{{created}}</span>
+                </div>
+                <div class="_JX_comment_body">{{{bodyHtml}}}</div>
+            </div>
+            {{/commentsForDisplay}}
+        </div>
+        {{/commentsForDisplay.length}}
     </div>
     {{/hasBodyContent}}
 

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -35,6 +35,28 @@
     </div>
     {{/description}}
 
+    {{#fixVersions.length}}
+    <div class="_JX_field_group">
+        <div class="_JX_field_label">Fix Version(s)</div>
+        <div class="_JX_field_values">
+            {{#fixVersions}}
+            <span class="_JX_field_chip">{{name}}</span>
+            {{/fixVersions}}
+        </div>
+    </div>
+    {{/fixVersions.length}}
+
+    {{#sprints.length}}
+    <div class="_JX_field_group">
+        <div class="_JX_field_label">Sprint</div>
+        <div class="_JX_field_values">
+            {{#sprints}}
+            <span class="_JX_field_chip">{{name}}{{#state}} ({{state}}){{/state}}</span>
+            {{/sprints}}
+        </div>
+    </div>
+    {{/sprints.length}}
+
     {{#prs.length}}
     <div class="_JX_related_pr">
     <table>

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -9,9 +9,27 @@
             {{/assignee}}
         </div>
         <a class="_JX_copyable_link" id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}" target="_blank" rel="noopener noreferrer">{{urlTitle}}</a>
-        <button class="_JX_title_copy _JX_copy_link" data-url="{{copyUrl}}" data-ticket="{{copyTicket}}" data-title="{{copyTitle}}">
-            <svg width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><path d="M10 19h8V8h-8v11zM8 7.992C8 6.892 8.902 6 10.009 6h7.982C19.101 6 20 6.893 20 7.992v11.016c0 1.1-.902 1.992-2.009 1.992H10.01A2.001 2.001 0 0 1 8 19.008V7.992z"></path><path d="M5 16V4.992C5 3.892 5.902 3 7.009 3H15v13H5zm2 0h8V5H7v11z"></path></g></svg>
-        </button>
+        <div class="_JX_title_controls">
+            <button class="_JX_control_button _JX_title_copy _JX_copy_link" type="button" title="Copy pretty link" aria-label="Copy pretty link" data-url="{{copyUrl}}" data-ticket="{{copyTicket}}" data-title="{{copyTitle}}">
+                <svg width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><path d="M10 19h8V8h-8v11zM8 7.992C8 6.892 8.902 6 10.009 6h7.982C19.101 6 20 6.893 20 7.992v11.016c0 1.1-.902 1.992-2.009 1.992H10.01A2.001 2.001 0 0 1 8 19.008V7.992z"></path><path d="M5 16V4.992C5 3.892 5.902 3 7.009 3H15v13H5zm2 0h8V5H7v11z"></path></g></svg>
+            </button>
+            {{#hasQuickActions}}
+            <div class="_JX_actions">
+                <button class="_JX_control_button _JX_actions_toggle{{#actionsOpen}} is-open{{/actionsOpen}}" type="button" title="Quick actions" aria-label="Quick actions" aria-haspopup="menu" aria-expanded="{{#actionsOpen}}true{{/actionsOpen}}{{^actionsOpen}}false{{/actionsOpen}}">
+                    <svg class="_JX_actions_toggle_icon" width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><circle cx="6" cy="12" r="1.8"></circle><circle cx="12" cy="12" r="1.8"></circle><circle cx="18" cy="12" r="1.8"></circle></g></svg>
+                    <svg class="_JX_actions_toggle_chevron" width="12" height="12" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"></path></svg>
+                </button>
+                {{#actionsOpen}}
+                <div class="_JX_actions_menu" role="menu">
+                    {{#quickActions}}
+                    {{#showDividerBefore}}<div class="_JX_action_divider" role="separator" aria-hidden="true"></div>{{/showDividerBefore}}
+                    <button class="_JX_action_item{{#disabled}} is-disabled{{/disabled}}{{#isLoading}} is-loading{{/isLoading}}" type="button" role="menuitem" data-action-key="{{key}}" {{disabledAttr}}>{{labelText}}</button>
+                    {{/quickActions}}
+                </div>
+                {{/actionsOpen}}
+            </div>
+            {{/hasQuickActions}}
+        </div>
     </div>
     <div class="_JX_status">
         {{#row1Chips.length}}
@@ -47,7 +65,10 @@
             {{/row3Chips}}
         </div>
         {{/row3Chips.length}}
-    </div>
+        </div>
+    {{#hasActionNotice}}
+    <div class="_JX_action_notice {{actionNoticeClass}}">{{actionNoticeText}}</div>
+    {{/hasActionNotice}}
 
     <div class="_JX_description">
         {{#description}}
@@ -113,3 +134,6 @@
         {{/emptyBodyText}}
     </div>
 </div>
+
+
+

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -53,12 +53,14 @@
 
     <div class="_JX_description">
         {{#description}}
+        <div class="_JX_section_title">Description</div>
         <div class="_JX_description_text">
             {{{description}}}
         </div>
         {{/description}}
         {{#previewAttachments.length}}
         <div class="_JX_description_attachments">
+            <div class="_JX_section_title">Attachments</div>
             {{#previewAttachments}}
             <div data-mime-type="{{mimeType}}" data-url="{{content}}" data-preview-src="{{content}}" class="_JX_thumb">
                 <a href="{{content}}" target="_blank">
@@ -72,6 +74,7 @@
         {{/previewAttachments.length}}
         {{#commentsForDisplay.length}}
         <div class="_JX_comments">
+            <div class="_JX_section_title">Comments</div>
             {{#commentsForDisplay}}
             <div class="_JX_comment">
                 <div class="_JX_comment_meta">

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -14,41 +14,27 @@
         </button>
     </div>
     <div class="_JX_status">
-        {{#statusChips}}
-        <span class="_JX_field_chip">{{text}}</span>
-        {{/statusChips}}
-        {{#epicParentChips}}
-        <span class="_JX_field_chip">{{text}}</span>
-        {{/epicParentChips}}
-        {{#affectsText}}
-        <span class="_JX_field_chip">{{affectsText}}</span>
-        {{/affectsText}}
-        {{#sprintChips}}
-        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
-        {{/sprintChips}}
-        {{#sprintFallbackText}}
-        <span class="_JX_field_chip">{{sprintFallbackText}}</span>
-        {{/sprintFallbackText}}
-        {{#fixVersionChips}}
-        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
-        {{/fixVersionChips}}
-        {{#fixVersionFallbackText}}
-        <span class="_JX_field_chip">{{fixVersionFallbackText}}</span>
-        {{/fixVersionFallbackText}}
-        {{#labelChips}}
-        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
-        {{/labelChips}}
-        {{#accountChips}}
-        <span class="_JX_field_chip">{{text}}</span>
-        {{/accountChips}}
-        {{#attachmentChips}}
-        <span class="_JX_field_chip">{{icon}} {{count}}</span>
-        {{/attachmentChips}}
-        {{#hasComments}}
-        <span class="_JX_field_chip">
-            💬 {{commentsTotal}}
-        </span>
-        {{/hasComments}}
+        {{#row1Chips.length}}
+        <div class="_JX_status_row">
+            {{#row1Chips}}
+            <span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>
+            {{/row1Chips}}
+        </div>
+        {{/row1Chips.length}}
+        {{#row2Chips.length}}
+        <div class="_JX_status_row">
+            {{#row2Chips}}
+            <span class="_JX_field_chip">{{text}}</span>
+            {{/row2Chips}}
+        </div>
+        {{/row2Chips.length}}
+        {{#row3Chips.length}}
+        <div class="_JX_status_row">
+            {{#row3Chips}}
+            <span class="_JX_field_chip">{{text}}</span>
+            {{/row3Chips}}
+        </div>
+        {{/row3Chips.length}}
     </div>
 
     <div class="_JX_description">

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -15,23 +15,35 @@
     </div>
     <div class="_JX_status">
         {{#row1Chips.length}}
-        <div class="_JX_status_row">
-            {{#row1Chips}}
-            <span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>
-            {{/row1Chips}}
+        <div class="_JX_status_row _JX_status_row_primary">
+            <div class="_JX_status_row_main">
+                {{#row1Chips}}
+                {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</a>{{/url}}
+                {{^url}}<span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/url}}
+                {{/row1Chips}}
+            </div>
+            {{#activityIndicators.length}}
+            <div class="_JX_activity_strip">
+                {{#activityIndicators}}
+                <span class="_JX_activity_item" title="{{title}}">{{icon}} <strong>{{count}}</strong></span>
+                {{/activityIndicators}}
+            </div>
+            {{/activityIndicators.length}}
         </div>
         {{/row1Chips.length}}
         {{#row2Chips.length}}
         <div class="_JX_status_row">
             {{#row2Chips}}
-            <span class="_JX_field_chip">{{text}}</span>
+            {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>{{/url}}
+            {{^url}}<span class="_JX_field_chip">{{text}}</span>{{/url}}
             {{/row2Chips}}
         </div>
         {{/row2Chips.length}}
         {{#row3Chips.length}}
         <div class="_JX_status_row">
             {{#row3Chips}}
-            <span class="_JX_field_chip">{{text}}</span>
+            {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>{{/url}}
+            {{^url}}<span class="_JX_field_chip">{{text}}</span>{{/url}}
             {{/row3Chips}}
         </div>
         {{/row3Chips.length}}
@@ -58,6 +70,31 @@
             {{/previewAttachments}}
         </div>
         {{/previewAttachments.length}}
+        {{#prs.length}}
+        <div class="_JX_related_pr">
+            <div class="_JX_section_title">Pull Requests</div>
+            <table>
+                <thead>
+                <tr>
+                    <td>Title</td>
+                    <td>Author</td>
+                    <td>Branch</td>
+                    <td>Status</td>
+                </tr>
+                </thead>
+                <tbody>
+                {{#prs}}
+                <tr>
+                    <td><a href="{{url}}" target="_blank" rel="noopener noreferrer">{{title}}</a></td>
+                    <td>{{authorName}}</td>
+                    <td>{{branchText}}</td>
+                    <td><div class="_JX_PR_STATUS _JX_PR_{{status}}">{{status}}</div></td>
+                </tr>
+                {{/prs}}
+                </tbody>
+            </table>
+        </div>
+        {{/prs.length}}
         {{#commentsForDisplay.length}}
         <div class="_JX_comments">
             <div class="_JX_section_title">Comments</div>
@@ -75,34 +112,4 @@
         <div class="_JX_empty_body">{{emptyBodyText}}</div>
         {{/emptyBodyText}}
     </div>
-
-    {{#prs.length}}
-    <div class="_JX_related_pr">
-    <table>
-        <thead>
-        <tr>
-            <td>#</td>
-            <td>title</td>
-            <td>author</td>
-            <td>status</td>
-        </tr>
-        </thead>
-        <tbody>
-        {{#prs}}
-        <tr>
-            <td><a href="{{url}}">{{id}}</a></td>
-            <td><a href="{{url}}">{{name}}</a></td>
-            <td>
-            <img class="_JX_avatar" title="{{author.name}}" src="{{author.avatar}}">
-            </td>
-            <td>
-            <div class="_JX_PR_STATUS _JX_PR_{{status}}">{{status}}</div>
-            </td>
-        </tr>
-        {{/prs}}
-        </tbody>
-    </table>
-    </div>
-    {{/prs.length}}
-
 </div>

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -7,55 +7,46 @@
         </button>
     </div>
     <div class="_JX_status">
-        {{#issuetype}}
-        <div title="Issue Type">
-            <img class="_JX_status_icon" src="{{iconUrl}}"> {{name}}
-        </div>
-        {{/issuetype}}
-        {{#status}}
-        <div title="Status">
-            <img class="_JX_status_icon" src="{{iconUrl}}"> {{name}}
-        </div>
-        {{/status}}
-        {{#priority}}
-        <div title="Priority">
-            <img class="_JX_status_icon" src="{{iconUrl}}"> {{name}}
-        </div>
-        {{/priority}}
-        {{#comment.total}}
-        <a title="{{comments}}" target="_blank" style="display: block" href="{{commentUrl}}">
-            💬 &nbsp; {{comment.total}}
+        <span class="_JX_field_chip">
+            {{#issuetype.iconUrl}}<img class="_JX_status_icon" src="{{issuetype.iconUrl}}">{{/issuetype.iconUrl}}{{issueTypeText}}
+        </span>
+        <span class="_JX_field_chip">
+            {{#status.iconUrl}}<img class="_JX_status_icon" src="{{status.iconUrl}}">{{/status.iconUrl}}{{statusText}}
+        </span>
+        {{#hasComments}}
+        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" href="{{commentUrl}}">
+            💬 {{commentsTotal}}
         </a>
-        {{/comment.total}}
+        {{/hasComments}}
+        <span class="_JX_field_chip">{{fixVersionText}}</span>
+        <span class="_JX_field_chip">{{sprintText}}</span>
+        {{#attachmentChips}}
+        <span class="_JX_field_chip">{{icon}} {{count}}</span>
+        {{/attachmentChips}}
     </div>
 
-    {{#description}}
+    {{#hasBodyContent}}
     <div class="_JX_description">
-      {{{description}}}
-    </div>
-    {{/description}}
-
-    {{#fixVersions.length}}
-    <div class="_JX_field_group">
-        <div class="_JX_field_label">Fix Version(s)</div>
-        <div class="_JX_field_values">
-            {{#fixVersions}}
-            <span class="_JX_field_chip">{{name}}</span>
-            {{/fixVersions}}
+        {{#description}}
+        <div class="_JX_description_text">
+            {{{description}}}
         </div>
-    </div>
-    {{/fixVersions.length}}
-
-    {{#sprints.length}}
-    <div class="_JX_field_group">
-        <div class="_JX_field_label">Sprint</div>
-        <div class="_JX_field_values">
-            {{#sprints}}
-            <span class="_JX_field_chip">{{name}}{{#state}} ({{state}}){{/state}}</span>
-            {{/sprints}}
+        {{/description}}
+        {{#previewAttachments.length}}
+        <div class="_JX_description_attachments">
+            {{#previewAttachments}}
+            <div data-mime-type="{{mimeType}}" data-url="{{content}}" class="_JX_thumb">
+                <a href="{{content}}" target="_blank">
+                    <img title="{{filename}}" src="{{thumbnail}}">
+                    <div class="_JX_thumb_filename">{{filename}}</div>
+                    <img class="_JX_file_loader" src="{{loaderGifUrl}}">
+                </a>
+            </div>
+            {{/previewAttachments}}
         </div>
+        {{/previewAttachments.length}}
     </div>
-    {{/sprints.length}}
+    {{/hasBodyContent}}
 
     {{#prs.length}}
     <div class="_JX_related_pr">
@@ -85,19 +76,5 @@
     </table>
     </div>
     {{/prs.length}}
-
-    {{#attachments.length}}
-    <div class="_JX_attachments">
-    {{#attachments}}
-    <div data-mime-type="{{mimeType}}" data-url="{{content}}" class="_JX_thumb">
-        <a href="{{content}}" target="_blank">
-        <img title="{{filename}}" src="{{thumbnail}}">
-        <div class="_JX_thumb_filename">{{filename}}</div>
-        <img class="_JX_file_loader" src="{{loaderGifUrl}}">
-        </a>
-    </div>
-    {{/attachments}}
-    </div>
-    {{/attachments.length}}
 
 </div>

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -1,27 +1,53 @@
 <div class="_JX_annotation">
     <div class="_JX_title">
-        <img class="_JX_title_user" title="{{reporter.displayName}}" src="{{reporter.avatarUrls.48x48}}">
-        <a id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}">{{urlTitle}}</a>
-        <button class="_JX_title_copy">
+        <div class="_JX_title_users">
+            {{#reporter}}
+            <img class="_JX_title_user" title="Reporter: {{displayName}}" src="{{avatarUrls.48x48}}">
+            {{/reporter}}
+            {{#assignee}}
+            <img class="_JX_title_user _JX_title_user_assignee" title="Assignee: {{displayName}}" src="{{avatarUrls.48x48}}">
+            {{/assignee}}
+        </div>
+        <a class="_JX_copyable_link" id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}" target="_blank" rel="noopener noreferrer">{{urlTitle}}</a>
+        <button class="_JX_title_copy _JX_copy_link" data-url="{{copyUrl}}" data-ticket="{{copyTicket}}" data-title="{{copyTitle}}">
             <svg width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><path d="M10 19h8V8h-8v11zM8 7.992C8 6.892 8.902 6 10.009 6h7.982C19.101 6 20 6.893 20 7.992v11.016c0 1.1-.902 1.992-2.009 1.992H10.01A2.001 2.001 0 0 1 8 19.008V7.992z"></path><path d="M5 16V4.992C5 3.892 5.902 3 7.009 3H15v13H5zm2 0h8V5H7v11z"></path></g></svg>
         </button>
     </div>
     <div class="_JX_status">
-        <span class="_JX_field_chip">
-            {{#issuetype.iconUrl}}<img class="_JX_status_icon" src="{{issuetype.iconUrl}}">{{/issuetype.iconUrl}}{{issueTypeText}}
-        </span>
-        <span class="_JX_field_chip">
-            {{#status.iconUrl}}<img class="_JX_status_icon" src="{{status.iconUrl}}">{{/status.iconUrl}}{{statusText}}
-        </span>
-        <span class="_JX_field_chip">{{sprintText}}</span>
-        <span class="_JX_field_chip">{{fixVersionText}}</span>
+        {{#statusChips}}
+        <span class="_JX_field_chip">{{text}}</span>
+        {{/statusChips}}
+        {{#epicParentChips}}
+        <span class="_JX_field_chip">{{text}}</span>
+        {{/epicParentChips}}
+        {{#affectsText}}
+        <span class="_JX_field_chip">{{affectsText}}</span>
+        {{/affectsText}}
+        {{#sprintChips}}
+        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
+        {{/sprintChips}}
+        {{#sprintFallbackText}}
+        <span class="_JX_field_chip">{{sprintFallbackText}}</span>
+        {{/sprintFallbackText}}
+        {{#fixVersionChips}}
+        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
+        {{/fixVersionChips}}
+        {{#fixVersionFallbackText}}
+        <span class="_JX_field_chip">{{fixVersionFallbackText}}</span>
+        {{/fixVersionFallbackText}}
+        {{#labelChips}}
+        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
+        {{/labelChips}}
+        {{#accountChips}}
+        <span class="_JX_field_chip">{{text}}</span>
+        {{/accountChips}}
         {{#attachmentChips}}
         <span class="_JX_field_chip">{{icon}} {{count}}</span>
         {{/attachmentChips}}
         {{#hasComments}}
-        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" href="{{commentUrl}}">
+        <span class="_JX_field_chip">
             💬 {{commentsTotal}}
-        </a>
+        </span>
         {{/hasComments}}
     </div>
 

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -18,8 +18,8 @@
         <div class="_JX_status_row _JX_status_row_primary">
             <div class="_JX_status_row_main">
                 {{#row1Chips}}
-                {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</a>{{/url}}
-                {{^url}}<span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/url}}
+                {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</a>{{/linkUrl}}
+                {{^linkUrl}}<span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/linkUrl}}
                 {{/row1Chips}}
             </div>
             {{#activityIndicators.length}}
@@ -34,16 +34,16 @@
         {{#row2Chips.length}}
         <div class="_JX_status_row">
             {{#row2Chips}}
-            {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>{{/url}}
-            {{^url}}<span class="_JX_field_chip">{{text}}</span>{{/url}}
+            {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}">{{text}}</a>{{/linkUrl}}
+            {{^linkUrl}}<span class="_JX_field_chip">{{text}}</span>{{/linkUrl}}
             {{/row2Chips}}
         </div>
         {{/row2Chips.length}}
         {{#row3Chips.length}}
         <div class="_JX_status_row">
             {{#row3Chips}}
-            {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>{{/url}}
-            {{^url}}<span class="_JX_field_chip">{{text}}</span>{{/url}}
+            {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}">{{text}}</a>{{/linkUrl}}
+            {{^linkUrl}}<span class="_JX_field_chip">{{text}}</span>{{/linkUrl}}
             {{/row3Chips}}
         </div>
         {{/row3Chips.length}}

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -51,7 +51,6 @@
         {{/hasComments}}
     </div>
 
-    {{#hasBodyContent}}
     <div class="_JX_description">
         {{#description}}
         <div class="_JX_description_text">
@@ -83,8 +82,10 @@
             {{/commentsForDisplay}}
         </div>
         {{/commentsForDisplay.length}}
+        {{#emptyBodyText}}
+        <div class="_JX_empty_body">{{emptyBodyText}}</div>
+        {{/emptyBodyText}}
     </div>
-    {{/hasBodyContent}}
 
     {{#prs.length}}
     <div class="_JX_related_pr">

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -7,9 +7,28 @@ const executeScript = promisifyChrome(chrome.scripting, 'executeScript');
 const sendMessage = promisifyChrome(chrome.tabs, 'sendMessage');
 
 var SEND_RESPONSE_IS_ASYNC = true;
+
+async function fetchWithCredentials(url) {
+  const response = await fetch(url, {credentials: 'include'});
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} - ${response.statusText}`);
+  }
+  return response;
+}
+
+async function blobToDataUrl(blob) {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return `data:${blob.type || 'application/octet-stream'};base64,${btoa(binary)}`;
+}
+
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.action === 'get') {
-    fetch(request.url)
+    fetchWithCredentials(request.url)
       .then(async response => {
         if (!response.ok) {
           throw new Error(`HTTP ${response.status} – ${response.statusText}`);
@@ -22,6 +41,22 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
           ? await response.json()
           : await response.text();
         sendResponse({ result });
+      })
+      .catch(error => {
+        sendResponse({ error: error.message });
+      });
+    return SEND_RESPONSE_IS_ASYNC;
+  }
+
+  if (request.action === 'getImageDataUrl') {
+    fetchWithCredentials(request.url)
+      .then(async response => {
+        const contentType = response.headers.get('Content-Type') || '';
+        if (!contentType.startsWith('image/')) {
+          throw new Error(`Expected image content but got: ${contentType || 'unknown'}`);
+        }
+        const dataUrl = await blobToDataUrl(await response.blob());
+        sendResponse({ result: dataUrl });
       })
       .catch(error => {
         sendResponse({ error: error.message });

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -8,7 +8,7 @@ const sendMessage = promisifyChrome(chrome.tabs, 'sendMessage');
 
 var SEND_RESPONSE_IS_ASYNC = true;
 const EXTENSION_ORIGIN = new URL(chrome.runtime.getURL('')).origin;
-const FETCH_TIMEOUT_MS = 1000;
+const FETCH_TIMEOUT_MS = 10000;
 
 async function getInstanceOrigin() {
   const {instanceUrl} = await storageGet(defaultConfig);
@@ -199,9 +199,9 @@ async function browserOnClicked (tab) {
   });
 
   chrome.action.onClicked.addListener(tab => {
-    browserOnClicked(tab).catch( (err) => {
-      console.log('Error: ', err)
-    });
+    browserOnClicked(tab).catch(() => {});
   });
 })();
+
+
 

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -98,7 +98,7 @@ async function browserOnClicked (tab) {
     await storageSet(config);
     await resetDeclarativeMapping();
     await executeScript({
-      target: {tabId: null},
+      target: {tabId: tab.id},
       files: [contentScript]
     });
     await sendMessage(tab.id, {

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -7,6 +7,77 @@ const executeScript = promisifyChrome(chrome.scripting, 'executeScript');
 const sendMessage = promisifyChrome(chrome.tabs, 'sendMessage');
 
 var SEND_RESPONSE_IS_ASYNC = true;
+const EXTENSION_ORIGIN = new URL(chrome.runtime.getURL('')).origin;
+
+async function getInstanceOrigin() {
+  const {instanceUrl} = await storageGet(defaultConfig);
+  if (!instanceUrl) {
+    return null;
+  }
+  try {
+    return new URL(instanceUrl).origin;
+  } catch (ex) {
+    return null;
+  }
+}
+
+async function assertAllowedRequestUrl(rawUrl, {allowExtension = false} = {}) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch (ex) {
+    throw new Error('Invalid request URL');
+  }
+
+  if (allowExtension && parsed.origin === EXTENSION_ORIGIN) {
+    return parsed.toString();
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error('Unsupported URL protocol');
+  }
+
+  const instanceOrigin = await getInstanceOrigin();
+  if (!instanceOrigin || parsed.origin !== instanceOrigin) {
+    throw new Error('URL is outside configured Jira instance');
+  }
+
+  return parsed.toString();
+}
+
+function validateMessageSender(sender) {
+  if (!sender || sender.id !== chrome.runtime.id) {
+    throw new Error('Rejected sender');
+  }
+}
+
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+async function ensureContentScriptReady(tabId) {
+  await executeScript({
+    target: {tabId},
+    files: [contentScript]
+  });
+}
+
+async function notifyTab(tabId, message) {
+  const maxAttempts = 3;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      if (attempt > 0) {
+        await ensureContentScriptReady(tabId);
+      }
+      await sendMessage(tabId, {
+        action: 'message',
+        message
+      });
+      return true;
+    } catch (ex) {
+      await delay(80);
+    }
+  }
+  return false;
+}
 
 async function fetchWithCredentials(url) {
   const response = await fetch(url, {credentials: 'include'});
@@ -27,8 +98,16 @@ async function blobToDataUrl(blob) {
 }
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+  try {
+    validateMessageSender(sender);
+  } catch (error) {
+    sendResponse({error: error.message});
+    return false;
+  }
+
   if (request.action === 'get') {
-    fetchWithCredentials(request.url)
+    assertAllowedRequestUrl(request.url, {allowExtension: true})
+      .then(fetchWithCredentials)
       .then(async response => {
         if (!response.ok) {
           throw new Error(`HTTP ${response.status} – ${response.statusText}`);
@@ -49,7 +128,8 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   }
 
   if (request.action === 'getImageDataUrl') {
-    fetchWithCredentials(request.url)
+    assertAllowedRequestUrl(request.url)
+      .then(fetchWithCredentials)
       .then(async response => {
         const contentType = response.headers.get('Content-Type') || '';
         if (!contentType.startsWith('image/')) {
@@ -63,9 +143,14 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       });
     return SEND_RESPONSE_IS_ASYNC;
   }
+
+  return false;
 });
 
 async function browserOnClicked (tab) {
+  if (!tab || !tab.id || !tab.url || !/^https?:\/\//i.test(tab.url)) {
+    return;
+  }
   const config = await storageGet(defaultConfig);
   if (!config.instanceUrl || !config.v15upgrade) {
     chrome.runtime.openOptionsPage();
@@ -76,35 +161,14 @@ async function browserOnClicked (tab) {
   if (granted) {
     const config = await storageGet(defaultConfig);
     if (config.domains.indexOf(origin) !== -1) {
-      try {
-        await sendMessage(tab.id, {
-          action: 'message',
-          message: origin + ' is already added.'
-        });
-      } catch (ex) {
-        // extension was just installed and not injected on this tab yet
-        await executeScript({
-          target: {tabId: tab.id},
-          files: [contentScript]
-        });
-        await sendMessage(tab.id, {
-          action: 'message',
-          message: 'Jira HotLinker enabled successfully !'
-        });
-      }
+      await notifyTab(tab.id, origin + ' is already added.');
       return;
     }
     config.domains.push(origin);
     await storageSet(config);
     await resetDeclarativeMapping();
-    await executeScript({
-      target: {tabId: tab.id},
-      files: [contentScript]
-    });
-    await sendMessage(tab.id, {
-      action: 'message',
-      message: origin + ' added successfully !'
-    });
+    await ensureContentScriptReady(tab.id);
+    await notifyTab(tab.id, origin + ' added successfully !');
   }
 }
 

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -8,6 +8,7 @@ const sendMessage = promisifyChrome(chrome.tabs, 'sendMessage');
 
 var SEND_RESPONSE_IS_ASYNC = true;
 const EXTENSION_ORIGIN = new URL(chrome.runtime.getURL('')).origin;
+const FETCH_TIMEOUT_MS = 1000;
 
 async function getInstanceOrigin() {
   const {instanceUrl} = await storageGet(defaultConfig);
@@ -80,11 +81,26 @@ async function notifyTab(tabId, message) {
 }
 
 async function fetchWithCredentials(url) {
-  const response = await fetch(url, {credentials: 'include'});
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status} - ${response.statusText}`);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      credentials: 'include',
+      signal: controller.signal
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} - ${response.statusText}`);
+    }
+    return response;
+  } catch (error) {
+    if (error && error.name === 'AbortError') {
+      throw new Error(`Request timed out after ${FETCH_TIMEOUT_MS}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
   }
-  return response;
 }
 
 async function blobToDataUrl(blob) {
@@ -188,3 +204,4 @@ async function browserOnClicked (tab) {
     });
   });
 })();
+

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -256,6 +256,7 @@ async function mainAsyncLocal() {
     maybeNormalizeAvatar(issueData.fields.assignee);
     maybeNormalizeIcon(issueData.fields.issuetype);
     maybeNormalizeIcon(issueData.fields.status);
+    maybeNormalizeIcon(issueData.fields.priority);
 
     (issueData.fields.attachment || []).forEach(attachment => {
       attachment.content = toAbsoluteJiraUrl(attachment.content);
@@ -625,35 +626,6 @@ async function mainAsyncLocal() {
     return `${INSTANCE_URL}issues/?jql=${encodeURIComponent(jql)}`;
   }
 
-  function toSearchChip(fieldName, value, label = value) {
-    if (!value) {
-      return null;
-    }
-    const jql = `${fieldName} = ${encodeJqlValue(value)}`;
-    return {
-      text: label,
-      url: buildJqlUrl(jql)
-    };
-  }
-
-  function toIssueSearchChip(issueTypeName, statusName, value, label = value) {
-    if (!value) {
-      return null;
-    }
-    const criteria = [];
-    if (issueTypeName) {
-      criteria.push(`issuetype = ${encodeJqlValue(issueTypeName)}`);
-    }
-    if (statusName) {
-      criteria.push(`status = ${encodeJqlValue(statusName)}`);
-    }
-    criteria.push(`text ~ ${encodeJqlValue(value)}`);
-    return {
-      text: label,
-      url: buildJqlUrl(criteria.join(' AND '))
-    };
-  }
-
   function buildAttachmentChips(attachments) {
     const totals = {
       image: 0,
@@ -969,42 +941,38 @@ async function mainAsyncLocal() {
           const statusName = issueData.fields.status?.name;
           const priorityName = issueData.fields.priority?.name;
 
-          const statusChips = [
-            displayFields.issueType ? {text: issueTypeName || 'No type'} : null,
-            displayFields.status ? {text: statusName || 'No status'} : null,
-            displayFields.priority ? {text: priorityName || 'No priority'} : null
+          const row1Chips = [
+            displayFields.issueType ? {
+              text: issueTypeName || 'No type',
+              iconUrl: issueData.fields.issuetype?.iconUrl || ''
+            } : null,
+            displayFields.status ? {
+              text: statusName || 'No status',
+              iconUrl: issueData.fields.status?.iconUrl || ''
+            } : null,
+            displayFields.priority ? {
+              text: priorityName || 'No priority',
+              iconUrl: issueData.fields.priority?.iconUrl || ''
+            } : null,
+            displayFields.epicParent ? {
+              text: epicOrParent
+                ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
+                : 'Parent: --'
+            } : null
           ].filter(Boolean);
 
-          const sprintChips = displayFields.sprint ? sprints
-            .map(sprint => {
-              const label = sprint.state ? `${sprint.name} (${sprint.state})` : sprint.name;
-              return toSearchChip('Sprint', sprint.name, label);
-            })
-            .filter(Boolean) : [];
-          const sprintFallbackText = displayFields.sprint && !sprintChips.length ? 'Sprint: --' : '';
+          const row2Chips = [
+            displayFields.sprint ? {text: `Sprint: ${formatSprintText(sprints) || '--'}`} : null,
+            displayFields.affects ? {
+              text: `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`
+            } : null,
+            displayFields.fixVersions ? {text: `Fix version: ${formatFixVersionText(fixVersions) || '--'}`} : null
+          ].filter(Boolean);
 
-          const fixVersionChips = displayFields.fixVersions ? fixVersions
-            .map(version => toSearchChip('fixVersion', version.name))
-            .filter(Boolean) : [];
-          const fixVersionFallbackText = displayFields.fixVersions && !fixVersionChips.length ? 'Fix version: --' : '';
-
-          const labelChips = displayFields.labels ? labels
-            .map(label => toIssueSearchChip(issueTypeName, statusName, label))
-            .filter(Boolean) : [];
-
-          const accountChips = displayFields.account ? accountValues
-            .map(accountValue => ({text: accountValue}))
-            .filter(Boolean) : [];
-
-          const epicParentChips = displayFields.epicParent && epicOrParent
-            ? [{
-              text: `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`,
-            }]
-            : [];
-
-          const affectsText = displayFields.affects
-            ? `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`
-            : '';
+          const row3Chips = [
+            displayFields.labels ? {text: `Labels: ${labels.filter(Boolean).join(', ') || '--'}`} : null,
+            displayFields.account ? {text: `Account: ${accountValues.filter(Boolean).join(', ') || '--'}`} : null
+          ].filter(Boolean);
 
           const copyTicketMeta = (ticket) => ({
             copyUrl: ticket.url,
@@ -1038,30 +1006,16 @@ async function mainAsyncLocal() {
             statusText: displayFields.status ? (statusName || 'No status') : '',
             sprintText: displayFields.sprint ? (formatSprintText(sprints) || 'No sprint') : '',
             fixVersionText: displayFields.fixVersions ? (formatFixVersionText(fixVersions) || 'No fix version') : '',
-            statusChips,
-            epicParentChips,
-            sprintChips,
-            sprintFallbackText,
-            fixVersionChips,
-            fixVersionFallbackText,
-            labelChips,
-            accountChips,
-            affectsText,
+            row1Chips,
+            row2Chips,
+            row3Chips,
             hasComments: displayFields.comments && commentsTotal > 0,
             commentsTotal: displayFields.comments ? commentsTotal : 0,
             attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
             reporter: displayFields.reporter ? issueData.fields.reporter : null,
             assignee: displayFields.assignee ? issueData.fields.assignee : null,
             commentUrl: INSTANCE_URL + 'browse/' + key,
-            hasFieldSummary: statusChips.length > 0 ||
-              epicParentChips.length > 0 ||
-              !!affectsText ||
-              sprintChips.length > 0 ||
-              !!sprintFallbackText ||
-              fixVersionChips.length > 0 ||
-              !!fixVersionFallbackText ||
-              labelChips.length > 0 ||
-              accountChips.length > 0,
+            hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
             loaderGifUrl,
           };
           if (issueData.fields.comment?.comments?.[0]?.id) {

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -41,6 +41,7 @@ async function getSprintFieldIds(instanceUrl) {
   return sprintFieldIdsPromise;
 }
 
+
 /**
  * Returns a function that will return an array of jira tickets for any given string
  * @param projectKeys project keys to match
@@ -168,7 +169,6 @@ async function mainAsyncLocal() {
     fixVersions: true,
     affects: true,
     labels: true,
-    account: true,
     epicParent: true,
     attachments: true,
     comments: true,
@@ -178,6 +178,7 @@ async function mainAsyncLocal() {
     pullRequests: true,
     ...(config.displayFields || {})
   };
+  const customFields = normalizeCustomFields(config.customFields);
   let jiraProjects = [];
   let getJiraKeys = buildFallbackJiraKeyMatcher();
   try {
@@ -190,9 +191,8 @@ async function mainAsyncLocal() {
     getJiraKeys = buildJiraKeyMatcher(jiraProjects.map(function (project) {
       return project.key;
     }));
-  } else {
-    console.log("Couldn't load Jira projects, using fallback issue-key matcher.");
   }
+
   const annotationTemplate = await fetch(chrome.runtime.getURL('resources/annotation.html')).then(response => response.text());
   const loaderGifUrl = chrome.runtime.getURL('resources/ajax-loader.gif');
   const imageProxyCache = {};
@@ -437,8 +437,47 @@ async function mainAsyncLocal() {
   }
 
   function getPullRequestData(issueId, applicationType) {
-    const appTypeQuery = applicationType ? `&applicationType=${encodeURIComponent(applicationType)}` : '';
-    return get(`${INSTANCE_URL}rest/dev-status/1.0/issue/details?issueId=${issueId}${appTypeQuery}&dataType=pullrequest`);
+    return get(INSTANCE_URL + 'rest/dev-status/1.0/issue/detail?issueId=' + issueId + '&applicationType=gitlabselfmanaged&dataType=pullrequest');
+  }
+
+  function getPullRequestSummaryData(issueId) {
+    return get(`${INSTANCE_URL}rest/dev-status/1.0/issue/summary?issueId=${issueId}`);
+  }
+
+  async function probeDevStatusEndpoints(issueId) {
+    const probes = [
+      {label: '1.0 summary', url: `${INSTANCE_URL}rest/dev-status/1.0/issue/summary?issueId=${issueId}`},
+      {label: 'latest summary', url: `${INSTANCE_URL}rest/dev-status/latest/issue/summary?issueId=${issueId}`},
+      {label: '1.0 details none', url: `${INSTANCE_URL}rest/dev-status/1.0/issue/detail?issueId=${issueId}&dataType=pullrequest`},
+      {label: 'latest details none', url: `${INSTANCE_URL}rest/dev-status/latest/issue/detail?issueId=${issueId}&dataType=pullrequest`},
+      {label: '1.0 details gitlabselfmanaged', url: `${INSTANCE_URL}rest/dev-status/1.0/issue/detail?issueId=${issueId}&applicationType=gitlabselfmanaged&dataType=pullrequest`},
+      {label: 'latest details gitlabselfmanaged', url: `${INSTANCE_URL}rest/dev-status/latest/issue/detail?issueId=${issueId}&applicationType=gitlabselfmanaged&dataType=pullrequest`}
+    ];
+
+    const results = [];
+    for (const probe of probes) {
+      try {
+        const response = await get(probe.url);
+        results.push({
+          label: probe.label,
+          url: probe.url,
+          ok: true,
+          topLevelKeys: Object.keys(response || {}),
+          hasSummary: Array.isArray(response?.summary),
+          hasDetail: Array.isArray(response?.detail),
+          summaryCount: Array.isArray(response?.summary) ? response.summary.length : null,
+          detailCount: Array.isArray(response?.detail) ? response.detail.length : null
+        });
+      } catch (ex) {
+        results.push({
+          label: probe.label,
+          url: probe.url,
+          ok: false,
+          error: ex?.message || String(ex)
+        });
+      }
+    }
+    return results;
   }
 
   async function getCachedValue(cache, key, buildValue) {
@@ -473,7 +512,8 @@ async function mainAsyncLocal() {
         'versions',
         'parent',
         'fixVersions',
-        ...sprintFieldIds
+        ...sprintFieldIds,
+        ...customFields.map(({fieldId}) => fieldId)
       ];
       return get(INSTANCE_URL + 'rest/api/2/issue/' + issueKey + '?fields=' + fields.join(',') + '&expand=renderedFields,names');
     });
@@ -484,6 +524,78 @@ async function mainAsyncLocal() {
     return getCachedValue(pullRequestCache, cacheKey, () => {
       return getPullRequestData(issueId, applicationType);
     });
+  }
+
+  function getPullRequestSummaryDataCached(issueId) {
+    return getCachedValue(pullRequestCache, `summary__${issueId}`, () => {
+      return getPullRequestSummaryData(issueId);
+    });
+  }
+
+  function normalizePullRequests(response) {
+    if (Array.isArray(response)) {
+      return response.filter(Boolean);
+    }
+
+    const detailEntries = Array.isArray(response?.detail)
+      ? response.detail
+      : Array.isArray(response?.details)
+        ? response.details
+        : response ? [response] : [];
+
+    return detailEntries
+      .flatMap(entry => {
+        if (Array.isArray(entry?.pullRequests)) {
+          return entry.pullRequests;
+        }
+        if (Array.isArray(entry?.pullrequests)) {
+          return entry.pullrequests;
+        }
+        if (Array.isArray(entry?.pullRequest)) {
+          return entry.pullRequest;
+        }
+        return [];
+      })
+      .filter(Boolean);
+  }
+
+  function summarizePullRequestDebugResponse(response) {
+    const detail = Array.isArray(response?.detail) ? response.detail : [];
+    return {
+      detailCount: detail.length,
+      details: detail.map(entry => ({
+        applicationType: entry?.applicationType || '',
+        objectName: entry?.objectName || '',
+        repoCount: Array.isArray(entry?.repositories) ? entry.repositories.length : 0,
+        pullRequestCount: Array.isArray(entry?.pullRequests) ? entry.pullRequests.length : 0,
+        pullRequests: (entry?.pullRequests || []).map(pr => ({
+          id: pr?.id,
+          name: pr?.name,
+          url: pr?.url,
+          status: pr?.status
+        }))
+      }))
+    };
+  }
+
+  function summarizePullRequestSummaryResponse(response) {
+    const summary = Array.isArray(response?.summary) ? response.summary : [];
+    return {
+      summaryCount: summary.length,
+      summary: summary.map(entry => ({
+        applicationType: entry?.applicationType || '',
+        dataType: entry?.dataType || '',
+        branchCount: entry?.branch?.overall?.count ?? entry?.branches?.overall?.count ?? null,
+        repositoryCount: entry?.repository?.overall?.count ?? entry?.repositories?.overall?.count ?? null,
+        commitCount: entry?.commit?.overall?.count ?? entry?.commits?.overall?.count ?? null,
+        pullRequestCount: entry?.pullrequest?.overall?.count ?? entry?.pullRequest?.overall?.count ?? entry?.pullrequests?.overall?.count ?? null,
+        reviewCount: entry?.review?.overall?.count ?? entry?.reviews?.overall?.count ?? null,
+        buildCount: entry?.build?.overall?.count ?? entry?.builds?.overall?.count ?? null,
+        deploymentCount: entry?.deployment?.overall?.count ?? entry?.deployments?.overall?.count ?? null,
+        overall: entry?.overall || null,
+        rawKeys: Object.keys(entry || {})
+      }))
+    };
   }
 
   async function getIssueSummary(issueKey) {
@@ -535,31 +647,70 @@ async function mainAsyncLocal() {
     }
   }
 
-  function readAccountValues(issueData) {
+  function normalizeCustomFields(customFields) {
+    if (!Array.isArray(customFields)) {
+      return [];
+    }
+    const seen = {};
+    return customFields
+      .map(field => {
+        const fieldId = String(field?.fieldId || '').trim();
+        const row = Math.min(3, Math.max(1, Number(field?.row) || 3));
+        return {fieldId, row};
+      })
+      .filter(field => {
+        if (!field.fieldId || seen[field.fieldId]) {
+          return false;
+        }
+        seen[field.fieldId] = true;
+        return true;
+      });
+  }
+
+  function formatCustomFieldChip(fieldName, entry) {
+    if (entry === undefined || entry === null) {
+      return null;
+    }
+    if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
+      const textValue = String(entry);
+      const looksLikeUrl = /^https?:\/\//i.test(textValue);
+      return {
+        text: looksLikeUrl ? (fieldName || textValue) : (fieldName ? `${fieldName}: ${textValue}` : textValue),
+        url: looksLikeUrl ? textValue : ''
+      };
+    }
+    const primaryText = entry.name || entry.value || entry.displayName || entry.id || entry.key;
+    const rawUrl = [entry.self, entry.url, entry.href].find(value => typeof value === 'string' && value.trim());
+    if (!primaryText && !rawUrl) {
+      return null;
+    }
+    const formattedValue = entry.key && (entry.name || entry.value)
+      ? `[${entry.key}] ${entry.name || entry.value}`
+      : primaryText ? String(primaryText) : rawUrl;
+    return {
+      text: fieldName ? `${fieldName}: ${formattedValue}` : formattedValue,
+      url: rawUrl ? toAbsoluteJiraUrl(rawUrl) : ''
+    };
+  }
+  function buildCustomFieldChips(issueData, customFields) {
     const names = issueData.names || {};
     const fields = issueData.fields || {};
-    const accountFieldIds = Object.keys(names).filter(fieldId => {
-      return String(names[fieldId] || '').toLowerCase().includes('account');
-    });
-    const values = [];
-    accountFieldIds.forEach(fieldId => {
-      const value = fields[fieldId];
-      if (!value) {
+    const chipsByRow = {1: [], 2: [], 3: []};
+    customFields.forEach(({fieldId, row}) => {
+      const rawValue = fields[fieldId];
+      if (rawValue === undefined || rawValue === null || rawValue === '') {
         return;
       }
-      const entries = Array.isArray(value) ? value : [value];
+      const fieldName = String(names[fieldId] || fieldId);
+      const entries = Array.isArray(rawValue) ? rawValue : [rawValue];
       entries.forEach(entry => {
-        if (!entry) {
-          return;
+        const chip = formatCustomFieldChip(fieldName, entry);
+        if (chip && chip.text) {
+          chipsByRow[row].push(chip);
         }
-        if (typeof entry === 'string') {
-          values.push(entry);
-          return;
-        }
-        values.push(entry.name || entry.value || entry.key || entry.id);
       });
     });
-    return [...new Set(values.filter(Boolean))];
+    return chipsByRow;
   }
 
   function readSprintsFromIssue(issueData) {
@@ -662,6 +813,40 @@ async function mainAsyncLocal() {
     if (totals.doc) chips.push({icon: '📝', count: totals.doc});
     if (totals.other) chips.push({icon: '📎', count: totals.other});
     return chips;
+  }
+
+
+  function buildActivityIndicators(attachments, commentsTotal, pullRequestsTotal) {
+    const attachmentCount = Array.isArray(attachments) ? attachments.length : 0;
+    const commentCount = Number(commentsTotal) || 0;
+    const pullRequestCount = Number(pullRequestsTotal) || 0;
+    return [
+      {icon: '📎', count: attachmentCount, label: 'Attachments'},
+      {icon: '💬', count: commentCount, label: 'Comments'},
+      {icon: '🔀', count: pullRequestCount, label: 'Pull requests'}
+    ].map(item => ({
+      ...item,
+      title: item.count + ' ' + item.label.toLowerCase()
+    }));
+  }
+
+  function formatPullRequestTitle(pr) {
+    const id = pr?.id || pr?.number || pr?.key || '';
+    const title = pr?.name || pr?.title || 'Untitled pull request';
+    return id ? '[' + id + '] ' + title : title;
+  }
+
+  function formatPullRequestAuthor(pr) {
+    return pr?.author?.name || pr?.author?.displayName || pr?.author?.username || pr?.author?.email || '--';
+  }
+
+  function formatPullRequestBranch(pr) {
+    const source = pr?.source?.branch || pr?.sourceBranch || pr?.fromRef?.displayId || pr?.fromRef?.id || pr?.source?.displayId || '';
+    const target = pr?.destination?.branch || pr?.targetBranch || pr?.toRef?.displayId || pr?.toRef?.id || pr?.destination?.displayId || '';
+    if (source && target) {
+      return source + ' --> ' + target;
+    }
+    return source || target || '--';
   }
 
   function buildPreviewAttachments(attachments) {
@@ -914,11 +1099,17 @@ async function mainAsyncLocal() {
           const issueData = await getIssueMetaData(key);
           await normalizeIssueImages(issueData);
           let pullRequests = [];
-          try {
-            const githubPrs = await getPullRequestDataCached(issueData.id, 'github');
-            pullRequests = githubPrs.detail?.[0]?.pullRequests || [];
-          } catch (ex) {
-            // probably no access
+          if (displayFields.pullRequests) {
+            try {
+              const pullRequestResponse = await getPullRequestDataCached(issueData.id);
+              pullRequests = normalizePullRequests(pullRequestResponse);
+            } catch (ex) {
+              console.log('[Jira HotLinker] Pull request fetch failed', {
+                issueKey: key,
+                issueId: issueData.id,
+                error: ex?.message || String(ex)
+              });
+            }
           }
 
           if (cancelToken.cancel) {
@@ -935,7 +1126,7 @@ async function mainAsyncLocal() {
           const attachments = issueData.fields.attachment || [];
           const previewAttachments = buildPreviewAttachments(attachments);
           const labels = issueData.fields.labels || [];
-          const accountValues = readAccountValues(issueData);
+          const customFieldChips = buildCustomFieldChips(issueData, customFields);
           const epicOrParent = await readEpicOrParent(issueData);
           const issueTypeName = issueData.fields.issuetype?.name;
           const statusName = issueData.fields.status?.name;
@@ -958,7 +1149,8 @@ async function mainAsyncLocal() {
               text: epicOrParent
                 ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
                 : 'Parent: --'
-            } : null
+            } : null,
+            ...customFieldChips[1]
           ].filter(Boolean);
 
           const row2Chips = [
@@ -966,12 +1158,13 @@ async function mainAsyncLocal() {
             displayFields.affects ? {
               text: `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`
             } : null,
-            displayFields.fixVersions ? {text: `Fix version: ${formatFixVersionText(fixVersions) || '--'}`} : null
+            displayFields.fixVersions ? {text: `Fix version: ${formatFixVersionText(fixVersions) || '--'}`} : null,
+            ...customFieldChips[2]
           ].filter(Boolean);
 
           const row3Chips = [
             displayFields.labels ? {text: `Labels: ${labels.filter(Boolean).join(', ') || '--'}`} : null,
-            displayFields.account ? {text: `Account: ${accountValues.filter(Boolean).join(', ') || '--'}`} : null
+            ...customFieldChips[3]
           ].filter(Boolean);
 
           const copyTicketMeta = (ticket) => ({
@@ -980,6 +1173,8 @@ async function mainAsyncLocal() {
             copyTitle: ticket.summary
           });
 
+          const visibleCommentsTotal = displayFields.comments ? commentsTotal : 0;
+          const visibleAttachments = displayFields.attachments ? previewAttachments : [];
           const displayData = {
             urlTitle: `[${key}] ${issueData.fields.summary}`,
             ticketKey: key,
@@ -993,11 +1188,11 @@ async function mainAsyncLocal() {
             prs: [],
             description: displayFields.description ? normalizedDescription : '',
             hasBodyContent: true,
-            emptyBodyText: (!normalizedDescription && previewAttachments.length === 0 && commentsForDisplay.length === 0)
+            emptyBodyText: (!normalizedDescription && visibleAttachments.length === 0 && visibleCommentsTotal === 0)
               ? 'No description, attachments or comments.'
               : '',
             attachments,
-            previewAttachments: displayFields.attachments ? previewAttachments : [],
+            previewAttachments: visibleAttachments,
             commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
             issuetype: issueData.fields.issuetype,
             status: issueData.fields.status,
@@ -1009,31 +1204,39 @@ async function mainAsyncLocal() {
             row1Chips,
             row2Chips,
             row3Chips,
-            hasComments: displayFields.comments && commentsTotal > 0,
-            commentsTotal: displayFields.comments ? commentsTotal : 0,
+            hasComments: visibleCommentsTotal > 0,
+            commentsTotal: visibleCommentsTotal,
             attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
             reporter: displayFields.reporter ? issueData.fields.reporter : null,
             assignee: displayFields.assignee ? issueData.fields.assignee : null,
             commentUrl: INSTANCE_URL + 'browse/' + key,
             hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
+            activityIndicators: [],
             loaderGifUrl,
           };
           if (issueData.fields.comment?.comments?.[0]?.id) {
             displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
           }
           if (displayFields.pullRequests && size(pullRequests)) {
-            displayData.prs = pullRequests.filter(function (pr) {
-              return pr.url !== location.href;
-            }).map(function (pr) {
+            const filteredPullRequests = pullRequests.filter(function (pr) {
+              return pr && pr.url !== location.href;
+            });
+            displayData.prs = filteredPullRequests.map(function (pr) {
               return {
                 id: pr.id,
                 url: pr.url,
-                name: pr.name,
+                title: formatPullRequestTitle(pr),
                 status: pr.status,
-                author: pr.author
+                authorName: formatPullRequestAuthor(pr),
+                branchText: formatPullRequestBranch(pr)
               };
             });
           }
+          displayData.activityIndicators = buildActivityIndicators(
+            displayFields.attachments ? attachments : [],
+            visibleCommentsTotal,
+            displayData.prs.length
+          );
           // TODO: fix scrolling in google docs
           container.html(Mustache.render(annotationTemplate, displayData));
           if (!containerPinned) {
@@ -1056,5 +1259,14 @@ if (!window.__JX__script_injected__) {
 }
 
 window.__JX__script_injected__ = true;
+
+
+
+
+
+
+
+
+
 
 

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -750,6 +750,7 @@ async function mainAsyncLocal() {
   $(document.body).append(previewOverlay);
   new draggable({
     handle: '._JX_title, ._JX_status',
+    cancel: 'a, button, input, textarea, img, ._JX_description, ._JX_comments, ._JX_comment_body, ._JX_description_text, ._JX_related_pr'
   }, container);
   
   function buildPrettyLinkPayload(sourceElement) {

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -133,6 +133,15 @@ async function getImageDataUrl(url) {
     throw err;
   }
 }
+async function requestJson(method, url, body) {
+  const response = await sendMessage({action: 'requestJson', method, url, body});
+  if (Object.prototype.hasOwnProperty.call(response, 'result')) {
+    return response.result;
+  }
+  const err = new Error(response.error || 'Request failed');
+  err.inner = response.error;
+  throw err;
+}
 
 function isJiraConnectionFailure(error) {
   const message = String(error?.message || error?.inner || error || '');
@@ -199,6 +208,9 @@ async function mainAsyncLocal() {
   const cacheTtlMs = 60 * 1000;
   const issueCache = new Map();
   const pullRequestCache = new Map();
+  let currentUserPromise;
+  const projectSprintOptionsPromises = new Map();
+  let popupState = null;
 
   function toAbsoluteJiraUrl(url) {
     if (!url) {
@@ -723,16 +735,17 @@ async function mainAsyncLocal() {
     const seen = {};
     const sprints = [];
 
-    const pushSprint = (name, state) => {
+    const pushSprint = (id, name, state) => {
       if (!name) {
         return;
       }
-      const key = `${name}__${state || ''}`;
+      const sprintId = id ? String(id) : '';
+      const key = sprintId || `${name}__${state || ''}`;
       if (seen[key]) {
         return;
       }
       seen[key] = true;
-      sprints.push({name, state: state || ''});
+      sprints.push({id: sprintId, name, state: state || ''});
     };
 
     sprintValues.forEach(value => {
@@ -742,12 +755,17 @@ async function mainAsyncLocal() {
           return;
         }
         if (typeof entry === 'string') {
+          const idMatch = entry.match(/id=([^,\]]+)/i);
           const nameMatch = entry.match(/name=([^,\]]+)/i);
           const stateMatch = entry.match(/state=([^,\]]+)/i);
-          pushSprint(nameMatch && nameMatch[1] ? nameMatch[1] : entry, stateMatch && stateMatch[1]);
+          pushSprint(
+            idMatch && idMatch[1] ? idMatch[1] : '',
+            nameMatch && nameMatch[1] ? nameMatch[1] : entry,
+            stateMatch && stateMatch[1]
+          );
           return;
         }
-        pushSprint(entry.name || entry.goal || entry.id, entry.state);
+        pushSprint(entry.id || '', entry.name || entry.goal || entry.id, entry.state);
       });
     });
     return sprints;
@@ -871,6 +889,504 @@ async function mainAsyncLocal() {
     });
   }
 
+  function buildQuickActionError(error) {
+    return error?.message || error?.inner || 'Action failed';
+  }
+
+  function areSameJiraUser(left, right) {
+    if (!left || !right) {
+      return false;
+    }
+    const leftIds = [left.accountId, left.name, left.username, left.key].filter(Boolean);
+    const rightIds = [right.accountId, right.name, right.username, right.key].filter(Boolean);
+    return leftIds.some(value => rightIds.includes(value));
+  }
+
+  async function getCurrentUserInfo() {
+    if (currentUserPromise) {
+      return currentUserPromise;
+    }
+
+    currentUserPromise = (async () => {
+      try {
+        const myself = await get(INSTANCE_URL + 'rest/api/2/myself');
+        return {
+          accountId: myself?.accountId || '',
+          name: myself?.name || myself?.username || myself?.key || '',
+          username: myself?.username || myself?.name || '',
+          key: myself?.key || '',
+          displayName: myself?.displayName || myself?.name || myself?.username || 'You'
+        };
+      } catch (primaryError) {
+        const session = await get(INSTANCE_URL + 'rest/auth/1/session');
+        const user = session?.user || {};
+        return {
+          accountId: '',
+          name: user.name || user.username || user.key || '',
+          username: user.username || user.name || '',
+          key: user.key || '',
+          displayName: user.displayName || user.name || user.username || 'You'
+        };
+      }
+    })().catch(error => {
+      currentUserPromise = null;
+      throw error;
+    });
+
+    return currentUserPromise;
+  }
+
+  function buildAssignPayload(user) {
+    if (user?.accountId) {
+      return {accountId: user.accountId};
+    }
+    if (user?.name) {
+      return {name: user.name};
+    }
+    if (user?.key) {
+      return {key: user.key};
+    }
+    throw new Error('Could not resolve the current Jira user');
+  }
+
+  async function getAvailableTransitions(issueKey) {
+    const response = await get(`${INSTANCE_URL}rest/api/2/issue/${issueKey}/transitions`);
+    return Array.isArray(response?.transitions) ? response.transitions : [];
+  }
+
+  function isInProgressStatusCategory(statusCategory) {
+    const key = String(statusCategory?.key || '').toLowerCase();
+    const name = String(statusCategory?.name || '').toLowerCase();
+    return key === 'indeterminate' || name.includes('in progress');
+  }
+
+  function buildTransitionActionLabel(transition) {
+    const transitionName = String(transition?.name || '').trim();
+    const targetName = String(transition?.to?.name || '').trim();
+    const normalizedTransitionName = transitionName.toLowerCase();
+
+    if (
+      normalizedTransitionName.includes('start') ||
+      normalizedTransitionName.includes('progress') ||
+      normalizedTransitionName.includes('begin') ||
+      normalizedTransitionName.includes('resume')
+    ) {
+      return transitionName || 'Start progress';
+    }
+
+    if (targetName) {
+      return `Move to ${targetName}`;
+    }
+
+    return transitionName || 'Start progress';
+  }
+
+  function findStartProgressTransition(transitions) {
+    const candidates = Array.isArray(transitions) ? transitions.filter(Boolean) : [];
+    return candidates.find(transition => {
+      const transitionName = String(transition?.name || '').toLowerCase();
+      const targetName = String(transition?.to?.name || '').toLowerCase();
+      return isInProgressStatusCategory(transition?.to?.statusCategory) ||
+        targetName.includes('in progress') ||
+        transitionName.includes('start progress') ||
+        transitionName.includes('start work') ||
+        transitionName.includes('begin progress') ||
+        transitionName.includes('begin work') ||
+        transitionName.includes('resume progress');
+    }) || null;
+  }
+
+  function compareSprintState(left, right) {
+    const order = {
+      active: 0,
+      future: 1,
+      closed: 2
+    };
+    return (order[String(left || '').toLowerCase()] ?? 99) - (order[String(right || '').toLowerCase()] ?? 99);
+  }
+
+  function formatSprintActionLabel(sprint) {
+    const sprintName = String(sprint?.name || '').trim();
+    const sprintState = String(sprint?.state || '').toLowerCase();
+    const stateSuffix = sprintState === 'active'
+      ? ' (ACTIVE)'
+      : (sprintState === 'future' ? ' (NEXT)' : '');
+    return `Move to Sprint ${sprintName}${stateSuffix}`.trim();
+  }
+
+  async function getProjectSprintOptions(issueData) {
+    const projectKey = String(issueData?.key || '').split('-')[0];
+    if (!projectKey) {
+      return {
+        activeSprints: [],
+        upcomingSprint: null
+      };
+    }
+    if (projectSprintOptionsPromises.has(projectKey)) {
+      return projectSprintOptionsPromises.get(projectKey);
+    }
+
+    const sprintPromise = (async () => {
+      const sprintFieldIds = await getSprintFieldIds(INSTANCE_URL);
+      if (!sprintFieldIds.length) {
+        return {
+          activeSprints: [],
+          upcomingSprint: null
+        };
+      }
+
+      const boardResponse = await get(`${INSTANCE_URL}rest/agile/1.0/board?projectKeyOrId=${encodeURIComponent(projectKey)}&maxResults=50`);
+      const boards = Array.isArray(boardResponse?.values) ? boardResponse.values : [];
+      if (!boards.length) {
+        return {
+          activeSprints: [],
+          upcomingSprint: null
+        };
+      }
+
+      const sprintMap = new Map();
+      const sprintResponses = await Promise.allSettled(boards.map(board => {
+        return get(`${INSTANCE_URL}rest/agile/1.0/board/${board.id}/sprint?state=active,future&maxResults=50`)
+          .then(response => ({board, response}));
+      }));
+
+      sprintResponses.forEach(result => {
+        if (result.status !== 'fulfilled') {
+          return;
+        }
+        const board = result.value?.board || {};
+        const sprints = Array.isArray(result.value?.response?.values) ? result.value.response.values : [];
+        sprints.forEach(sprint => {
+          if (!sprint?.id || !sprint?.name) {
+            return;
+          }
+          const sprintId = String(sprint.id);
+          const existingSprint = sprintMap.get(sprintId);
+          const boardRefs = Array.isArray(existingSprint?.boardRefs) ? existingSprint.boardRefs.slice() : [];
+          const boardRefKey = String(board.id || '');
+          if (boardRefKey && !boardRefs.some(ref => String(ref.id) === boardRefKey)) {
+            boardRefs.push({
+              id: board.id,
+              name: board.name || '',
+              projectKey
+            });
+          }
+          sprintMap.set(sprintId, {
+            ...(existingSprint || {}),
+            ...sprint,
+            boardRefs
+          });
+        });
+      });
+
+      readSprintsFromIssue(issueData).forEach(sprint => {
+        if (!sprint?.id || !sprint?.name) {
+          return;
+        }
+        const sprintId = String(sprint.id);
+        if (sprintMap.has(sprintId)) {
+          return;
+        }
+        sprintMap.set(sprintId, {
+          ...sprint,
+          boardRefs: []
+        });
+      });
+
+      const sortedSprints = [...sprintMap.values()].sort((left, right) => {
+        const stateOrder = compareSprintState(left?.state, right?.state);
+        if (stateOrder !== 0) {
+          return stateOrder;
+        }
+        return String(left?.name || '').localeCompare(String(right?.name || ''));
+      });
+
+      const activeSprints = sortedSprints.filter(sprint => String(sprint?.state || '').toLowerCase() === 'active');
+      const upcomingSprint = sortedSprints.find(sprint => String(sprint?.state || '').toLowerCase() === 'future') || null;
+
+      return {
+        activeSprints,
+        upcomingSprint
+      };
+    })().catch(error => {
+      projectSprintOptionsPromises.delete(projectKey);
+      return {
+        activeSprints: [],
+        upcomingSprint: null
+      };
+    });
+
+    projectSprintOptionsPromises.set(projectKey, sprintPromise);
+    return sprintPromise;
+  }
+
+  function pickSprintFieldId(issueData, sprintFieldIds) {
+    const populatedFieldId = (sprintFieldIds || []).find(fieldId => {
+      const value = issueData?.fields?.[fieldId];
+      return Array.isArray(value) ? value.length > 0 : !!value;
+    });
+    return populatedFieldId || sprintFieldIds?.[0] || '';
+  }
+
+  async function resolveQuickActions(issueData) {
+
+    const actionResults = await Promise.allSettled([
+      getCurrentUserInfo(),
+      getAvailableTransitions(issueData.key),
+      getProjectSprintOptions(issueData),
+      getSprintFieldIds(INSTANCE_URL)
+    ]);
+
+    const currentUser = actionResults[0].status === 'fulfilled' ? actionResults[0].value : null;
+    const transitions = actionResults[1].status === 'fulfilled' ? actionResults[1].value : [];
+    const sprintOptions = actionResults[2].status === 'fulfilled' ? actionResults[2].value : {activeSprints: [], upcomingSprint: null};
+    const sprintFieldIds = actionResults[3].status === 'fulfilled' ? actionResults[3].value : [];
+    const actions = [];
+
+    if (currentUser && !areSameJiraUser(issueData.fields.assignee, currentUser)) {
+      actions.push({
+        key: 'assign-to-me',
+        label: 'Assign to me',
+        successMessage: 'Assigned to you',
+        payload: buildAssignPayload(currentUser)
+      });
+    }
+
+    const startProgressTransition = findStartProgressTransition(transitions);
+    if (startProgressTransition) {
+      actions.push({
+        key: 'start-progress',
+        label: buildTransitionActionLabel(startProgressTransition),
+        successMessage: `Moved to ${startProgressTransition.to?.name || startProgressTransition.name}`,
+        transitionId: startProgressTransition.id
+      });
+    }
+
+    const sprintFieldId = pickSprintFieldId(issueData, sprintFieldIds);
+    const existingSprints = readSprintsFromIssue(issueData)
+      .map(sprint => String(sprint.id || ''))
+      .filter(Boolean);
+    const sprintCandidates = [
+      ...(Array.isArray(sprintOptions.activeSprints) ? sprintOptions.activeSprints : []),
+      ...(sprintOptions.upcomingSprint ? [sprintOptions.upcomingSprint] : [])
+    ].filter(sprint => sprint?.id && !existingSprints.includes(String(sprint.id)));
+    const seenSprintIds = new Set();
+    sprintCandidates.forEach(sprint => {
+      const sprintId = String(sprint.id);
+      if (seenSprintIds.has(sprintId) || !sprintFieldId) {
+        return;
+      }
+      seenSprintIds.add(sprintId);
+      actions.push({
+        key: `move-to-sprint-${sprintId}`,
+        kind: 'move-to-sprint',
+        label: formatSprintActionLabel(sprint),
+        successMessage: `Moved to Sprint ${sprint.name}`,
+        sprintId,
+        sprintFieldId
+      });
+    });
+
+    return actions;
+  }
+
+  async function executeQuickAction(action, issueData) {
+    if (!action) {
+      throw new Error('Action is unavailable');
+    }
+
+    if (action.key === 'assign-to-me') {
+      await requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}/assignee`, action.payload);
+      return action.successMessage;
+    }
+
+    if (action.key === 'start-progress') {
+      await requestJson('POST', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}/transitions`, {
+        transition: {id: action.transitionId}
+      });
+      return action.successMessage;
+    }
+
+    if (action.kind === 'move-to-sprint') {
+      await requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
+        fields: {
+          [action.sprintFieldId]: action.sprintId
+        }
+      });
+      return action.successMessage;
+    }
+
+    throw new Error('Unknown action');
+  }
+
+  function buildQuickActionViewData(actionsOpen, actionLoadingKey, quickActions) {
+    const sourceActions = Array.isArray(quickActions) ? quickActions : [];
+    const firstSprintActionIndex = sourceActions.findIndex(action => action?.kind === 'move-to-sprint');
+    const actions = sourceActions.map((action, index) => ({
+      ...action,
+      showDividerBefore: firstSprintActionIndex > 0 && index === firstSprintActionIndex,
+      disabled: actionLoadingKey && actionLoadingKey !== action.key,
+      disabledAttr: actionLoadingKey && actionLoadingKey !== action.key ? 'disabled' : '',
+      isLoading: actionLoadingKey === action.key,
+      labelText: actionLoadingKey === action.key ? `${action.label}...` : action.label
+    }));
+    return {
+      hasQuickActions: actions.length > 0,
+      actionsOpen: actionsOpen && actions.length > 0,
+      quickActions: actions
+    };
+  }
+
+  async function buildPopupDisplayData(state) {
+    const {key, issueData, pullRequests, actionLoadingKey, actionError, lastActionSuccess, actionsOpen, quickActions} = state;
+    const normalizedDescription = await normalizeRichHtml(issueData.renderedFields.description, {
+      imageMaxHeight: 180
+    });
+    const commentsForDisplay = await buildCommentsForDisplay(issueData);
+    const fixVersions = issueData.fields.fixVersions || [];
+    const affectsVersions = issueData.fields.versions || [];
+    const sprints = readSprintsFromIssue(issueData);
+    const commentsTotal = commentsForDisplay.length;
+    const attachments = issueData.fields.attachment || [];
+    const previewAttachments = buildPreviewAttachments(attachments);
+    const labels = issueData.fields.labels || [];
+    const customFieldChips = buildCustomFieldChips(issueData, customFields);
+    const epicOrParent = await readEpicOrParent(issueData);
+    const issueTypeName = issueData.fields.issuetype?.name;
+    const statusName = issueData.fields.status?.name;
+    const priorityName = issueData.fields.priority?.name;
+    const projectKey = key.split('-')[0];
+
+    const row1Chips = [
+      displayFields.issueType ? buildFilterChip(
+        issueTypeName || 'No type',
+        issueTypeName ? `${scopeJqlToProject(projectKey, `issuetype = ${encodeJqlValue(issueTypeName)}`)}` : '',
+        {iconUrl: issueData.fields.issuetype?.iconUrl || ''}
+      ) : null,
+      displayFields.status ? buildFilterChip(
+        statusName || 'No status',
+        statusName ? `${scopeJqlToProject(projectKey, `status = ${encodeJqlValue(statusName)}`)}` : '',
+        {iconUrl: issueData.fields.status?.iconUrl || ''}
+      ) : null,
+      displayFields.priority ? buildFilterChip(
+        priorityName || 'No priority',
+        priorityName ? `${scopeJqlToProject(projectKey, `priority = ${encodeJqlValue(priorityName)}`)}` : '',
+        {iconUrl: issueData.fields.priority?.iconUrl || ''}
+      ) : null,
+      displayFields.epicParent ? {
+        text: epicOrParent
+          ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
+          : 'Parent: --',
+        linkUrl: epicOrParent?.url || ''
+      } : null,
+      ...customFieldChips[1]
+    ].filter(Boolean);
+
+    const singleAffectsVersion = affectsVersions.length === 1 ? affectsVersions[0]?.name : '';
+    const singleFixVersion = fixVersions.length === 1 ? fixVersions[0]?.name : '';
+    const row2Chips = [
+      displayFields.sprint ? buildFilterChip(
+        `Sprint: ${formatSprintText(sprints) || '--'}`,
+        ''
+      ) : null,
+      displayFields.affects ? buildFilterChip(
+        `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`,
+        singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
+      ) : null,
+      displayFields.fixVersions ? buildFilterChip(
+        `Fix version: ${formatFixVersionText(fixVersions) || '--'}`,
+        singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
+      ) : null,
+      ...customFieldChips[2]
+    ].filter(Boolean);
+
+    const singleLabel = labels.length === 1 ? labels[0] : '';
+    const row3Chips = [
+      displayFields.labels ? buildFilterChip(
+        `Labels: ${labels.filter(Boolean).join(', ') || '--'}`,
+        singleLabel ? `${scopeJqlToProject(projectKey, `labels = ${encodeJqlValue(singleLabel)}`)}` : ''
+      ) : null,
+      ...customFieldChips[3]
+    ].filter(Boolean);
+
+    const copyTicketMeta = ticket => ({
+      copyUrl: ticket.url,
+      copyTicket: ticket.key,
+      copyTitle: ticket.summary
+    });
+
+    const visibleCommentsTotal = displayFields.comments ? commentsTotal : 0;
+    const visibleAttachments = displayFields.attachments ? previewAttachments : [];
+    const quickActionData = buildQuickActionViewData(actionsOpen, actionLoadingKey, quickActions);
+    const displayData = {
+      urlTitle: `[${key}] ${issueData.fields.summary}`,
+      ticketKey: key,
+      ticketTitle: issueData.fields.summary,
+      url: INSTANCE_URL + 'browse/' + key,
+      ...copyTicketMeta({
+        key,
+        summary: issueData.fields.summary,
+        url: INSTANCE_URL + 'browse/' + key
+      }),
+      prs: [],
+      description: displayFields.description ? normalizedDescription : '',
+      hasBodyContent: true,
+      emptyBodyText: (!normalizedDescription && visibleAttachments.length === 0 && visibleCommentsTotal === 0)
+        ? 'No description, attachments or comments.'
+        : '',
+      attachments,
+      previewAttachments: visibleAttachments,
+      commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
+      issuetype: issueData.fields.issuetype,
+      status: issueData.fields.status,
+      priority: issueData.fields.priority,
+      issueTypeText: displayFields.issueType ? (issueTypeName || 'No type') : '',
+      statusText: displayFields.status ? (statusName || 'No status') : '',
+      sprintText: displayFields.sprint ? (formatSprintText(sprints) || 'No sprint') : '',
+      fixVersionText: displayFields.fixVersions ? (formatFixVersionText(fixVersions) || 'No fix version') : '',
+      row1Chips,
+      row2Chips,
+      row3Chips,
+      hasComments: visibleCommentsTotal > 0,
+      commentsTotal: visibleCommentsTotal,
+      attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
+      reporter: displayFields.reporter ? issueData.fields.reporter : null,
+      assignee: displayFields.assignee ? issueData.fields.assignee : null,
+      commentUrl: INSTANCE_URL + 'browse/' + key,
+      hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
+      activityIndicators: [],
+      loaderGifUrl,
+      actionNoticeText: actionError || lastActionSuccess,
+      actionNoticeClass: actionError ? '_JX_action_notice_error' : '_JX_action_notice_success',
+      hasActionNotice: !!(actionError || lastActionSuccess),
+      ...quickActionData
+    };
+    if (issueData.fields.comment?.comments?.[0]?.id) {
+      displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
+    }
+    if (displayFields.pullRequests && size(pullRequests)) {
+      const filteredPullRequests = pullRequests.filter(pr => {
+        return pr && pr.url !== location.href;
+      });
+      displayData.prs = filteredPullRequests.map(pr => {
+        return {
+          id: pr.id,
+          url: pr.url,
+          linkUrl: pr.url,
+          title: formatPullRequestTitle(pr),
+          status: pr.status,
+          authorName: formatPullRequestAuthor(pr),
+          branchText: formatPullRequestBranch(pr)
+        };
+      });
+    }
+    displayData.activityIndicators = buildActivityIndicators(
+      displayFields.attachments ? attachments : [],
+      visibleCommentsTotal,
+      displayData.prs.length
+    );
+    return displayData;
+  }
   function getRelativeHref(href) {
     const documentHref = document.location.href.split('#')[0];
     if (href.startsWith(documentHref)) {
@@ -918,6 +1434,100 @@ async function mainAsyncLocal() {
   `);
   $(document.body).append(container);
   $(document.body).append(previewOverlay);
+  async function renderIssuePopup(state) {
+    if (!state?.issueData) {
+      return;
+    }
+    const displayData = await buildPopupDisplayData(state);
+    container.html(Mustache.render(annotationTemplate, displayData));
+    if (!containerPinned) {
+      container.css(computeVisibleContainerPosition(state.pointerX, state.pointerY));
+    }
+  }
+
+  function invalidatePopupCaches() {
+    if (!popupState?.key) {
+      return;
+    }
+    issueCache.delete(popupState.key);
+    if (popupState.issueData?.id) {
+      const issueId = String(popupState.issueData.id);
+      [...pullRequestCache.keys()].forEach(cacheKey => {
+        if (String(cacheKey).includes(issueId)) {
+          pullRequestCache.delete(cacheKey);
+        }
+      });
+    }
+  }
+  async function refreshPopupIssueState(successMessage = '') {
+    if (!popupState?.key) {
+      return;
+    }
+    invalidatePopupCaches();
+    const refreshedIssueData = await getIssueMetaData(popupState.key);
+    await normalizeIssueImages(refreshedIssueData);
+
+    let refreshedPullRequests = [];
+    if (displayFields.pullRequests) {
+      try {
+        const pullRequestResponse = await getPullRequestDataCached(refreshedIssueData.id);
+        refreshedPullRequests = normalizePullRequests(pullRequestResponse);
+      } catch (ex) {
+        refreshedPullRequests = [];
+      }
+    }
+
+    let quickActions = [];
+    try {
+      quickActions = await resolveQuickActions(refreshedIssueData);
+    } catch (ex) {
+      quickActions = [];
+    }
+
+    popupState = {
+      ...popupState,
+      issueData: refreshedIssueData,
+      pullRequests: refreshedPullRequests,
+      quickActions,
+      actionLoadingKey: '',
+      actionError: '',
+      lastActionSuccess: successMessage,
+      actionsOpen: false
+    };
+    await renderIssuePopup(popupState);
+  }
+
+  async function handleQuickAction(actionKey) {
+    if (!popupState?.issueData || popupState.actionLoadingKey) {
+      return;
+    }
+    const action = (popupState.quickActions || []).find(candidate => candidate.key === actionKey);
+    if (!action) {
+      return;
+    }
+
+    popupState = {
+      ...popupState,
+      actionsOpen: false,
+      actionLoadingKey: action.key,
+      actionError: '',
+      lastActionSuccess: ''
+    };
+    await renderIssuePopup(popupState);
+
+    try {
+      const successMessage = await executeQuickAction(action, popupState.issueData);
+      await refreshPopupIssueState(successMessage);
+    } catch (error) {
+      popupState = {
+        ...popupState,
+        actionLoadingKey: '',
+        actionError: buildQuickActionError(error),
+        lastActionSuccess: ''
+      };
+      await renderIssuePopup(popupState);
+    }
+  }
   new draggable({
     handle: '._JX_title, ._JX_status',
     cancel: 'a, button, input, textarea, img, ._JX_description, ._JX_comments, ._JX_comment_body, ._JX_description_text, ._JX_related_pr'
@@ -989,6 +1599,39 @@ async function mainAsyncLocal() {
     copyPrettyLink(e.currentTarget).catch(() => snackBar('There was an error!'));
   });
 
+  $(document.body).on('click', '._JX_actions_toggle', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!popupState) {
+      return;
+    }
+    popupState = {
+      ...popupState,
+      actionsOpen: !popupState.actionsOpen
+    };
+    renderIssuePopup(popupState).catch(() => {});
+  });
+
+  $(document.body).on('click', '._JX_action_item', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const actionKey = e.currentTarget.getAttribute('data-action-key');
+    handleQuickAction(actionKey).catch(() => {});
+  });
+
+  $(document.body).on('click', function (e) {
+    if (!popupState?.actionsOpen) {
+      return;
+    }
+    if ($(e.target).closest('._JX_actions').length) {
+      return;
+    }
+    popupState = {
+      ...popupState,
+      actionsOpen: false
+    };
+    renderIssuePopup(popupState).catch(() => {});
+  });
   function closePreviewOverlay() {
     previewOverlay.removeClass('is-open');
     previewOverlay.find('img').attr('src', '');
@@ -1028,6 +1671,7 @@ async function mainAsyncLocal() {
 
   function hideContainer() {
     lastHoveredKey = '';
+    popupState = null;
     containerPinned = false;
     container.css({
       left: -5000,
@@ -1100,6 +1744,13 @@ async function mainAsyncLocal() {
         clearTimeout(hideTimeOut);
         const key = keys[0].replace(' ', '-');
         if (lastHoveredKey === key && container.html()) {
+          if (popupState) {
+            popupState = {
+              ...popupState,
+              pointerX: e.pageX,
+              pointerY: e.pageY
+            };
+          }
           if (!containerPinned) {
             container.css(computeVisibleContainerPosition(e.pageX, e.pageY));
           }
@@ -1128,152 +1779,26 @@ async function mainAsyncLocal() {
           if (cancelToken.cancel) {
             return;
           }
-          const normalizedDescription = await normalizeRichHtml(issueData.renderedFields.description, {
-            imageMaxHeight: 180
-          });
-          const commentsForDisplay = await buildCommentsForDisplay(issueData);
-          const fixVersions = issueData.fields.fixVersions || [];
-          const affectsVersions = issueData.fields.versions || [];
-          const sprints = readSprintsFromIssue(issueData);
-          const commentsTotal = commentsForDisplay.length;
-          const attachments = issueData.fields.attachment || [];
-          const previewAttachments = buildPreviewAttachments(attachments);
-          const labels = issueData.fields.labels || [];
-          const customFieldChips = buildCustomFieldChips(issueData, customFields);
-          const epicOrParent = await readEpicOrParent(issueData);
-          const issueTypeName = issueData.fields.issuetype?.name;
-          const statusName = issueData.fields.status?.name;
-          const priorityName = issueData.fields.priority?.name;
-          const projectKey = key.split('-')[0];
+          let quickActions = [];
+          try {
+            quickActions = await resolveQuickActions(issueData);
+          } catch (ex) {
+            quickActions = [];
+          }
 
-          const row1Chips = [
-            displayFields.issueType ? buildFilterChip(
-              issueTypeName || 'No type',
-              issueTypeName ? `${scopeJqlToProject(projectKey, `issuetype = ${encodeJqlValue(issueTypeName)}`)}` : '',
-              {iconUrl: issueData.fields.issuetype?.iconUrl || ''}
-            ) : null,
-            displayFields.status ? buildFilterChip(
-              statusName || 'No status',
-              statusName ? `${scopeJqlToProject(projectKey, `status = ${encodeJqlValue(statusName)}`)}` : '',
-              {iconUrl: issueData.fields.status?.iconUrl || ''}
-            ) : null,
-            displayFields.priority ? buildFilterChip(
-              priorityName || 'No priority',
-              priorityName ? `${scopeJqlToProject(projectKey, `priority = ${encodeJqlValue(priorityName)}`)}` : '',
-              {iconUrl: issueData.fields.priority?.iconUrl || ''}
-            ) : null,
-            displayFields.epicParent ? {
-              text: epicOrParent
-                ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
-                : 'Parent: --',
-              linkUrl: epicOrParent?.url || ''
-            } : null,
-            ...customFieldChips[1]
-          ].filter(Boolean);
-
-          const singleAffectsVersion = affectsVersions.length === 1 ? affectsVersions[0]?.name : '';
-          const singleFixVersion = fixVersions.length === 1 ? fixVersions[0]?.name : '';
-          const row2Chips = [
-            displayFields.sprint ? buildFilterChip(
-              `Sprint: ${formatSprintText(sprints) || '--'}`,
-              ''
-            ) : null,
-            displayFields.affects ? buildFilterChip(
-              `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`,
-              singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
-            ) : null,
-            displayFields.fixVersions ? buildFilterChip(
-              `Fix version: ${formatFixVersionText(fixVersions) || '--'}`,
-              singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
-            ) : null,
-            ...customFieldChips[2]
-          ].filter(Boolean);
-
-          const singleLabel = labels.length === 1 ? labels[0] : '';
-          const row3Chips = [
-            displayFields.labels ? buildFilterChip(
-              `Labels: ${labels.filter(Boolean).join(', ') || '--'}`,
-              singleLabel ? `${scopeJqlToProject(projectKey, `labels = ${encodeJqlValue(singleLabel)}`)}` : ''
-            ) : null,
-            ...customFieldChips[3]
-          ].filter(Boolean);
-
-          const copyTicketMeta = (ticket) => ({
-            copyUrl: ticket.url,
-            copyTicket: ticket.key,
-            copyTitle: ticket.summary
-          });
-
-          const visibleCommentsTotal = displayFields.comments ? commentsTotal : 0;
-          const visibleAttachments = displayFields.attachments ? previewAttachments : [];
-          const displayData = {
-            urlTitle: `[${key}] ${issueData.fields.summary}`,
-            ticketKey: key,
-            ticketTitle: issueData.fields.summary,
-            url: INSTANCE_URL + 'browse/' + key,
-            ...copyTicketMeta({
-              key,
-              summary: issueData.fields.summary,
-              url: INSTANCE_URL + 'browse/' + key
-            }),
-            prs: [],
-            description: displayFields.description ? normalizedDescription : '',
-            hasBodyContent: true,
-            emptyBodyText: (!normalizedDescription && visibleAttachments.length === 0 && visibleCommentsTotal === 0)
-              ? 'No description, attachments or comments.'
-              : '',
-            attachments,
-            previewAttachments: visibleAttachments,
-            commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
-            issuetype: issueData.fields.issuetype,
-            status: issueData.fields.status,
-            priority: issueData.fields.priority,
-            issueTypeText: displayFields.issueType ? (issueTypeName || 'No type') : '',
-            statusText: displayFields.status ? (statusName || 'No status') : '',
-            sprintText: displayFields.sprint ? (formatSprintText(sprints) || 'No sprint') : '',
-            fixVersionText: displayFields.fixVersions ? (formatFixVersionText(fixVersions) || 'No fix version') : '',
-            row1Chips,
-            row2Chips,
-            row3Chips,
-            hasComments: visibleCommentsTotal > 0,
-            commentsTotal: visibleCommentsTotal,
-            attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
-            reporter: displayFields.reporter ? issueData.fields.reporter : null,
-            assignee: displayFields.assignee ? issueData.fields.assignee : null,
-            commentUrl: INSTANCE_URL + 'browse/' + key,
-            hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
-            activityIndicators: [],
-            loaderGifUrl,
+          popupState = {
+            key,
+            issueData,
+            pullRequests,
+            pointerX,
+            pointerY,
+            quickActions,
+            actionsOpen: false,
+            actionLoadingKey: '',
+            actionError: '',
+            lastActionSuccess: ''
           };
-          if (issueData.fields.comment?.comments?.[0]?.id) {
-            displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
-          }
-          if (displayFields.pullRequests && size(pullRequests)) {
-            const filteredPullRequests = pullRequests.filter(function (pr) {
-              return pr && pr.url !== location.href;
-            });
-            displayData.prs = filteredPullRequests.map(function (pr) {
-              return {
-                id: pr.id,
-                url: pr.url,
-                linkUrl: pr.url,
-                title: formatPullRequestTitle(pr),
-                status: pr.status,
-                authorName: formatPullRequestAuthor(pr),
-                branchText: formatPullRequestBranch(pr)
-              };
-            });
-          }
-          displayData.activityIndicators = buildActivityIndicators(
-            displayFields.attachments ? attachments : [],
-            visibleCommentsTotal,
-            displayData.prs.length
-          );
-          // TODO: fix scrolling in google docs
-          container.html(Mustache.render(annotationTemplate, displayData));
-          if (!containerPinned) {
-            container.css(computeVisibleContainerPosition(pointerX, pointerY));
-          }
+          await renderIssuePopup(popupState);
         })(cancelToken).catch((error) => {
           notifyJiraConnectionFailure(INSTANCE_URL, error);
           lastHoveredKey = '';
@@ -1291,6 +1816,9 @@ if (!window.__JX__script_injected__) {
 }
 
 window.__JX__script_injected__ = true;
+
+
+
 
 
 

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -183,7 +183,6 @@ async function mainAsyncLocal() {
     maybeNormalizeAvatar(issueData.fields.assignee);
     maybeNormalizeIcon(issueData.fields.issuetype);
     maybeNormalizeIcon(issueData.fields.status);
-    maybeNormalizeIcon(issueData.fields.priority);
 
     (issueData.fields.attachment || []).forEach(attachment => {
       attachment.content = toAbsoluteJiraUrl(attachment.content);
@@ -198,6 +197,35 @@ async function mainAsyncLocal() {
     });
 
     await Promise.all(imageLoads);
+  }
+
+  async function normalizeDescriptionHtml(descriptionHtml) {
+    if (!descriptionHtml) {
+      return descriptionHtml;
+    }
+    const temp = document.createElement('div');
+    temp.innerHTML = descriptionHtml;
+
+    const imageNodes = Array.from(temp.querySelectorAll('img[src]'));
+    await Promise.all(imageNodes.map(async img => {
+      const src = img.getAttribute('src');
+      const absoluteSrc = toAbsoluteJiraUrl(src);
+      const displaySrc = await getDisplayImageUrl(absoluteSrc);
+      if (displaySrc) {
+        img.setAttribute('src', displaySrc);
+      }
+    }));
+
+    const anchorNodes = Array.from(temp.querySelectorAll('a[href]'));
+    anchorNodes.forEach(anchor => {
+      const href = anchor.getAttribute('href');
+      const absoluteHref = toAbsoluteJiraUrl(href);
+      if (absoluteHref) {
+        anchor.setAttribute('href', absoluteHref);
+      }
+    });
+
+    return temp.innerHTML;
   }
 
   /***
@@ -228,7 +256,6 @@ async function mainAsyncLocal() {
       'comment',
       'issuetype',
       'status',
-      'priority',
       'fixVersions',
       ...sprintFieldIds
     ];
@@ -277,12 +304,104 @@ async function mainAsyncLocal() {
     return sprints;
   }
 
+  function formatFixVersionText(fixVersions) {
+    return (fixVersions || [])
+      .map(version => version.name)
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  function formatSprintText(sprints) {
+    return (sprints || [])
+      .map(sprint => sprint.state ? `${sprint.name} (${sprint.state})` : sprint.name)
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  function buildAttachmentChips(attachments) {
+    const totals = {
+      image: 0,
+      pdf: 0,
+      doc: 0,
+      other: 0
+    };
+
+    (attachments || []).forEach(attachment => {
+      const mimeType = (attachment.mimeType || '').toLowerCase();
+      if (mimeType.startsWith('image/')) {
+        totals.image += 1;
+      } else if (mimeType === 'application/pdf') {
+        totals.pdf += 1;
+      } else if (
+        mimeType.includes('word') ||
+        mimeType.includes('excel') ||
+        mimeType.includes('powerpoint') ||
+        mimeType.includes('officedocument') ||
+        mimeType.includes('msword') ||
+        mimeType.includes('opendocument') ||
+        mimeType.includes('rtf') ||
+        mimeType.startsWith('text/')
+      ) {
+        totals.doc += 1;
+      } else {
+        totals.other += 1;
+      }
+    });
+
+    const chips = [];
+    if (totals.image) chips.push({icon: '🖼️', count: totals.image});
+    if (totals.pdf) chips.push({icon: '📕', count: totals.pdf});
+    if (totals.doc) chips.push({icon: '📝', count: totals.doc});
+    if (totals.other) chips.push({icon: '📎', count: totals.other});
+    return chips;
+  }
+
+  function buildPreviewAttachments(attachments) {
+    return (attachments || []).filter(attachment => {
+      return !!attachment &&
+        typeof attachment.mimeType === 'string' &&
+        attachment.mimeType.toLowerCase().startsWith('image') &&
+        !!attachment.thumbnail;
+    });
+  }
+
   function getRelativeHref(href) {
     const documentHref = document.location.href.split('#')[0];
     if (href.startsWith(documentHref)) {
       return href.slice(documentHref.length);
     }
     return href;
+  }
+
+  function computeVisibleContainerPosition(pointerX, pointerY) {
+    const margin = 8;
+    const preferredLeft = pointerX + 20;
+    const preferredTop = pointerY + 25;
+    const width = container.outerWidth();
+    const height = container.outerHeight();
+    const viewportLeft = window.scrollX + margin;
+    const viewportTop = window.scrollY + margin;
+    const viewportRight = window.scrollX + window.innerWidth - margin;
+    const viewportBottom = window.scrollY + window.innerHeight - margin;
+
+    let left = preferredLeft;
+    let top = preferredTop;
+
+    if (left + width > viewportRight) {
+      left = pointerX - width - 15;
+    }
+    if (left < viewportLeft) {
+      left = viewportLeft;
+    }
+
+    if (top + height > viewportBottom) {
+      top = pointerY - height - 15;
+    }
+    if (top < viewportTop) {
+      top = viewportTop;
+    }
+
+    return {left, top};
   }
 
   const container = $('<div class="_JX_container">');
@@ -397,6 +516,8 @@ async function mainAsyncLocal() {
       if (size(keys)) {
         clearTimeout(hideTimeOut);
         const key = keys[0].replace(" ", "-");
+        const pointerX = e.pageX;
+        const pointerY = e.pageY;
         (async function (cancelToken) {
           const issueData = await getIssueMetaData(key);
           await normalizeIssueImages(issueData);
@@ -417,25 +538,39 @@ async function mainAsyncLocal() {
               comment => comment.author.displayName + ':\n' + comment.body
             ).join('\n\n');
           }
+          const normalizedDescription = await normalizeDescriptionHtml(issueData.renderedFields.description);
+          const fixVersions = issueData.fields.fixVersions || [];
+          const sprints = readSprintsFromIssue(issueData);
+          const commentsTotal = issueData.fields.comment?.total || 0;
+          const attachments = issueData.fields.attachment || [];
+          const previewAttachments = buildPreviewAttachments(attachments);
           const displayData = {
             urlTitle: key + ' ' + issueData.fields.summary,
             url: INSTANCE_URL + 'browse/' + key,
             prs: [],
-            description: issueData.renderedFields.description,
-            attachments: issueData.fields.attachment,
+            description: normalizedDescription,
+            hasBodyContent: !!normalizedDescription || previewAttachments.length > 0,
+            attachments,
+            previewAttachments,
             issuetype: issueData.fields.issuetype,
             status: issueData.fields.status,
-            priority: issueData.fields.priority,
-            fixVersions: issueData.fields.fixVersions || [],
-            sprints: readSprintsFromIssue(issueData),
+            issueTypeText: issueData.fields.issuetype?.name || 'No type',
+            statusText: issueData.fields.status?.name || 'No status',
+            hasComments: commentsTotal > 0,
+            commentsTotal,
+            fixVersionText: formatFixVersionText(fixVersions) || 'No fix version',
+            sprintText: formatSprintText(sprints) || 'No sprint',
+            attachmentChips: buildAttachmentChips(attachments),
             comment: issueData.fields.comment,
             reporter: issueData.fields.reporter,
             assignee: issueData.fields.assignee,
             comments,
-            commentUrl: '',
+            commentUrl: INSTANCE_URL + 'browse/' + key,
             loaderGifUrl,
           };
-          displayData.commentUrl = `${displayData.url}#comment-${displayData.comment?.comments?.[0]?.id || ''}`;
+          if (displayData.comment?.comments?.[0]?.id) {
+            displayData.commentUrl = `${displayData.url}#comment-${displayData.comment.comments[0].id}`;
+          }
           if (size(pullRequests)) {
             displayData.prs = pullRequests.filter(function (pr) {
               return pr.url !== location.href;
@@ -450,13 +585,9 @@ async function mainAsyncLocal() {
             });
           }
           // TODO: fix scrolling in google docs
-          const css = {
-            left: e.pageX + 20,
-            top: e.pageY + 25
-          };
           container.html(Mustache.render(annotationTemplate, displayData));
           if (!containerPinned) {
-            container.css(css);
+            container.css(computeVisibleContainerPosition(pointerX, pointerY));
           }
         })(cancelToken);
       } else if (!containerPinned) {

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -14,6 +14,31 @@ const getInstanceUrl = async () => (await storageGet({
 })).instanceUrl;
 
 const getConfig = async () => (await storageGet(config));
+let sprintFieldIdsPromise;
+
+async function getSprintFieldIds(instanceUrl) {
+  if (sprintFieldIdsPromise) {
+    return sprintFieldIdsPromise;
+  }
+  sprintFieldIdsPromise = get(instanceUrl + 'rest/api/2/field')
+    .then(fields => {
+      if (!Array.isArray(fields)) {
+        return [];
+      }
+      return fields
+        .filter(field => {
+          const name = (field.name || '').toLowerCase();
+          const schemaCustom = ((field.schema && field.schema.custom) || '').toLowerCase();
+          const schemaType = ((field.schema && field.schema.type) || '').toLowerCase();
+          return name.includes('sprint') ||
+            schemaCustom.includes('gh-sprint') ||
+            schemaType === 'sprint';
+        })
+        .map(field => field.id);
+    })
+    .catch(() => []);
+  return sprintFieldIdsPromise;
+}
 
 /**
  * Returns a function that will return an array of jira tickets for any given string
@@ -71,6 +96,17 @@ async function get(url) {
   }
 }
 
+async function getImageDataUrl(url) {
+  const response = await sendMessage({action: 'getImageDataUrl', url});
+  if (response.result) {
+    return response.result;
+  } else if (response.error) {
+    const err = new Error(response.error);
+    err.inner = response.error;
+    throw err;
+  }
+}
+
 async function mainAsyncLocal() {
   const $ = require('jquery');
   const draggable = require('jquery-ui/ui/widgets/draggable');
@@ -89,6 +125,80 @@ async function mainAsyncLocal() {
   }));
   const annotationTemplate = await get(chrome.runtime.getURL('resources/annotation.html'));
   const loaderGifUrl = chrome.runtime.getURL('resources/ajax-loader.gif');
+  const imageProxyCache = {};
+
+  function toAbsoluteJiraUrl(url) {
+    if (!url) {
+      return url;
+    }
+    try {
+      return new URL(url, INSTANCE_URL).toString();
+    } catch (ex) {
+      return url;
+    }
+  }
+
+  async function getDisplayImageUrl(url) {
+    const absoluteUrl = toAbsoluteJiraUrl(url);
+    if (!absoluteUrl || !absoluteUrl.startsWith(INSTANCE_URL)) {
+      return absoluteUrl;
+    }
+    if (imageProxyCache[absoluteUrl]) {
+      return imageProxyCache[absoluteUrl];
+    }
+    try {
+      const dataUrl = await getImageDataUrl(absoluteUrl);
+      imageProxyCache[absoluteUrl] = dataUrl;
+      return dataUrl;
+    } catch (ex) {
+      return absoluteUrl;
+    }
+  }
+
+  async function normalizeIssueImages(issueData) {
+    const imageLoads = [];
+
+    const maybeNormalizeAvatar = field => {
+      const avatarUrl = field && field.avatarUrls && field.avatarUrls['48x48'];
+      if (avatarUrl) {
+        imageLoads.push(
+          getDisplayImageUrl(avatarUrl).then(src => {
+            field.avatarUrls['48x48'] = src;
+          })
+        );
+      }
+    };
+
+    const maybeNormalizeIcon = field => {
+      if (field && field.iconUrl) {
+        imageLoads.push(
+          getDisplayImageUrl(field.iconUrl).then(src => {
+            field.iconUrl = src;
+          })
+        );
+      }
+    };
+
+    maybeNormalizeAvatar(issueData.fields.reporter);
+    maybeNormalizeAvatar(issueData.fields.assignee);
+    maybeNormalizeIcon(issueData.fields.issuetype);
+    maybeNormalizeIcon(issueData.fields.status);
+    maybeNormalizeIcon(issueData.fields.priority);
+
+    (issueData.fields.attachment || []).forEach(attachment => {
+      attachment.content = toAbsoluteJiraUrl(attachment.content);
+      attachment.thumbnail = toAbsoluteJiraUrl(attachment.thumbnail) || attachment.content;
+      if (attachment.thumbnail) {
+        imageLoads.push(
+          getDisplayImageUrl(attachment.thumbnail).then(src => {
+            attachment.thumbnail = src;
+          })
+        );
+      }
+    });
+
+    await Promise.all(imageLoads);
+  }
 
   /***
    * Retrieve only the text that is directly owned by the node
@@ -106,8 +216,65 @@ async function mainAsyncLocal() {
     return get(INSTANCE_URL + 'rest/dev-status/1.0/issue/details?issueId=' + issueId + '&applicationType=' + applicationType + '&dataType=pullrequest');
   }
 
-  function getIssueMetaData(issueKey) {
-    return get(INSTANCE_URL + 'rest/api/2/issue/' + issueKey + '?fields=description,id,reporter,assignee,summary,attachment,comment,issuetype,status,priority&expand=renderedFields');
+  async function getIssueMetaData(issueKey) {
+    const sprintFieldIds = await getSprintFieldIds(INSTANCE_URL);
+    const fields = [
+      'description',
+      'id',
+      'reporter',
+      'assignee',
+      'summary',
+      'attachment',
+      'comment',
+      'issuetype',
+      'status',
+      'priority',
+      'fixVersions',
+      ...sprintFieldIds
+    ];
+    return get(INSTANCE_URL + 'rest/api/2/issue/' + issueKey + '?fields=' + fields.join(',') + '&expand=renderedFields,names');
+  }
+
+  function readSprintsFromIssue(issueData) {
+    const names = issueData.names || {};
+    const fields = issueData.fields || {};
+    const sprintFieldIds = Object.keys(names).filter(fieldId => {
+      return typeof names[fieldId] === 'string' && names[fieldId].toLowerCase().includes('sprint');
+    });
+    const sprintValues = sprintFieldIds
+      .map(fieldId => fields[fieldId])
+      .filter(value => value !== undefined && value !== null);
+    const seen = {};
+    const sprints = [];
+
+    const pushSprint = (name, state) => {
+      if (!name) {
+        return;
+      }
+      const key = `${name}__${state || ''}`;
+      if (seen[key]) {
+        return;
+      }
+      seen[key] = true;
+      sprints.push({name, state: state || ''});
+    };
+
+    sprintValues.forEach(value => {
+      const entries = Array.isArray(value) ? value : [value];
+      entries.forEach(entry => {
+        if (!entry) {
+          return;
+        }
+        if (typeof entry === 'string') {
+          const nameMatch = entry.match(/name=([^,\]]+)/i);
+          const stateMatch = entry.match(/state=([^,\]]+)/i);
+          pushSprint(nameMatch && nameMatch[1] ? nameMatch[1] : entry, stateMatch && stateMatch[1]);
+          return;
+        }
+        pushSprint(entry.name || entry.goal || entry.id, entry.state);
+      });
+    });
+    return sprints;
   }
 
   function getRelativeHref(href) {
@@ -232,6 +399,7 @@ async function mainAsyncLocal() {
         const key = keys[0].replace(" ", "-");
         (async function (cancelToken) {
           const issueData = await getIssueMetaData(key);
+          await normalizeIssueImages(issueData);
           let pullRequests = [];
           try {
             const githubPrs = await getPullRequestData(issueData.id, 'github');
@@ -258,6 +426,8 @@ async function mainAsyncLocal() {
             issuetype: issueData.fields.issuetype,
             status: issueData.fields.status,
             priority: issueData.fields.priority,
+            fixVersions: issueData.fields.fixVersions || [],
+            sprints: readSprintsFromIssue(issueData),
             comment: issueData.fields.comment,
             reporter: issueData.fields.reporter,
             assignee: issueData.fields.assignee,

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -2,7 +2,7 @@
 import size from 'lodash/size';
 import debounce from 'lodash/debounce';
 import Mustache from 'mustache';
-import {centerPopup, waitForDocument} from 'src/utils';
+import {waitForDocument} from 'src/utils';
 import {sendMessage, storageGet, storageSet} from 'src/chrome';
 import {snackBar} from 'src/snack';
 import config from 'options/config.js';
@@ -110,7 +110,6 @@ async function getImageDataUrl(url) {
 async function mainAsyncLocal() {
   const $ = require('jquery');
   const draggable = require('jquery-ui/ui/widgets/draggable');
-  const clipboard = require('clipboard/dist/clipboard');
 
   const config = await getConfig();
   const INSTANCE_URL = config.instanceUrl;
@@ -199,20 +198,70 @@ async function mainAsyncLocal() {
     await Promise.all(imageLoads);
   }
 
-  async function normalizeDescriptionHtml(descriptionHtml) {
-    if (!descriptionHtml) {
-      return descriptionHtml;
+  function escapeHtml(input) {
+    const node = document.createElement('div');
+    node.textContent = input || '';
+    return node.innerHTML;
+  }
+
+  function textToLinkedHtml(input) {
+    const escaped = escapeHtml(input || '');
+    const withLinks = escaped.replace(
+      /(https?:\/\/[^\s<]+)/g,
+      '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
+    );
+    return withLinks.replace(/\n/g, '<br/>');
+  }
+
+  function formatRelativeDate(created) {
+    const createdAt = new Date(created);
+    if (Number.isNaN(createdAt.getTime())) {
+      return '--';
     }
+    const diffMs = Date.now() - createdAt.getTime();
+    const twoDaysMs = 2 * 24 * 60 * 60 * 1000;
+    if (diffMs >= 0 && diffMs < twoDaysMs) {
+      const minuteMs = 60 * 1000;
+      const hourMs = 60 * minuteMs;
+      const dayMs = 24 * hourMs;
+      if (diffMs < hourMs) {
+        const minutes = Math.max(1, Math.floor(diffMs / minuteMs));
+        return `${minutes}m ago`;
+      }
+      if (diffMs < dayMs) {
+        const hours = Math.max(1, Math.floor(diffMs / hourMs));
+        return `${hours}h ago`;
+      }
+      const days = Math.max(1, Math.floor(diffMs / dayMs));
+      return `${days}d ago`;
+    }
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(createdAt);
+  }
+
+  async function normalizeRichHtml(html, options = {}) {
+    if (!html) {
+      return '';
+    }
+    const {imageMaxHeight} = options;
     const temp = document.createElement('div');
-    temp.innerHTML = descriptionHtml;
+    temp.innerHTML = html;
 
     const imageNodes = Array.from(temp.querySelectorAll('img[src]'));
     await Promise.all(imageNodes.map(async img => {
       const src = img.getAttribute('src');
       const absoluteSrc = toAbsoluteJiraUrl(src);
       const displaySrc = await getDisplayImageUrl(absoluteSrc);
-      if (displaySrc) {
-        img.setAttribute('src', displaySrc);
+      const resolvedSrc = displaySrc || absoluteSrc || src;
+      if (resolvedSrc) {
+        img.setAttribute('src', resolvedSrc);
+        img.setAttribute('data-jx-preview-src', resolvedSrc);
+        img.classList.add('_JX_previewable');
+      }
+      if (imageMaxHeight) {
+        img.style.maxHeight = `${imageMaxHeight}px`;
       }
     }));
 
@@ -223,9 +272,36 @@ async function mainAsyncLocal() {
       if (absoluteHref) {
         anchor.setAttribute('href', absoluteHref);
       }
+      anchor.setAttribute('target', '_blank');
+      anchor.setAttribute('rel', 'noopener noreferrer');
     });
 
     return temp.innerHTML;
+  }
+
+  async function buildCommentsForDisplay(issueData) {
+    const comments = [...(issueData.fields.comment?.comments || [])].sort((a, b) => {
+      return new Date(a.created).getTime() - new Date(b.created).getTime();
+    });
+    const renderedById = {};
+    ((issueData.renderedFields?.comment?.comments) || []).forEach(comment => {
+      if (comment && comment.id) {
+        renderedById[comment.id] = comment.body;
+      }
+    });
+
+    const result = [];
+    for (const comment of comments) {
+      const rendered = renderedById[comment.id];
+      const baseHtml = rendered || textToLinkedHtml(comment.body || '');
+      const bodyHtml = await normalizeRichHtml(baseHtml, {imageMaxHeight: 100});
+      result.push({
+        author: comment.author?.displayName || 'Unknown',
+        created: formatRelativeDate(comment.created),
+        bodyHtml
+      });
+    }
+    return result;
   }
 
   /***
@@ -405,48 +481,119 @@ async function mainAsyncLocal() {
   }
 
   const container = $('<div class="_JX_container">');
+  const previewOverlay = $(`
+    <div class="_JX_preview_overlay">
+      <img class="_JX_preview_image" />
+    </div>
+  `);
   $(document.body).append(container);
+  $(document.body).append(previewOverlay);
   new draggable({
     handle: '._JX_title, ._JX_status',
   }, container);
   
-  new clipboard('._JX_title_copy', {
-    text: function (trigger) {
-      return document.getElementById('_JX_title_link').text;
-    }
-  })
-  .on('success', e => { snackBar('Copied!');})
-  .on('error', e => { snackBar('There was an error!');});
+  function buildPrettyLinkPayload() {
+    const titleLink = document.getElementById('_JX_title_link');
+    const url = titleLink?.getAttribute('href') || '';
+    const ticket = titleLink?.getAttribute('data-ticket') || '';
+    const title = titleLink?.getAttribute('data-title') || '';
+    const label = `[${ticket}] ${title}`.trim();
+    const link = document.createElement('a');
+    link.href = url;
+    link.textContent = label;
+    return {
+      html: link.outerHTML,
+      text: url
+    };
+  }
 
-  $(document.body).on('click', '._JX_thumb', function previewThumb(e) {
-    const currentTarget = $(e.currentTarget);
-    if (currentTarget.data('_JX_loading')) {
+  function copyPrettyLinkFallback(html, text) {
+    return new Promise((resolve, reject) => {
+      const onCopy = event => {
+        event.preventDefault();
+        event.clipboardData.setData('text/html', html);
+        event.clipboardData.setData('text/plain', text);
+      };
+      document.addEventListener('copy', onCopy, {once: true});
+      const success = document.execCommand('copy');
+      if (!success) {
+        reject(new Error('Copy command failed'));
+        return;
+      }
+      resolve();
+    });
+  }
+
+  async function copyPrettyLink() {
+    const {html, text} = buildPrettyLinkPayload();
+    try {
+      if (navigator.clipboard && window.ClipboardItem && navigator.clipboard.write) {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'text/html': new Blob([html], {type: 'text/html'}),
+            'text/plain': new Blob([text], {type: 'text/plain'})
+          })
+        ]);
+        snackBar('Copied!');
+        return;
+      }
+    } catch (ex) {
+      // fall through to fallback copy path
+    }
+
+    try {
+      await copyPrettyLinkFallback(html, text);
+      snackBar('Copied!');
+    } catch (ex) {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(text);
+        snackBar('Copied as text');
+      } else {
+        snackBar('There was an error!');
+      }
+    }
+  }
+
+  $(document.body).on('click', '._JX_title_copy', function (e) {
+    e.preventDefault();
+    copyPrettyLink().catch(() => snackBar('There was an error!'));
+  });
+
+  function closePreviewOverlay() {
+    previewOverlay.removeClass('is-open');
+    previewOverlay.find('img').attr('src', '');
+  }
+
+  async function openPreviewOverlay(imageUrl) {
+    if (!imageUrl) {
       return;
     }
-    if (!currentTarget.data('mimeType').startsWith('image')) {
+    const displaySrc = await getDisplayImageUrl(imageUrl);
+    previewOverlay.find('img').attr('src', displaySrc || imageUrl);
+    previewOverlay.addClass('is-open');
+  }
+
+  previewOverlay.on('click', function (e) {
+    if (e.target === previewOverlay[0]) {
+      closePreviewOverlay();
+    }
+  });
+
+  $(document.body).on('click', '._JX_previewable', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const source = e.currentTarget.getAttribute('data-jx-preview-src') || e.currentTarget.getAttribute('src');
+    openPreviewOverlay(source).catch(() => {});
+  });
+
+  $(document.body).on('click', '._JX_thumb', function (e) {
+    if ($(e.target).closest('img._JX_previewable').length) {
       return;
     }
     e.preventDefault();
-    currentTarget.data('loading', true);
-    const opacityElements = currentTarget.children(':not(._JX_file_loader)');
-    opacityElements.css('opacity', 0.2);
-    currentTarget.find('._JX_file_loader').show();
-    const localCancelToken = cancelToken;
-    const img = new Image();
-    img.onload = function () {
-      currentTarget.data('_JX_loading', false);
-      currentTarget.find('._JX_file_loader').hide();
-      const name = currentTarget.find('._JX_thumb_filename').text();
-      opacityElements.css('opacity', 1);
-      if (localCancelToken.cancel) {
-        return;
-      }
-      centerPopup(chrome.runtime.getURL(`resources/preview.html?url=${currentTarget.data('url')}&title=${name}`), name, {
-        width: this.naturalWidth,
-        height: this.naturalHeight
-      }).focus();
-    };
-    img.src = currentTarget.data('url');
+    e.stopPropagation();
+    const source = e.currentTarget.getAttribute('data-preview-src') || e.currentTarget.getAttribute('data-url');
+    openPreviewOverlay(source).catch(() => {});
   });
 
   function hideContainer() {
@@ -464,6 +611,10 @@ async function mainAsyncLocal() {
     // TODO: escape not captured in google docs
     const ESCAPE_KEY_CODE = 27;
     if (e.keyCode === ESCAPE_KEY_CODE) {
+      if (previewOverlay.hasClass('is-open')) {
+        closePreviewOverlay();
+        return;
+      }
       hideContainer();
       passiveCancel(200);
     }
@@ -532,26 +683,26 @@ async function mainAsyncLocal() {
           if (cancelToken.cancel) {
             return;
           }
-          let comments = '';
-          if (issueData.fields.comment && issueData.fields.comment.total) {
-            comments = issueData.fields.comment.comments.map(
-              comment => comment.author.displayName + ':\n' + comment.body
-            ).join('\n\n');
-          }
-          const normalizedDescription = await normalizeDescriptionHtml(issueData.renderedFields.description);
+          const normalizedDescription = await normalizeRichHtml(issueData.renderedFields.description, {
+            imageMaxHeight: 180
+          });
+          const commentsForDisplay = await buildCommentsForDisplay(issueData);
           const fixVersions = issueData.fields.fixVersions || [];
           const sprints = readSprintsFromIssue(issueData);
-          const commentsTotal = issueData.fields.comment?.total || 0;
+          const commentsTotal = commentsForDisplay.length;
           const attachments = issueData.fields.attachment || [];
           const previewAttachments = buildPreviewAttachments(attachments);
           const displayData = {
-            urlTitle: key + ' ' + issueData.fields.summary,
+            urlTitle: `[${key}] ${issueData.fields.summary}`,
+            ticketKey: key,
+            ticketTitle: issueData.fields.summary,
             url: INSTANCE_URL + 'browse/' + key,
             prs: [],
             description: normalizedDescription,
-            hasBodyContent: !!normalizedDescription || previewAttachments.length > 0,
+            hasBodyContent: !!normalizedDescription || previewAttachments.length > 0 || commentsForDisplay.length > 0,
             attachments,
             previewAttachments,
+            commentsForDisplay,
             issuetype: issueData.fields.issuetype,
             status: issueData.fields.status,
             issueTypeText: issueData.fields.issuetype?.name || 'No type',
@@ -561,15 +712,13 @@ async function mainAsyncLocal() {
             fixVersionText: formatFixVersionText(fixVersions) || 'No fix version',
             sprintText: formatSprintText(sprints) || 'No sprint',
             attachmentChips: buildAttachmentChips(attachments),
-            comment: issueData.fields.comment,
             reporter: issueData.fields.reporter,
             assignee: issueData.fields.assignee,
-            comments,
             commentUrl: INSTANCE_URL + 'browse/' + key,
             loaderGifUrl,
           };
-          if (displayData.comment?.comments?.[0]?.id) {
-            displayData.commentUrl = `${displayData.url}#comment-${displayData.comment.comments[0].id}`;
+          if (issueData.fields.comment?.comments?.[0]?.id) {
+            displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
           }
           if (size(pullRequests)) {
             displayData.prs = pullRequests.filter(function (pr) {

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -673,23 +673,21 @@ async function mainAsyncLocal() {
     }
     if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
       const textValue = String(entry);
-      const looksLikeUrl = /^https?:\/\//i.test(textValue);
       return {
-        text: looksLikeUrl ? (fieldName || textValue) : (fieldName ? `${fieldName}: ${textValue}` : textValue),
-        url: looksLikeUrl ? textValue : ''
+        text: fieldName ? `${fieldName}: ${textValue}` : textValue,
+        linkUrl: ''
       };
     }
     const primaryText = entry.name || entry.value || entry.displayName || entry.id || entry.key;
-    const rawUrl = [entry.self, entry.url, entry.href].find(value => typeof value === 'string' && value.trim());
-    if (!primaryText && !rawUrl) {
+    if (!primaryText) {
       return null;
     }
     const formattedValue = entry.key && (entry.name || entry.value)
       ? `[${entry.key}] ${entry.name || entry.value}`
-      : primaryText ? String(primaryText) : rawUrl;
+      : String(primaryText);
     return {
       text: fieldName ? `${fieldName}: ${formattedValue}` : formattedValue,
-      url: rawUrl ? toAbsoluteJiraUrl(rawUrl) : ''
+      linkUrl: ''
     };
   }
   function buildCustomFieldChips(issueData, customFields) {
@@ -775,6 +773,21 @@ async function mainAsyncLocal() {
 
   function buildJqlUrl(jql) {
     return `${INSTANCE_URL}issues/?jql=${encodeURIComponent(jql)}`;
+  }
+
+  function scopeJqlToProject(projectKey, clause) {
+    if (!projectKey || !clause) {
+      return clause || '';
+    }
+    return `project = ${encodeJqlValue(projectKey)} AND ${clause}`;
+  }
+
+  function buildFilterChip(text, jql, extra = {}) {
+    return {
+      text,
+      linkUrl: jql ? buildJqlUrl(jql) : '',
+      ...extra
+    };
   }
 
   function buildAttachmentChips(attachments) {
@@ -1131,39 +1144,57 @@ async function mainAsyncLocal() {
           const issueTypeName = issueData.fields.issuetype?.name;
           const statusName = issueData.fields.status?.name;
           const priorityName = issueData.fields.priority?.name;
+          const projectKey = key.split('-')[0];
 
           const row1Chips = [
-            displayFields.issueType ? {
-              text: issueTypeName || 'No type',
-              iconUrl: issueData.fields.issuetype?.iconUrl || ''
-            } : null,
-            displayFields.status ? {
-              text: statusName || 'No status',
-              iconUrl: issueData.fields.status?.iconUrl || ''
-            } : null,
-            displayFields.priority ? {
-              text: priorityName || 'No priority',
-              iconUrl: issueData.fields.priority?.iconUrl || ''
-            } : null,
+            displayFields.issueType ? buildFilterChip(
+              issueTypeName || 'No type',
+              issueTypeName ? `${scopeJqlToProject(projectKey, `issuetype = ${encodeJqlValue(issueTypeName)}`)}` : '',
+              {iconUrl: issueData.fields.issuetype?.iconUrl || ''}
+            ) : null,
+            displayFields.status ? buildFilterChip(
+              statusName || 'No status',
+              statusName ? `${scopeJqlToProject(projectKey, `status = ${encodeJqlValue(statusName)}`)}` : '',
+              {iconUrl: issueData.fields.status?.iconUrl || ''}
+            ) : null,
+            displayFields.priority ? buildFilterChip(
+              priorityName || 'No priority',
+              priorityName ? `${scopeJqlToProject(projectKey, `priority = ${encodeJqlValue(priorityName)}`)}` : '',
+              {iconUrl: issueData.fields.priority?.iconUrl || ''}
+            ) : null,
             displayFields.epicParent ? {
               text: epicOrParent
                 ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
-                : 'Parent: --'
+                : 'Parent: --',
+              linkUrl: epicOrParent?.url || ''
             } : null,
             ...customFieldChips[1]
           ].filter(Boolean);
 
+          const singleAffectsVersion = affectsVersions.length === 1 ? affectsVersions[0]?.name : '';
+          const singleFixVersion = fixVersions.length === 1 ? fixVersions[0]?.name : '';
           const row2Chips = [
-            displayFields.sprint ? {text: `Sprint: ${formatSprintText(sprints) || '--'}`} : null,
-            displayFields.affects ? {
-              text: `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`
-            } : null,
-            displayFields.fixVersions ? {text: `Fix version: ${formatFixVersionText(fixVersions) || '--'}`} : null,
+            displayFields.sprint ? buildFilterChip(
+              `Sprint: ${formatSprintText(sprints) || '--'}`,
+              ''
+            ) : null,
+            displayFields.affects ? buildFilterChip(
+              `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`,
+              singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
+            ) : null,
+            displayFields.fixVersions ? buildFilterChip(
+              `Fix version: ${formatFixVersionText(fixVersions) || '--'}`,
+              singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
+            ) : null,
             ...customFieldChips[2]
           ].filter(Boolean);
 
+          const singleLabel = labels.length === 1 ? labels[0] : '';
           const row3Chips = [
-            displayFields.labels ? {text: `Labels: ${labels.filter(Boolean).join(', ') || '--'}`} : null,
+            displayFields.labels ? buildFilterChip(
+              `Labels: ${labels.filter(Boolean).join(', ') || '--'}`,
+              singleLabel ? `${scopeJqlToProject(projectKey, `labels = ${encodeJqlValue(singleLabel)}`)}` : ''
+            ) : null,
             ...customFieldChips[3]
           ].filter(Boolean);
 
@@ -1225,6 +1256,7 @@ async function mainAsyncLocal() {
               return {
                 id: pr.id,
                 url: pr.url,
+                linkUrl: pr.url,
                 title: formatPullRequestTitle(pr),
                 status: pr.status,
                 authorName: formatPullRequestAuthor(pr),

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -69,6 +69,22 @@ function buildJiraKeyMatcher(projectKeys) {
   };
 }
 
+function buildFallbackJiraKeyMatcher() {
+  const jiraTicketRegex = /\b[A-Z][A-Z0-9]{1,14}[- ]\d+\b/g;
+
+  return function (text) {
+    let matches;
+    const result = [];
+    const input = text || '';
+
+    while ((matches = jiraTicketRegex.exec(input)) !== null) {
+      result.push(matches[0]);
+    }
+    jiraTicketRegex.lastIndex = 0;
+    return result;
+  };
+}
+
 chrome.runtime.onMessage.addListener(function (msg) {
   if (msg.action === 'message') {
     snackBar(msg.message);
@@ -76,6 +92,7 @@ chrome.runtime.onMessage.addListener(function (msg) {
 });
 
 let ui_tips_shown_local = [];
+const CONNECTION_ERROR_PATTERN = /(failed to fetch|networkerror|network request failed|load failed|err_|timed?\s*out)/i;
 
 async function showTip(tipName, tipMessage) {
   if (ui_tips_shown_local.indexOf(tipName) !== -1) {
@@ -116,6 +133,27 @@ async function getImageDataUrl(url) {
   }
 }
 
+function isJiraConnectionFailure(error) {
+  const message = String(error?.message || error?.inner || error || '');
+  return CONNECTION_ERROR_PATTERN.test(message);
+}
+
+function notifyJiraConnectionFailure(instanceUrl, error) {
+  if (!isJiraConnectionFailure(error)) {
+    return false;
+  }
+
+  let host = '';
+  try {
+    host = new URL(instanceUrl).hostname;
+  } catch (ex) {
+    host = '';
+  }
+
+  snackBar(`Could not reach Jira${host ? ` at ${host}` : ''}. Check your VPN or network connection.`, 1500);
+  return true;
+}
+
 async function mainAsyncLocal() {
   const $ = require('jquery');
   const draggable = require('jquery-ui/ui/widgets/draggable');
@@ -140,15 +178,21 @@ async function mainAsyncLocal() {
     pullRequests: true,
     ...(config.displayFields || {})
   };
-  const jiraProjects = await get(await getInstanceUrl() + 'rest/api/2/project');
-
-  if (!size(jiraProjects)) {
-    console.log('Couldn\'t find any jira projects...');
-    return;
+  let jiraProjects = [];
+  let getJiraKeys = buildFallbackJiraKeyMatcher();
+  try {
+    jiraProjects = await get(await getInstanceUrl() + 'rest/api/2/project');
+  } catch (ex) {
+    // Keep hover support alive offline; only notify on explicit hover fetch failures.
   }
-  const getJiraKeys = buildJiraKeyMatcher(jiraProjects.map(function (project) {
-    return project.key;
-  }));
+
+  if (size(jiraProjects)) {
+    getJiraKeys = buildJiraKeyMatcher(jiraProjects.map(function (project) {
+      return project.key;
+    }));
+  } else {
+    console.log("Couldn't load Jira projects, using fallback issue-key matcher.");
+  }
   const annotationTemplate = await fetch(chrome.runtime.getURL('resources/annotation.html')).then(response => response.text());
   const loaderGifUrl = chrome.runtime.getURL('resources/ajax-loader.gif');
   const imageProxyCache = {};
@@ -979,9 +1023,10 @@ async function mainAsyncLocal() {
             }),
             prs: [],
             description: displayFields.description ? normalizedDescription : '',
-            hasBodyContent: (displayFields.description && !!normalizedDescription) ||
-              (displayFields.attachments && previewAttachments.length > 0) ||
-              (displayFields.comments && commentsForDisplay.length > 0),
+            hasBodyContent: true,
+            emptyBodyText: (!normalizedDescription && previewAttachments.length === 0 && commentsForDisplay.length === 0)
+              ? 'No description, attachments or comments.'
+              : '',
             attachments,
             previewAttachments: displayFields.attachments ? previewAttachments : [],
             commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
@@ -1039,7 +1084,8 @@ async function mainAsyncLocal() {
           if (!containerPinned) {
             container.css(computeVisibleContainerPosition(pointerX, pointerY));
           }
-        })(cancelToken).catch(() => {
+        })(cancelToken).catch((error) => {
+          notifyJiraConnectionFailure(INSTANCE_URL, error);
           lastHoveredKey = '';
         });
       } else if (!containerPinned) {
@@ -1055,3 +1101,5 @@ if (!window.__JX__script_injected__) {
 }
 
 window.__JX__script_injected__ = true;
+
+

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -1,6 +1,7 @@
 /*global chrome */
 import size from 'lodash/size';
 import debounce from 'lodash/debounce';
+import regexEscape from 'escape-string-regexp';
 import Mustache from 'mustache';
 import {waitForDocument} from 'src/utils';
 import {sendMessage, storageGet, storageSet} from 'src/chrome';
@@ -46,7 +47,15 @@ async function getSprintFieldIds(instanceUrl) {
  * @returns {Function}
  */
 function buildJiraKeyMatcher(projectKeys) {
-  const projectMatches = projectKeys.join('|');
+  const escapedKeys = (projectKeys || [])
+    .filter(Boolean)
+    .map(key => regexEscape(key));
+  if (!escapedKeys.length) {
+    return function () {
+      return [];
+    };
+  }
+  const projectMatches = escapedKeys.join('|');
   const jiraTicketRegex = new RegExp('(?:' + projectMatches + ')[- ]\\d+', 'ig');
 
   return function (text) {
@@ -86,7 +95,7 @@ storageGet({'ui_tips_shown': []}).then(function ({ui_tips_shown}) {
 });
 
 async function get(url) {
-  var response = await sendMessage({action: "get", url: url});
+  const response = await sendMessage({action: 'get', url: url});
   if (response.result) {
     return response.result;
   } else if (response.error) {
@@ -113,6 +122,24 @@ async function mainAsyncLocal() {
 
   const config = await getConfig();
   const INSTANCE_URL = config.instanceUrl;
+  const displayFields = {
+    issueType: true,
+    status: true,
+    priority: true,
+    sprint: true,
+    fixVersions: true,
+    affects: true,
+    labels: true,
+    account: true,
+    epicParent: true,
+    attachments: true,
+    comments: true,
+    description: true,
+    reporter: true,
+    assignee: true,
+    pullRequests: true,
+    ...(config.displayFields || {})
+  };
   const jiraProjects = await get(await getInstanceUrl() + 'rest/api/2/project');
 
   if (!size(jiraProjects)) {
@@ -122,9 +149,12 @@ async function mainAsyncLocal() {
   const getJiraKeys = buildJiraKeyMatcher(jiraProjects.map(function (project) {
     return project.key;
   }));
-  const annotationTemplate = await get(chrome.runtime.getURL('resources/annotation.html'));
+  const annotationTemplate = await fetch(chrome.runtime.getURL('resources/annotation.html')).then(response => response.text());
   const loaderGifUrl = chrome.runtime.getURL('resources/ajax-loader.gif');
   const imageProxyCache = {};
+  const cacheTtlMs = 60 * 1000;
+  const issueCache = new Map();
+  const pullRequestCache = new Map();
 
   function toAbsoluteJiraUrl(url) {
     if (!url) {
@@ -241,13 +271,58 @@ async function mainAsyncLocal() {
     }).format(createdAt);
   }
 
+  function sanitizeRichHtml(rawHtml) {
+    const temp = document.createElement('div');
+    temp.innerHTML = rawHtml || '';
+
+    const blockedTags = [
+      'script', 'style', 'iframe', 'object', 'embed', 'link', 'meta', 'base',
+      'form', 'input', 'button', 'textarea', 'select', 'svg', 'math'
+    ];
+    blockedTags.forEach(tagName => {
+      Array.from(temp.querySelectorAll(tagName)).forEach(node => node.remove());
+    });
+
+    const elements = Array.from(temp.querySelectorAll('*'));
+    elements.forEach(element => {
+      Array.from(element.attributes).forEach(attribute => {
+        const name = attribute.name.toLowerCase();
+        const value = attribute.value || '';
+
+        if (name.startsWith('on') || name === 'srcdoc' || name === 'style') {
+          element.removeAttribute(attribute.name);
+          return;
+        }
+
+        if (name === 'href') {
+          const normalized = value.trim();
+          if (/^(javascript|data):/i.test(normalized)) {
+            element.removeAttribute(attribute.name);
+          }
+          return;
+        }
+
+        if (name === 'src') {
+          const normalized = value.trim();
+          const safeImageDataUrl = /^data:image\/(gif|png|jpeg|jpg|webp);/i.test(normalized);
+          const safeHttpUrl = /^https?:/i.test(normalized);
+          if (!safeImageDataUrl && !safeHttpUrl) {
+            element.removeAttribute(attribute.name);
+          }
+          return;
+        }
+      });
+    });
+
+    return temp;
+  }
+
   async function normalizeRichHtml(html, options = {}) {
     if (!html) {
       return '';
     }
     const {imageMaxHeight} = options;
-    const temp = document.createElement('div');
-    temp.innerHTML = html;
+    const temp = sanitizeRichHtml(html);
 
     const imageNodes = Array.from(temp.querySelectorAll('img[src]'));
     await Promise.all(imageNodes.map(async img => {
@@ -317,25 +392,129 @@ async function mainAsyncLocal() {
   }
 
   function getPullRequestData(issueId, applicationType) {
-    return get(INSTANCE_URL + 'rest/dev-status/1.0/issue/details?issueId=' + issueId + '&applicationType=' + applicationType + '&dataType=pullrequest');
+    const appTypeQuery = applicationType ? `&applicationType=${encodeURIComponent(applicationType)}` : '';
+    return get(`${INSTANCE_URL}rest/dev-status/1.0/issue/details?issueId=${issueId}${appTypeQuery}&dataType=pullrequest`);
+  }
+
+  async function getCachedValue(cache, key, buildValue) {
+    const existing = cache.get(key);
+    if (existing && (Date.now() - existing.createdAt) < cacheTtlMs) {
+      return existing.value;
+    }
+
+    const value = await buildValue();
+    cache.set(key, {
+      createdAt: Date.now(),
+      value
+    });
+    return value;
   }
 
   async function getIssueMetaData(issueKey) {
-    const sprintFieldIds = await getSprintFieldIds(INSTANCE_URL);
-    const fields = [
-      'description',
-      'id',
-      'reporter',
-      'assignee',
-      'summary',
-      'attachment',
-      'comment',
-      'issuetype',
-      'status',
-      'fixVersions',
-      ...sprintFieldIds
-    ];
-    return get(INSTANCE_URL + 'rest/api/2/issue/' + issueKey + '?fields=' + fields.join(',') + '&expand=renderedFields,names');
+    return getCachedValue(issueCache, issueKey, async () => {
+      const sprintFieldIds = await getSprintFieldIds(INSTANCE_URL);
+      const fields = [
+        'description',
+        'id',
+        'reporter',
+        'assignee',
+        'summary',
+        'attachment',
+        'comment',
+        'issuetype',
+        'status',
+        'priority',
+        'labels',
+        'versions',
+        'parent',
+        'fixVersions',
+        ...sprintFieldIds
+      ];
+      return get(INSTANCE_URL + 'rest/api/2/issue/' + issueKey + '?fields=' + fields.join(',') + '&expand=renderedFields,names');
+    });
+  }
+
+  function getPullRequestDataCached(issueId, applicationType) {
+    const cacheKey = `${issueId}__${applicationType}`;
+    return getCachedValue(pullRequestCache, cacheKey, () => {
+      return getPullRequestData(issueId, applicationType);
+    });
+  }
+
+  async function getIssueSummary(issueKey) {
+    if (!issueKey) {
+      return null;
+    }
+    return getCachedValue(issueCache, `summary__${issueKey}`, async () => {
+      const data = await get(`${INSTANCE_URL}rest/api/2/issue/${issueKey}?fields=summary`);
+      return {
+        key: issueKey,
+        summary: data?.fields?.summary || issueKey
+      };
+    });
+  }
+
+  async function readEpicOrParent(issueData) {
+    const parent = issueData.fields?.parent;
+    if (parent && parent.key) {
+      return {
+        key: parent.key,
+        summary: parent.fields?.summary || parent.key,
+        url: `${INSTANCE_URL}browse/${parent.key}`
+      };
+    }
+
+    const names = issueData.names || {};
+    const fields = issueData.fields || {};
+    const epicFieldId = Object.keys(names).find(fieldId => {
+      const name = String(names[fieldId] || '').toLowerCase();
+      return name === 'epic link' || name === 'epic';
+    });
+    const epicKey = epicFieldId ? fields[epicFieldId] : null;
+    if (!epicKey || typeof epicKey !== 'string') {
+      return null;
+    }
+    try {
+      const epic = await getIssueSummary(epicKey);
+      return {
+        key: epic.key,
+        summary: epic.summary || epic.key,
+        url: `${INSTANCE_URL}browse/${epic.key}`
+      };
+    } catch (ex) {
+      return {
+        key: epicKey,
+        summary: epicKey,
+        url: `${INSTANCE_URL}browse/${epicKey}`
+      };
+    }
+  }
+
+  function readAccountValues(issueData) {
+    const names = issueData.names || {};
+    const fields = issueData.fields || {};
+    const accountFieldIds = Object.keys(names).filter(fieldId => {
+      return String(names[fieldId] || '').toLowerCase().includes('account');
+    });
+    const values = [];
+    accountFieldIds.forEach(fieldId => {
+      const value = fields[fieldId];
+      if (!value) {
+        return;
+      }
+      const entries = Array.isArray(value) ? value : [value];
+      entries.forEach(entry => {
+        if (!entry) {
+          return;
+        }
+        if (typeof entry === 'string') {
+          values.push(entry);
+          return;
+        }
+        values.push(entry.name || entry.value || entry.key || entry.id);
+      });
+    });
+    return [...new Set(values.filter(Boolean))];
   }
 
   function readSprintsFromIssue(issueData) {
@@ -392,6 +571,43 @@ async function mainAsyncLocal() {
       .map(sprint => sprint.state ? `${sprint.name} (${sprint.state})` : sprint.name)
       .filter(Boolean)
       .join(', ');
+  }
+
+  function encodeJqlValue(value) {
+    return `"${String(value || '').replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+
+  function buildJqlUrl(jql) {
+    return `${INSTANCE_URL}issues/?jql=${encodeURIComponent(jql)}`;
+  }
+
+  function toSearchChip(fieldName, value, label = value) {
+    if (!value) {
+      return null;
+    }
+    const jql = `${fieldName} = ${encodeJqlValue(value)}`;
+    return {
+      text: label,
+      url: buildJqlUrl(jql)
+    };
+  }
+
+  function toIssueSearchChip(issueTypeName, statusName, value, label = value) {
+    if (!value) {
+      return null;
+    }
+    const criteria = [];
+    if (issueTypeName) {
+      criteria.push(`issuetype = ${encodeJqlValue(issueTypeName)}`);
+    }
+    if (statusName) {
+      criteria.push(`status = ${encodeJqlValue(statusName)}`);
+    }
+    criteria.push(`text ~ ${encodeJqlValue(value)}`);
+    return {
+      text: label,
+      url: buildJqlUrl(criteria.join(' AND '))
+    };
   }
 
   function buildAttachmentChips(attachments) {
@@ -492,11 +708,10 @@ async function mainAsyncLocal() {
     handle: '._JX_title, ._JX_status',
   }, container);
   
-  function buildPrettyLinkPayload() {
-    const titleLink = document.getElementById('_JX_title_link');
-    const url = titleLink?.getAttribute('href') || '';
-    const ticket = titleLink?.getAttribute('data-ticket') || '';
-    const title = titleLink?.getAttribute('data-title') || '';
+  function buildPrettyLinkPayload(sourceElement) {
+    const url = sourceElement?.getAttribute('data-url') || sourceElement?.getAttribute('href') || '';
+    const ticket = sourceElement?.getAttribute('data-ticket') || '';
+    const title = sourceElement?.getAttribute('data-title') || '';
     const label = `[${ticket}] ${title}`.trim();
     const link = document.createElement('a');
     link.href = url;
@@ -524,8 +739,8 @@ async function mainAsyncLocal() {
     });
   }
 
-  async function copyPrettyLink() {
-    const {html, text} = buildPrettyLinkPayload();
+  async function copyPrettyLink(sourceElement) {
+    const {html, text} = buildPrettyLinkPayload(sourceElement);
     try {
       if (navigator.clipboard && window.ClipboardItem && navigator.clipboard.write) {
         await navigator.clipboard.write([
@@ -554,9 +769,9 @@ async function mainAsyncLocal() {
     }
   }
 
-  $(document.body).on('click', '._JX_title_copy', function (e) {
+  $(document.body).on('click', '._JX_copy_link', function (e) {
     e.preventDefault();
-    copyPrettyLink().catch(() => snackBar('There was an error!'));
+    copyPrettyLink(e.currentTarget).catch(() => snackBar('There was an error!'));
   });
 
   function closePreviewOverlay() {
@@ -597,6 +812,7 @@ async function mainAsyncLocal() {
   });
 
   function hideContainer() {
+    lastHoveredKey = '';
     containerPinned = false;
     container.css({
       left: -5000,
@@ -632,6 +848,7 @@ async function mainAsyncLocal() {
 
   let hideTimeOut;
   let containerPinned = false;
+  let lastHoveredKey = '';
   container.on('dragstop', () => {
     if (!containerPinned) {
       snackBar('Ticket Pinned! Hit esc to close !');
@@ -660,13 +877,20 @@ async function mainAsyncLocal() {
       if (!size(keys) && element.href) {
         keys = getJiraKeys(getRelativeHref(element.href));
       }
-      if (!size(keys) && element.parentElement.href) {
+      if (!size(keys) && element.parentElement && element.parentElement.href) {
         keys = getJiraKeys(getRelativeHref(element.parentElement.href));
       }
 
       if (size(keys)) {
         clearTimeout(hideTimeOut);
-        const key = keys[0].replace(" ", "-");
+        const key = keys[0].replace(' ', '-');
+        if (lastHoveredKey === key && container.html()) {
+          if (!containerPinned) {
+            container.css(computeVisibleContainerPosition(e.pageX, e.pageY));
+          }
+          return;
+        }
+        lastHoveredKey = key;
         const pointerX = e.pageX;
         const pointerY = e.pageY;
         (async function (cancelToken) {
@@ -674,8 +898,8 @@ async function mainAsyncLocal() {
           await normalizeIssueImages(issueData);
           let pullRequests = [];
           try {
-            const githubPrs = await getPullRequestData(issueData.id, 'github');
-            pullRequests = githubPrs.detail[0].pullRequests;
+            const githubPrs = await getPullRequestDataCached(issueData.id, 'github');
+            pullRequests = githubPrs.detail?.[0]?.pullRequests || [];
           } catch (ex) {
             // probably no access
           }
@@ -688,39 +912,116 @@ async function mainAsyncLocal() {
           });
           const commentsForDisplay = await buildCommentsForDisplay(issueData);
           const fixVersions = issueData.fields.fixVersions || [];
+          const affectsVersions = issueData.fields.versions || [];
           const sprints = readSprintsFromIssue(issueData);
           const commentsTotal = commentsForDisplay.length;
           const attachments = issueData.fields.attachment || [];
           const previewAttachments = buildPreviewAttachments(attachments);
+          const labels = issueData.fields.labels || [];
+          const accountValues = readAccountValues(issueData);
+          const epicOrParent = await readEpicOrParent(issueData);
+          const issueTypeName = issueData.fields.issuetype?.name;
+          const statusName = issueData.fields.status?.name;
+          const priorityName = issueData.fields.priority?.name;
+
+          const statusChips = [
+            displayFields.issueType ? {text: issueTypeName || 'No type'} : null,
+            displayFields.status ? {text: statusName || 'No status'} : null,
+            displayFields.priority ? {text: priorityName || 'No priority'} : null
+          ].filter(Boolean);
+
+          const sprintChips = displayFields.sprint ? sprints
+            .map(sprint => {
+              const label = sprint.state ? `${sprint.name} (${sprint.state})` : sprint.name;
+              return toSearchChip('Sprint', sprint.name, label);
+            })
+            .filter(Boolean) : [];
+          const sprintFallbackText = displayFields.sprint && !sprintChips.length ? 'Sprint: --' : '';
+
+          const fixVersionChips = displayFields.fixVersions ? fixVersions
+            .map(version => toSearchChip('fixVersion', version.name))
+            .filter(Boolean) : [];
+          const fixVersionFallbackText = displayFields.fixVersions && !fixVersionChips.length ? 'Fix version: --' : '';
+
+          const labelChips = displayFields.labels ? labels
+            .map(label => toIssueSearchChip(issueTypeName, statusName, label))
+            .filter(Boolean) : [];
+
+          const accountChips = displayFields.account ? accountValues
+            .map(accountValue => ({text: accountValue}))
+            .filter(Boolean) : [];
+
+          const epicParentChips = displayFields.epicParent && epicOrParent
+            ? [{
+              text: `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`,
+            }]
+            : [];
+
+          const affectsText = displayFields.affects
+            ? `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`
+            : '';
+
+          const copyTicketMeta = (ticket) => ({
+            copyUrl: ticket.url,
+            copyTicket: ticket.key,
+            copyTitle: ticket.summary
+          });
+
           const displayData = {
             urlTitle: `[${key}] ${issueData.fields.summary}`,
             ticketKey: key,
             ticketTitle: issueData.fields.summary,
             url: INSTANCE_URL + 'browse/' + key,
+            ...copyTicketMeta({
+              key,
+              summary: issueData.fields.summary,
+              url: INSTANCE_URL + 'browse/' + key
+            }),
             prs: [],
-            description: normalizedDescription,
-            hasBodyContent: !!normalizedDescription || previewAttachments.length > 0 || commentsForDisplay.length > 0,
+            description: displayFields.description ? normalizedDescription : '',
+            hasBodyContent: (displayFields.description && !!normalizedDescription) ||
+              (displayFields.attachments && previewAttachments.length > 0) ||
+              (displayFields.comments && commentsForDisplay.length > 0),
             attachments,
-            previewAttachments,
-            commentsForDisplay,
+            previewAttachments: displayFields.attachments ? previewAttachments : [],
+            commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
             issuetype: issueData.fields.issuetype,
             status: issueData.fields.status,
-            issueTypeText: issueData.fields.issuetype?.name || 'No type',
-            statusText: issueData.fields.status?.name || 'No status',
-            hasComments: commentsTotal > 0,
-            commentsTotal,
-            fixVersionText: formatFixVersionText(fixVersions) || 'No fix version',
-            sprintText: formatSprintText(sprints) || 'No sprint',
-            attachmentChips: buildAttachmentChips(attachments),
-            reporter: issueData.fields.reporter,
-            assignee: issueData.fields.assignee,
+            priority: issueData.fields.priority,
+            issueTypeText: displayFields.issueType ? (issueTypeName || 'No type') : '',
+            statusText: displayFields.status ? (statusName || 'No status') : '',
+            sprintText: displayFields.sprint ? (formatSprintText(sprints) || 'No sprint') : '',
+            fixVersionText: displayFields.fixVersions ? (formatFixVersionText(fixVersions) || 'No fix version') : '',
+            statusChips,
+            epicParentChips,
+            sprintChips,
+            sprintFallbackText,
+            fixVersionChips,
+            fixVersionFallbackText,
+            labelChips,
+            accountChips,
+            affectsText,
+            hasComments: displayFields.comments && commentsTotal > 0,
+            commentsTotal: displayFields.comments ? commentsTotal : 0,
+            attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
+            reporter: displayFields.reporter ? issueData.fields.reporter : null,
+            assignee: displayFields.assignee ? issueData.fields.assignee : null,
             commentUrl: INSTANCE_URL + 'browse/' + key,
+            hasFieldSummary: statusChips.length > 0 ||
+              epicParentChips.length > 0 ||
+              !!affectsText ||
+              sprintChips.length > 0 ||
+              !!sprintFallbackText ||
+              fixVersionChips.length > 0 ||
+              !!fixVersionFallbackText ||
+              labelChips.length > 0 ||
+              accountChips.length > 0,
             loaderGifUrl,
           };
           if (issueData.fields.comment?.comments?.[0]?.id) {
             displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
           }
-          if (size(pullRequests)) {
+          if (displayFields.pullRequests && size(pullRequests)) {
             displayData.prs = pullRequests.filter(function (pr) {
               return pr.url !== location.href;
             }).map(function (pr) {
@@ -738,8 +1039,11 @@ async function mainAsyncLocal() {
           if (!containerPinned) {
             container.css(computeVisibleContainerPosition(pointerX, pointerY));
           }
-        })(cancelToken);
+        })(cancelToken).catch(() => {
+          lastHoveredKey = '';
+        });
       } else if (!containerPinned) {
+        lastHoveredKey = '';
         hideTimeOut = setTimeout(hideContainer, 250);
       }
     }

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -216,6 +216,15 @@ body ._JX {
     }
   }
 
+  &_section_title {
+    color: #5e6c84;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    margin: 0 0 6px;
+    text-transform: uppercase;
+  }
+
   &_comments {
     border-top: 1px solid #dde4e6;
     margin-top: 6px;

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -13,18 +13,23 @@ body ._JX {
     padding: 10px 10px;
     border: 1px solid #dde4e6;
     display: flex;
+    align-items: center;
     min-width: 0;
     user-select: none;
     -webkit-user-select: none;
 
     &_users {
       display: inline-flex;
+      align-items: center;
+      flex: 0 0 auto;
       margin-left: -3px;
       margin-right: 6px;
       min-width: 20px;
     }
 
     &_user {
+      display: block;
+      flex: 0 0 20px;
       width: 20px;
       height: 20px;
       margin-right: -6px;
@@ -34,6 +39,8 @@ body ._JX {
       border: 1px solid #dfe1e6;
       border-radius: 50%;
       background: #fff;
+      object-fit: cover;
+      overflow: hidden;
     }
 
     &_user_assignee {
@@ -55,6 +62,7 @@ body ._JX {
     }
 
     #_JX_title_link {
+      flex: 1 1 auto;
       font-size: 14px;
       line-height: 1.3;
       min-width: 0;

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -93,6 +93,21 @@ body ._JX {
       min-width: 0;
     }
 
+    &_row_primary {
+      align-items: stretch;
+      flex-wrap: nowrap;
+      justify-content: space-between;
+      gap: 10px;
+    }
+
+    &_row_main {
+      display: flex;
+      flex: 1 1 auto;
+      flex-wrap: wrap;
+      gap: 6px;
+      min-width: 0;
+    }
+
     ._JX_status_icon {
       width: 14px;
       height: 14px;
@@ -139,30 +154,27 @@ body ._JX {
     }
   }
 
-  &_related_pr {
-    max-height: 300px;
-    overflow-y: auto;
-    overflow-x: hidden;
-    border-bottom: 1px solid rgb(221, 228, 230);
+  &_activity_strip {
+    align-items: center;
+    border-left: 1px solid #d9e1ea;
+    color: #52657a;
+    display: inline-flex;
+    flex: 0 0 auto;
+    gap: 10px;
+    padding-left: 10px;
+    white-space: nowrap;
+  }
 
-    td {
-      padding: 10px;
-      border-bottom: 1px solid #dde4e6;
-      min-width: 0;
-      overflow-wrap: anywhere;
-      word-break: break-word;
-    }
+  &_activity_item {
+    align-items: center;
+    display: inline-flex;
+    font-size: 12px;
+    gap: 4px;
+  }
 
-    table {
-      width: 100%;
-      table-layout: fixed;
-    }
-
-    thead td {
-      border-bottom: 1px solid #dde4e6;
-      text-transform: capitalize;
-      font-weight: bold;
-    }
+  &_activity_item strong {
+    font-size: 12px;
+    font-weight: 700;
   }
 
   &_description {
@@ -230,6 +242,59 @@ body ._JX {
     letter-spacing: 0.05em;
     margin: 0 0 6px;
     text-transform: uppercase;
+  }
+
+  &_related_pr {
+    border-top: 1px solid #dde4e6;
+    margin-top: 6px;
+    padding-top: 4px;
+    min-width: 0;
+    font-size: 12px;
+    line-height: 1.35;
+
+    a {
+      font-size: 12px;
+    }
+
+    td {
+      padding: 8px 10px;
+      border-bottom: 1px solid #dde4e6;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+      vertical-align: top;
+    }
+
+    table {
+      width: 100%;
+      table-layout: fixed;
+      border-collapse: collapse;
+    }
+
+    thead td {
+      border-bottom: 1px solid #dde4e6;
+      color: #5e6c84;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    tbody td:first-child {
+      width: 42%;
+    }
+
+    tbody td:nth-child(2) {
+      width: 18%;
+    }
+
+    tbody td:nth-child(3) {
+      width: 24%;
+    }
+
+    tbody td:nth-child(4) {
+      width: 16%;
+    }
   }
 
   &_comments {
@@ -348,11 +413,6 @@ body ._JX {
     color: #172b4d !important;
   }
 
-  &_avatar {
-    width: 20px;
-    height: 20px;
-  }
-
   &_PR_STATUS {
     border: 1px solid #a5b3c2;
     border-radius: 3px;
@@ -458,6 +518,23 @@ body ._JX {
     cursor: pointer !important;
   }
 }
+@media (max-width: 640px) {
+  body ._JX {
+    &_status_row_primary {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    &_activity_strip {
+      border-left: none;
+      border-top: 1px solid #d9e1ea;
+      padding-left: 0;
+      padding-top: 8px;
+      width: 100%;
+    }
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   body ._JX {
     &_container {

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -80,11 +80,18 @@ body ._JX {
     background-color: #f2f8fa;
     border-bottom: 1px solid #dde4e6;
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: 6px;
     padding: 8px;
     user-select: none;
     -webkit-user-select: none;
+
+    &_row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      min-width: 0;
+    }
 
     ._JX_status_icon {
       width: 14px;
@@ -323,7 +330,8 @@ body ._JX {
     border: 1px solid #dfe1e6;
     border-radius: 20px;
     color: #172b4d;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     font-size: 12px;
     line-height: 18px;
     padding: 2px 10px;

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -42,28 +42,15 @@ body ._JX {
     background-color: #f2f8fa;
     border-bottom: 1px solid #dde4e6;
     display: flex;
-
-    > div,
-    > a {
-      flex-grow: 1;
-      justify-content: space-evenly;
-      border-right: 1px solid #dde4e6;
-      padding: 5px 10px;
-
-      &:last-child {
-        border-right: none;
-      }
-    }
-
-    > a {
-      text-decoration: none !important;
-    }
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px;
 
     ._JX_status_icon {
-      position: relative;
-      top: 3px;
-      margin-right: 3px;
-      width: 16px;
+      width: 14px;
+      height: 14px;
+      margin-right: 4px;
+      vertical-align: text-bottom;
     }
   }
 
@@ -133,6 +120,20 @@ body ._JX {
       padding-left: 15px;
       margin-bottom: 15px;
     }
+
+    &_text img {
+      max-width: 100%;
+      max-height: 180px;
+      height: auto;
+      width: auto;
+    }
+
+    &_attachments {
+      border-top: 1px solid #dde4e6;
+      margin-top: 10px;
+      padding-top: 8px;
+      overflow: hidden;
+    }
   }
 
   &_field_group {
@@ -163,6 +164,15 @@ body ._JX {
     font-size: 12px;
     line-height: 18px;
     padding: 2px 10px;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &_field_chip_link {
+    text-decoration: none !important;
+    color: #172b4d !important;
   }
 
   &_avatar {

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -28,6 +28,7 @@ body ._JX {
       color: #172b4d;
       background-color: transparent;
       border: none;
+      cursor: pointer;
       vertical-align: middle;
       position: relative;
       top: 2px;
@@ -35,6 +36,11 @@ body ._JX {
       &:hover {
         color: #8993a4;
       }
+    }
+
+    #_JX_title_link {
+      font-size: 14px;
+      line-height: 1.3;
     }
   }
 
@@ -57,6 +63,7 @@ body ._JX {
   &_annotation {
     max-width: 600px;
     color: #24292f;
+    font-family: 'Nunito', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     border: 1px solid #dde4e6;
     border-radius: 3px;
     background-color: white;
@@ -122,10 +129,16 @@ body ._JX {
     }
 
     &_text img {
+      cursor: pointer;
       max-width: 100%;
       max-height: 180px;
       height: auto;
       width: auto;
+    }
+
+    &_text {
+      font-size: 14px;
+      line-height: 1.35;
     }
 
     &_attachments {
@@ -133,6 +146,53 @@ body ._JX {
       margin-top: 10px;
       padding-top: 8px;
       overflow: hidden;
+    }
+  }
+
+  &_comments {
+    border-top: 1px solid #dde4e6;
+    margin-top: 6px;
+    padding-top: 4px;
+  }
+
+  &_comment {
+    border-bottom: 1px solid #dde4e6;
+    margin-bottom: 4px;
+    padding-bottom: 4px;
+
+    &:last-child {
+      border-bottom: none;
+      margin-bottom: 0;
+      padding-bottom: 0;
+    }
+  }
+
+  &_comment_meta {
+    color: #5e6c84;
+    font-size: 11px;
+    margin-bottom: 3px;
+    text-align: left;
+  }
+
+  &_comment_author {
+    color: #172b4d;
+    font-weight: bold;
+  }
+
+  &_comment_body {
+    font-size: 14px;
+    line-height: 1.35;
+    word-break: break-word;
+
+    a {
+      text-decoration: underline;
+    }
+
+    img {
+      cursor: pointer;
+      display: block;
+      margin-top: 6px;
+      max-width: 100%;
     }
   }
 
@@ -219,17 +279,34 @@ body ._JX {
     margin: 5px;
     border: 1px solid rgb(221, 228, 230) !important;
     cursor: pointer;
-    height: 145px;
-    width: 200px;
+    height: auto;
+    width: auto;
+    max-width: 100%;
     position: relative;
     overflow: hidden;
+
+    a,
+    img {
+      cursor: pointer !important;
+    }
+
+    > a > img:not(._JX_file_loader) {
+      display: block;
+      height: auto;
+      max-height: 100px;
+      max-width: 100%;
+      width: auto;
+    }
   }
 
   &_thumb_filename {
     position: absolute;
     white-space: nowrap;
-    width: 200px;
+    width: 100%;
     background-color: white;
+    color: #172b4d;
+    font-size: 14px;
+    line-height: 18px;
     max-height: 20px;
     text-overflow: ellipsis;
     overflow: hidden;
@@ -242,6 +319,30 @@ body ._JX {
     top: 23%;
     left: 35%;
     position: absolute;
+  }
+
+  &_preview_overlay {
+    align-items: center;
+    background: rgba(0, 0, 0, 0.84);
+    display: none;
+    inset: 0;
+    justify-content: center;
+    position: fixed;
+    z-index: 2147483647;
+
+    &.is-open {
+      display: flex;
+    }
+  }
+
+  &_preview_image {
+    max-height: 96vh;
+    max-width: 96vw;
+    object-fit: contain;
+  }
+
+  img._JX_previewable {
+    cursor: pointer !important;
   }
 }
 @media (prefers-color-scheme: dark) {

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -47,20 +47,17 @@ body ._JX {
       margin-right: 0;
     }
 
-    &_copy {
-      color: #172b4d;
-      background-color: transparent;
-      border: none;
-      cursor: pointer;
-      vertical-align: middle;
-      position: relative;
-      top: 2px;
-
-      &:hover {
-        color: #8993a4;
-      }
+    &_controls {
+      display: inline-flex;
+      align-items: center;
+      flex: 0 0 auto;
+      gap: 6px;
+      margin-left: 8px;
     }
 
+    &_copy {
+      padding: 0;
+    }
     #_JX_title_link {
       flex: 1 1 auto;
       font-size: 14px;
@@ -71,7 +68,131 @@ body ._JX {
     }
   }
 
-  &_subtitle {
+  &_control_button {
+    align-items: center;
+    appearance: none;
+    background: linear-gradient(180deg, #fff 0%, #f4f7fb 100%);
+    border: 1px solid #c4d2df;
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(9, 30, 66, 0.08);
+    color: #44546f;
+    cursor: pointer;
+    display: inline-flex;
+    gap: 3px;
+    height: 30px;
+    justify-content: center;
+    min-width: 30px;
+    padding: 0 8px;
+    transition: background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease, color 120ms ease, transform 120ms ease;
+
+    &:hover {
+      background: #eef4fb;
+      border-color: #8eb3da;
+      color: #1f4f82;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #4c9aff;
+      outline-offset: 2px;
+    }
+
+    &:active {
+      transform: translateY(1px);
+    }
+
+    svg {
+      display: block;
+    }
+  }
+
+  &_actions {
+    position: relative;
+    flex: 0 0 auto;
+  }
+
+  &_actions_toggle {
+    padding-right: 6px;
+
+    &.is-open {
+      background: linear-gradient(180deg, #d8e9ff 0%, #eef5ff 100%);
+      border-color: #76a4d5;
+      box-shadow: 0 0 0 3px rgba(76, 154, 255, 0.14);
+      color: #0c4a7a;
+    }
+
+    &.is-open ._JX_actions_toggle_chevron {
+      transform: rotate(180deg);
+    }
+  }
+
+  &_actions_toggle_chevron {
+    opacity: 0.72;
+    transition: transform 120ms ease;
+  }
+
+  &_actions_menu {
+    background: #fff;
+    border: 1px solid #c7d5e3;
+    border-radius: 10px;
+    box-shadow: 0 14px 32px rgba(9, 30, 66, 0.16), 0 2px 6px rgba(9, 30, 66, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 220px;
+    padding: 8px;
+    position: absolute;
+    right: 0;
+    top: calc(100% + 8px);
+    z-index: 3;
+
+    &::before {
+      background: #fff;
+      border-left: 1px solid #c7d5e3;
+      border-top: 1px solid #c7d5e3;
+      content: '';
+      height: 10px;
+      position: absolute;
+      right: 11px;
+      top: -6px;
+      transform: rotate(45deg);
+      width: 10px;
+    }
+  }
+
+  &_action_divider {
+    border-top: 1px solid #d7e1ec;
+    margin: 6px 4px;
+  }
+
+  &_action_item {
+    appearance: none;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    color: #172b4d;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.3;
+    padding: 9px 11px;
+    text-align: left;
+    transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+
+    &:hover {
+      background: #eef4fb;
+      border-color: #c7daee;
+      color: #0c4a7a;
+    }
+
+    &.is-loading,
+    &.is-disabled,
+    &:disabled {
+      background: #f4f5f7;
+      border-color: transparent;
+      color: #7a869a;
+      cursor: wait;
+    }
+  }  &_subtitle {
     border-top: none;
     padding-left: 36px;
   }
@@ -177,6 +298,22 @@ body ._JX {
     font-weight: 700;
   }
 
+  &_action_notice {
+    border-bottom: 1px solid #dde4e6;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 8px 10px;
+  }
+
+  &_action_notice_success {
+    background: #edf9f1;
+    color: #18693d;
+  }
+
+  &_action_notice_error {
+    background: #fff3f1;
+    color: #ae2e24;
+  }
   &_description {
     max-height: 400px;
     overflow-y: auto;
@@ -564,3 +701,6 @@ body ._JX {
     }
   }
 }
+
+
+

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -14,6 +14,8 @@ body ._JX {
     border: 1px solid #dde4e6;
     display: flex;
     min-width: 0;
+    user-select: none;
+    -webkit-user-select: none;
 
     &_users {
       display: inline-flex;
@@ -73,6 +75,8 @@ body ._JX {
     flex-wrap: wrap;
     gap: 6px;
     padding: 8px;
+    user-select: none;
+    -webkit-user-select: none;
 
     ._JX_status_icon {
       width: 14px;
@@ -86,6 +90,8 @@ body ._JX {
     max-width: 600px;
     width: min(600px, calc(100vw - 24px));
     overflow-x: hidden;
+    user-select: text;
+    -webkit-user-select: text;
     color: #24292f;
     font-family: 'Nunito', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     border: 1px solid #dde4e6;
@@ -172,6 +178,9 @@ body ._JX {
       line-height: 1.35;
       overflow-wrap: anywhere;
       word-break: break-word;
+      white-space: normal;
+      user-select: text;
+      -webkit-user-select: text;
 
       a {
         overflow-wrap: anywhere;
@@ -180,6 +189,14 @@ body ._JX {
 
       * {
         max-width: 100%;
+        min-width: 0;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+
+      pre,
+      code {
+        white-space: pre-wrap;
       }
     }
 
@@ -227,6 +244,9 @@ body ._JX {
     line-height: 1.35;
     overflow-wrap: anywhere;
     word-break: break-word;
+    white-space: normal;
+    user-select: text;
+    -webkit-user-select: text;
 
     a {
       font-size: 11px;
@@ -244,6 +264,14 @@ body ._JX {
 
     * {
       max-width: 100%;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    pre,
+    code {
+      white-space: pre-wrap;
     }
   }
 

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -135,6 +135,36 @@ body ._JX {
     }
   }
 
+  &_field_group {
+    padding: 10px;
+    border-bottom: 1px solid #dde4e6;
+  }
+
+  &_field_label {
+    color: #5e6c84;
+    font-size: 12px;
+    font-weight: bold;
+    margin-bottom: 6px;
+    text-transform: uppercase;
+  }
+
+  &_field_values {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  &_field_chip {
+    background: #ebecf0;
+    border: 1px solid #dfe1e6;
+    border-radius: 20px;
+    color: #172b4d;
+    display: inline-block;
+    font-size: 12px;
+    line-height: 18px;
+    padding: 2px 10px;
+  }
+
   &_avatar {
     width: 20px;
     height: 20px;

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -14,14 +14,27 @@ body ._JX {
     border: 1px solid #dde4e6;
     display: flex;
 
+    &_users {
+      display: inline-flex;
+      margin-left: -3px;
+      margin-right: 6px;
+      min-width: 20px;
+    }
+
     &_user {
       width: 20px;
       height: 20px;
-      margin-right: 6px;
-      margin-left: -3px;
+      margin-right: -6px;
       align-self: center;
       min-width: 20px;
       margin-top: -2px;
+      border: 1px solid #dfe1e6;
+      border-radius: 50%;
+      background: #fff;
+    }
+
+    &_user_assignee {
+      margin-right: 0;
     }
 
     &_copy {
@@ -42,6 +55,11 @@ body ._JX {
       font-size: 14px;
       line-height: 1.3;
     }
+  }
+
+  &_subtitle {
+    border-top: none;
+    padding-left: 36px;
   }
 
   &_status {
@@ -185,6 +203,7 @@ body ._JX {
     word-break: break-word;
 
     a {
+      font-size: 11px;
       text-decoration: underline;
     }
 

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -13,6 +13,7 @@ body ._JX {
     padding: 10px 10px;
     border: 1px solid #dde4e6;
     display: flex;
+    min-width: 0;
 
     &_users {
       display: inline-flex;
@@ -54,6 +55,9 @@ body ._JX {
     #_JX_title_link {
       font-size: 14px;
       line-height: 1.3;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
   }
 
@@ -80,6 +84,8 @@ body ._JX {
 
   &_annotation {
     max-width: 600px;
+    width: min(600px, calc(100vw - 24px));
+    overflow-x: hidden;
     color: #24292f;
     font-family: 'Nunito', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     border: 1px solid #dde4e6;
@@ -114,16 +120,21 @@ body ._JX {
 
   &_related_pr {
     max-height: 300px;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     border-bottom: 1px solid rgb(221, 228, 230);
 
     td {
       padding: 10px;
       border-bottom: 1px solid #dde4e6;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
 
     table {
       width: 100%;
+      table-layout: fixed;
     }
 
     thead td {
@@ -135,9 +146,11 @@ body ._JX {
 
   &_description {
     max-height: 400px;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     border-bottom: 1px solid #dde4e6;
-    word-wrap: break-word;
+    overflow-wrap: anywhere;
+    word-break: break-word;
     padding: 10px;
 
     ol,
@@ -157,6 +170,17 @@ body ._JX {
     &_text {
       font-size: 14px;
       line-height: 1.35;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+
+      a {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+
+      * {
+        max-width: 100%;
+      }
     }
 
     &_attachments {
@@ -171,6 +195,7 @@ body ._JX {
     border-top: 1px solid #dde4e6;
     margin-top: 6px;
     padding-top: 4px;
+    min-width: 0;
   }
 
   &_comment {
@@ -200,11 +225,14 @@ body ._JX {
   &_comment_body {
     font-size: 14px;
     line-height: 1.35;
+    overflow-wrap: anywhere;
     word-break: break-word;
 
     a {
       font-size: 11px;
       text-decoration: underline;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
 
     img {
@@ -213,6 +241,17 @@ body ._JX {
       margin-top: 6px;
       max-width: 100%;
     }
+
+    * {
+      max-width: 100%;
+    }
+  }
+
+  &_empty_body {
+    color: #5e6c84;
+    font-size: 13px;
+    line-height: 1.4;
+    padding: 2px 0;
   }
 
   &_field_group {
@@ -246,7 +285,9 @@ body ._JX {
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   &_field_chip_link {

--- a/jira-plugin/src/snack.js
+++ b/jira-plugin/src/snack.js
@@ -3,9 +3,16 @@ import {waitForDocument} from 'src/utils';
 
 waitForDocument(() => require('src/snack.scss'));
 
-export function snackBar(message, timeout = 6000) {
+let activeSnackElement = null;
+let activeSnackTimer = null;
+
+function getOrCreateSnack() {
   const $ = require('jquery');
-  const content = $(`
+  if (activeSnackElement && activeSnackElement.length) {
+    return activeSnackElement;
+  }
+
+  activeSnackElement = $(`
       <div class="_JX_snack">
           <div class="_JX_snack_icon">
             <img src="${chrome.runtime.getURL('resources/jiralink128.png')}" class="_JX_snack_icon_img" />
@@ -13,11 +20,21 @@ export function snackBar(message, timeout = 6000) {
           <div class="_JX_snack_message"></div>
       </div>
   `);
+  $(document.body).append(activeSnackElement);
+  return activeSnackElement;
+}
+
+export function snackBar(message, timeout = 6000) {
+  const content = getOrCreateSnack();
   content.find('._JX_snack_message').text(message || '');
-  $('._JX_snack').removeClass('_JX_snack_show');
-  $(document.body).append(content);
   content.addClass('_JX_snack_show');
-  setTimeout(function () {
-    content.removeClass('_JX_snack_show').on('transitionend', () => content.remove());
+
+  if (activeSnackTimer) {
+    clearTimeout(activeSnackTimer);
+  }
+
+  activeSnackTimer = setTimeout(function () {
+    content.removeClass('_JX_snack_show');
+    activeSnackTimer = null;
   }, timeout);
 }

--- a/jira-plugin/src/snack.js
+++ b/jira-plugin/src/snack.js
@@ -10,9 +10,10 @@ export function snackBar(message, timeout = 6000) {
           <div class="_JX_snack_icon">
             <img src="${chrome.runtime.getURL('resources/jiralink128.png')}" class="_JX_snack_icon_img" />
           </div>
-          <div class="_JX_snack_message">${message}</div>
+          <div class="_JX_snack_message"></div>
       </div>
   `);
+  content.find('._JX_snack_message').text(message || '');
   $('._JX_snack').removeClass('_JX_snack_show');
   $(document.body).append(content);
   content.addClass('_JX_snack_show');

--- a/jira-plugin/src/snack.scss
+++ b/jira-plugin/src/snack.scss
@@ -8,10 +8,6 @@ body ._JX {
     min-width: 50px;
     transform: translateX(-50%) translateY(100%) translateY(20px) !important;
     transition: transform 300ms !important;
-    &_show {
-      transition: transform 150ms !important;
-      transform: translateX(-50%) !important;
-    }
     background-color: #444444;
     padding: 14px 20px;
     border-radius: 50px;
@@ -19,6 +15,11 @@ body ._JX {
     border: 2px solid white;
     font-size: 16px;
     line-height: 22px;
+
+    &_show {
+      transition: transform 150ms !important;
+      transform: translateX(-50%) !important;
+    }
 
     &_icon {
       box-sizing: border-box !important;

--- a/jira-plugin/src/snack.scss
+++ b/jira-plugin/src/snack.scss
@@ -6,8 +6,7 @@ body ._JX {
     left: 50%;
     min-height: 30px;
     min-width: 50px;
-    transform: translateX(-50%) translateY(100%) translateY(20px) !important;
-    transition: transform 300ms !important;
+    transform: translateX(-50%) !important;
     background-color: #444444;
     padding: 14px 20px;
     border-radius: 50px;
@@ -15,10 +14,10 @@ body ._JX {
     border: 2px solid white;
     font-size: 16px;
     line-height: 22px;
+    display: none;
 
     &_show {
-      transition: transform 150ms !important;
-      transform: translateX(-50%) !important;
+      display: block;
     }
 
     &_icon {
@@ -32,6 +31,7 @@ body ._JX {
       border-radius: 30px;
       width: 39px;
       height: 39px;
+
       &_img {
         width: 27px;
         background-color: white;
@@ -40,6 +40,7 @@ body ._JX {
         left: 6px;
       }
     }
+
     &_message {
       margin-left: 40px;
       color: white;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2518,9 +2518,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5217,9 +5217,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5522,9 +5522,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,14 +24,14 @@
         "eslint-plugin-react": "7.28.0",
         "jquery": "3.6.0",
         "jquery-ui": "1.14.1",
-        "lodash": "4.17.21",
+        "lodash": "4.17.23",
         "mustache": "4.2.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "sass": "1.89.2",
         "sass-loader": "16.0.5",
         "style-loader": "3.3.1",
-        "webpack": "5.101.0",
+        "webpack": "5.105.4",
         "webpack-bundle-analyzer": "4.5.0",
         "webpack-cli": "4.9.2"
       }
@@ -1855,9 +1855,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.10.tgz",
-      "integrity": "sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2245,13 +2245,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -2469,9 +2469,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2553,9 +2553,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2881,6 +2881,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -2938,9 +2951,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -2958,10 +2971,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001726",
-        "electron-to-chromium": "^1.5.173",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3038,9 +3052,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001776",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
+      "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
       "dev": true,
       "funding": [
         {
@@ -3450,9 +3464,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.192",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.192.tgz",
-      "integrity": "sha512-rP8Ez0w7UNw/9j5eSXCe10o1g/8B1P5SM90PCCMVkIRQn2R0LEHWz4Eh9RnxkniuDe1W0cTSOB3MLlkTGDcuCg==",
+      "version": "1.5.307",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
+      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "dev": true,
       "license": "ISC"
     },
@@ -3467,14 +3481,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
-      "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -3583,9 +3597,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4038,9 +4052,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true,
       "funding": [
         {
@@ -5320,13 +5334,17 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/loader-utils": {
@@ -5371,9 +5389,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5595,9 +5613,9 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6111,16 +6129,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -6420,27 +6428,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6613,16 +6600,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/set-function-length": {
@@ -7040,24 +7017,28 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
-      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terser": {
-      "version": "5.43.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
-      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -7069,16 +7050,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
+      "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -7104,9 +7084,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7141,9 +7121,9 @@
       "license": "MIT"
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7329,9 +7309,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7380,9 +7360,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -7435,9 +7415,9 @@
       "license": "MIT"
     },
     "node_modules/watchpack": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7449,9 +7429,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.0.tgz",
-      "integrity": "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==",
+      "version": "5.105.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
+      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7461,25 +7441,25 @@
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.24.0",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.2",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.20.0",
+        "es-module-lexer": "^2.0.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
+        "loader-runner": "^4.3.1",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.3.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.17",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.4"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -7601,9 +7581,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7611,9 +7591,9 @@
       }
     },
     "node_modules/webpack/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7672,9 +7652,9 @@
       "license": "MIT"
     },
     "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
     "eslint-plugin-react": "7.28.0",
     "jquery": "3.6.0",
     "jquery-ui": "1.14.1",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "mustache": "4.2.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "sass": "1.89.2",
+    "sass-loader": "16.0.5",
     "style-loader": "3.3.1",
-    "webpack": "5.101.0",
+    "webpack": "5.105.4",
     "webpack-bundle-analyzer": "4.5.0",
-    "webpack-cli": "4.9.2",
-    "sass-loader": "16.0.5"
+    "webpack-cli": "4.9.2"
   }
 }

--- a/plans/adaptive-pr-discovery-plan.md
+++ b/plans/adaptive-pr-discovery-plan.md
@@ -1,0 +1,370 @@
+# Adaptive PR Discovery Plan
+
+## Goal
+
+Make pull request rendering resilient across Jira deployments, git providers, and on-prem integration setups by:
+
+- discovering a working Jira development-data endpoint at runtime
+- discovering a working `applicationType` at runtime
+- caching the resolved strategy per Jira instance
+- ensuring PR lookup failures never break the main hover popup
+
+## Current Problems
+
+1. PR fetching is effectively hardcoded to one endpoint and one `applicationType`.
+2. Jira Server/Data Center development APIs are private and differ across deployments.
+3. Some instances expose summary counts but not PR details on the same route.
+4. When discovery logic is mixed directly into popup rendering, regressions can break the whole hover flow.
+
+## Non-Goals
+
+- Do not query GitHub, GitLab, or Bitbucket directly.
+- Do not build provider-specific logic based on hostnames alone.
+- Do not block popup rendering while running large endpoint scans on every hover.
+
+## Desired Runtime Behavior
+
+### Scenario A: Known working Jira instance
+
+- Hover starts.
+- Core issue data loads.
+- Cached PR strategy is reused immediately.
+- PR list is fetched using the cached strategy.
+- If fetch fails once, mark strategy as suspect and continue without PRs.
+
+### Scenario B: First run on a Jira instance
+
+- Hover starts.
+- Core issue data loads.
+- No cached PR strategy exists.
+- Run a bounded discovery sequence.
+- Cache the first working strategy.
+- Render PRs if found; otherwise render popup without PRs.
+
+### Scenario C: Jira knows PR counts but details are unavailable
+
+- Summary endpoint returns pull request count > 0.
+- All detail endpoints return empty or error.
+- Popup renders without PR rows.
+- Debug state records that Jira exposes summary-only development data.
+
+### Scenario D: Endpoint/applicationType changed after Jira upgrade
+
+- Cached strategy starts failing.
+- Mark strategy stale.
+- Re-run discovery.
+- Replace cache entry if a new working strategy is found.
+
+## Proposed Architecture
+
+### 1. Introduce a PR discovery layer
+
+Add a small module-level strategy abstraction in `jira-plugin/src/content.jsx` or extract into a dedicated helper file:
+
+```js
+{
+  endpointVariant: 'dev-status-1-detail',
+  applicationType: 'gitlabselfmanaged',
+  dataType: 'pullrequest',
+  responseShape: 'detail.pullRequests',
+  discoveredAt: 1772850000000,
+  lastVerifiedAt: 1772850000000
+}
+```
+
+This object represents the resolved Jira-specific PR fetch strategy.
+
+### 2. Separate three concerns
+
+Implement three distinct layers:
+
+- `fetchCoreIssueData(issueKey)`
+  - required for popup rendering
+- `discoverPullRequestStrategy(issueId)`
+  - optional, bounded, cached
+- `fetchPullRequests(issueId, strategy)`
+  - optional, normalized, failure-tolerant
+
+Core issue rendering must never depend on discovery success.
+
+### 3. Define endpoint candidates explicitly
+
+Create a fixed ordered candidate list.
+
+Initial detail candidates:
+
+```text
+/rest/dev-status/1.0/issue/detail
+/rest/dev-status/latest/issue/detail
+/rest/dev-status/1.0/issue/details
+/rest/dev-status/latest/issue/details
+```
+
+Initial summary candidates:
+
+```text
+/rest/dev-status/1.0/issue/summary
+/rest/dev-status/latest/issue/summary
+```
+
+Each endpoint candidate should define:
+
+- path template
+- required query params
+- expected response roots (`detail`, `details`, `summary`)
+- whether it is for `summary` or `detail`
+
+### 4. Define application type candidates explicitly
+
+Use a bounded ordered list:
+
+```text
+(none)
+gitlabselfmanaged
+gitlab
+github
+bitbucket
+stash
+```
+
+Rules:
+
+- Summary probes should run without `applicationType` first.
+- Detail probes should test `(none)` first, then provider values.
+- Stop probing after the first candidate that returns parseable PR objects.
+
+### 5. Add response normalization
+
+Implement a single normalization function for all development responses:
+
+```js
+normalizePullRequestPayload(response) => {
+  pullRequests: [],
+  summaryCount: number | null,
+  source: {
+    root: 'detail',
+    shape: 'detail[0].pullRequests'
+  }
+}
+```
+
+Normalization should inspect, in order:
+
+- `response.detail[].pullRequests`
+- `response.detail[].pullrequests`
+- `response.details[].pullRequests`
+- `response.details[].pullrequests`
+- single-object variants with `pullRequests`
+- fallback empty result
+
+This function should never throw.
+
+### 6. Define “working” strategy criteria
+
+A detail strategy is considered working if:
+
+- the HTTP request succeeds, and
+- the response shape is parseable, and
+- either:
+  - PR objects are present, or
+  - the endpoint returns a valid development wrapper consistently
+
+A summary strategy is considered useful if:
+
+- the HTTP request succeeds, and
+- a pull request count can be read from the response
+
+Store summary and detail strategies separately if necessary.
+
+## Caching Design
+
+### Cache keys
+
+Cache by Jira instance origin, not by issue:
+
+```text
+prStrategy::<jira-origin>
+prSummaryStrategy::<jira-origin>
+```
+
+Example:
+
+```text
+prStrategy::https://jira.asseco-see.hr
+```
+
+### Cache payload
+
+```js
+{
+  endpointPath: '/rest/dev-status/1.0/issue/detail',
+  applicationType: 'gitlabselfmanaged',
+  responseShape: 'detail.pullRequests',
+  verified: true,
+  discoveredAt: 1772850000000,
+  lastVerifiedAt: 1772850300000,
+  failureCount: 0
+}
+```
+
+### Cache invalidation
+
+- Reuse cached strategy for up to 7 days.
+- If a cached strategy fails 2 consecutive times, mark it stale.
+- When stale, run discovery again.
+- If discovery still fails, keep popup working and suppress PRs.
+
+## Implementation Steps
+
+### Phase 1: Stabilize current code paths
+
+1. Move all PR fetching behind a single safe wrapper:
+   - `safeFetchPullRequests(issueData, instanceUrl)`
+2. Guarantee this wrapper always resolves to:
+   - `[]`
+   - or a normalized PR array
+3. Ensure all popup rendering uses only the normalized array.
+
+### Phase 2: Build discovery primitives
+
+1. Add endpoint candidate definitions.
+2. Add application type candidate definitions.
+3. Add request builders:
+   - `buildDevStatusSummaryUrl(issueId, endpointVariant)`
+   - `buildDevStatusDetailUrl(issueId, endpointVariant, applicationType)`
+4. Add normalization helpers for summary and detail responses.
+
+### Phase 3: Add strategy discovery
+
+1. Try cached detail strategy first.
+2. If missing or stale, run discovery:
+   - probe summary endpoints first
+   - probe detail endpoints second
+3. Record:
+   - which endpoint succeeded
+   - which `applicationType` succeeded
+   - which response shape matched
+
+### Phase 4: Integrate with popup rendering
+
+1. Load issue data as today.
+2. Start PR fetch in optional flow after issue data.
+3. If PR fetch completes before render cutoff, include PRs.
+4. If not, render popup without PRs.
+5. Optional enhancement:
+   - patch PR rows into already-open popup when late result arrives
+
+### Phase 5: Add diagnostics
+
+Keep debug logging behind a single toggle:
+
+- default off in normal builds
+- enabled by:
+  - local constant
+  - or options flag
+
+Log only:
+
+- chosen strategy
+- failed candidate count
+- summary count if available
+- normalized PR count
+
+Avoid always logging full raw JSON in normal usage.
+
+## Suggested Code Changes
+
+### `jira-plugin/src/content.jsx`
+
+Primary work:
+
+- replace hardcoded PR URL construction
+- add strategy discovery and cache lookup
+- add normalized PR extraction
+- make popup rendering independent from PR fetch failures
+
+Suggested functions:
+
+```js
+getInstanceStrategyCacheKey(instanceUrl)
+getSummaryStrategyCacheKey(instanceUrl)
+loadCachedPullRequestStrategy(instanceUrl)
+storeCachedPullRequestStrategy(instanceUrl, strategy)
+buildDevStatusUrl(issueId, endpointPath, query)
+normalizePullRequestPayload(response)
+normalizePullRequestSummary(response)
+discoverPullRequestStrategy(issueId, instanceUrl)
+safeFetchPullRequests(issueId, instanceUrl)
+```
+
+### `jira-plugin/options/config.js`
+
+Optional future enhancement:
+
+- add `debugPullRequests: false`
+
+This allows enabling diagnostics without shipping noisy logs by default.
+
+### `jira-plugin/options/options.jsx`
+
+Optional future enhancement:
+
+- add a checkbox for `Enable PR debug logging`
+
+This is not required for the first implementation.
+
+## Failure Handling Rules
+
+These rules should remain strict:
+
+1. PR fetch failure must never prevent popup render.
+2. Discovery failure must not retry endlessly on every mousemove.
+3. Unknown response shapes must be logged only in debug mode.
+4. Empty PR results are acceptable if Jira integration is partial.
+
+## Testing Plan
+
+### Manual scenarios
+
+1. Jira instance with working GitHub integration
+   - expect PRs displayed
+2. Jira instance with self-managed GitLab integration
+   - expect discovery to settle on correct endpoint/applicationType
+3. Jira instance with no development integration
+   - expect popup with no PRs and no regression
+4. Jira instance where summary works but details do not
+   - expect popup with no PRs, summary diagnostics only
+5. Temporary Jira outage
+   - expect popup failure only if core issue fetch fails
+   - PR logic should not alter behavior
+
+### Regression checks
+
+- hover popup still appears on Outlook pages
+- no console exceptions from PR logic
+- issue rendering works when PR field is disabled
+- strategy cache is reused between hovers
+
+## Rollout Strategy
+
+### Step 1
+
+Restore robust non-breaking PR fetch behavior.
+
+### Step 2
+
+Implement adaptive endpoint and `applicationType` discovery behind debug logging.
+
+### Step 3
+
+Once validated on the target Jira instance, reduce logging noise and keep only compact strategy diagnostics.
+
+## Expected Result
+
+After this work, the extension should:
+
+- continue showing the popup reliably
+- adapt to different Jira dev-status endpoint variants
+- adapt to different `applicationType` values
+- avoid hardcoding provider assumptions where possible
+- degrade gracefully when Jira exposes incomplete development data


### PR DESCRIPTION
## Summary
- restyle the quick actions trigger as an icon dropdown and align it visually with the copy control
- add quick actions for assign, transition, and project-scoped sprint moves with ACTIVE/NEXT sprint context
- separate sprint actions from the primary actions in the dropdown and refresh popup state after actions run

## Verification
- npx webpack --mode=development