### PR TITLE
Add Playwright E2E suite for Jira HotLinker

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,7 +13,6 @@
     ],
     "@babel/preset-react"
   ],
-  "plugins": [
-    "lodash"
-  ]
+  "plugins": []
 }
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 .idea/*
+.agents/
 .test.swp
 *.swp
 *.zip
 node_modules/
+tests/.auth/
+tests/output/
+playwright-report/
+test-results/
 jira-plugin/build/
 jira-plugin/options/build/
 jira-plugin/assets/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 jira-plugin/build/
 jira-plugin/options/build/
 jira-plugin/assets/
+Screenshot*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Jira HotLinker
+
+## Build
+
+```
+npx webpack --mode=development
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,20 @@
 - **Upstream**: https://github.com/helmus/Jira-Hot-Linker
 - PRs and issues go to `dgebaei/Jira-Hot-Linker`, not upstream
 
+## Git workflow
+
+- Always `git pull origin master --rebase` before starting work to stay in sync with remote
+- PRs target `master` on `dgebaei/Jira-Hot-Linker`
+
 ## Build
 
 ```
 npx webpack --mode=development
 ```
+
+## Release process
+
+1. Ensure master is up to date: `git checkout master && git pull origin master --rebase`
+2. Build: `npx webpack --mode=development`
+3. Package: `powershell -Command "Remove-Item -Force jira-plugin-build.zip -ErrorAction SilentlyContinue; Compress-Archive -Path jira-plugin/build, jira-plugin/resources, jira-plugin/options, jira-plugin/manifest.json -DestinationPath jira-plugin-build.zip"`
+4. Create release: `gh release create <version> jira-plugin-build.zip --repo dgebaei/Jira-Hot-Linker --title "<version> - <title>" --notes "<release notes>"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # Jira HotLinker
 
+## Repository
+
+- **GitHub repo**: https://github.com/dgebaei/Jira-Hot-Linker
+- **Upstream**: https://github.com/helmus/Jira-Hot-Linker
+- PRs and issues go to `dgebaei/Jira-Hot-Linker`, not upstream
+
 ## Build
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,11 @@
 npx webpack --mode=development
 ```
 
+## Jira API docs
+
+- Official Jira Server/Data Center REST API docs: https://developer.atlassian.com/server/jira/platform/rest/v10003/intro
+- The docs are very large, so only fetch/read them when repo inspection is not enough or when endpoint details need confirmation.
+
 ## Release process
 
 1. Ensure master is up to date: `git checkout master && git pull origin master --rebase`

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 ![Manifest V3](https://img.shields.io/badge/Manifest-V3-0f766e?style=for-the-badge)
 ![MIT License](https://img.shields.io/badge/License-MIT-f59e0b?style=for-the-badge)
 
-## See it in action
+## See it in action ✨
 
 Hover a Jira key and the extension brings the issue into view with context, actions, and linked development details right where you are already working.
 
-## The pitch
+## The pitch 🚀
 
 Jira keys are everywhere, but the context usually is not. You see `PROJ-1842` in a pull request, an email, a doc, or a comment thread, and then the tab-hopping begins.
 
@@ -22,25 +22,25 @@ It is the kind of extension that feels small until you use it for a day - then y
 
 Another important detail: Jira HotLinker does not ask you to hand over Jira credentials to a separate service. It works through your existing browser session, sending requests from the browser with the Jira access you already have.
 
-## Why it feels great
+## Why it feels great 🎯
 
-- Instant context exactly where the Jira key appears
-- Fewer tabs, fewer context switches, less waiting
-- Fast issue updates without losing your place
-- Works across the real tools teams use all day
-- Honors Jira workflows instead of fighting them
-- Does not rely on storing your Jira username or password in the extension
+- ✨ Instant context exactly where the Jira key appears
+- ⚡ Fewer tabs, fewer context switches, less waiting
+- ✍️ Fast issue updates without losing your place
+- 🌍 Works across the real tools teams use all day
+- ✅ Honors Jira workflows instead of fighting them
+- 🔐 Does not rely on storing your Jira username or password in the extension
 
-## Why people install it
+## Why people install it 💡
 
-- Stay in the conversation instead of bouncing between browser tabs
-- Understand a ticket before opening Jira
-- Make quick Jira updates in place instead of breaking focus to open the full issue page
-- Review code and product discussions with live Jira context nearby
-- Make Git providers, mail, docs, Jira, and Confluence all feel connected
-- Give your team fast access to the fields that actually matter
+- 💬 Stay in the conversation instead of bouncing between browser tabs
+- 👀 Understand a ticket before opening Jira
+- ✍️ Make quick Jira updates in place instead of breaking focus to open the full issue page
+- 🔎 Review code and product discussions with live Jira context nearby
+- 🔗 Make Git providers, mail, docs, Jira, and Confluence all feel connected
+- 🎯 Give your team fast access to the fields that actually matter
 
-## Without it / With it
+## Without it / With it 🔄
 
 **Without Jira HotLinker**
 
@@ -58,7 +58,7 @@ Another important detail: Jira HotLinker does not ask you to hand over Jira cred
 - You keep reading, reviewing, replying, or shipping
 - You stay in flow
 
-## Where it shines
+## Where it shines 🌍
 
 - Reviewing pull requests across GitHub, GitLab, Bitbucket, and other Git providers
 - Checking ticket status and priority during code review
@@ -67,28 +67,28 @@ Another important detail: Jira HotLinker does not ask you to hand over Jira cred
 - Following linked pull requests and related development activity faster
 - Surfacing custom Jira fields that matter to your team
 
-## Built for the messy real world
+## Built for the messy real world 🧩
 
 - Git platforms: GitHub, GitLab, Bitbucket, and similar review or repo tools
 - Email and communication: Gmail, Outlook, and any web app where Jira keys appear in text
 - Documents and knowledge tools: Google Docs, Jira, Confluence, and other configurable pages
 - Team-specific workflows: any internal tool or custom domain you choose to enable
 
-## What it can do
+## What it can do ⚡
 
-- Detect Jira issue keys on the pages you use most and turn them into rich hover cards
-- Work across Git providers, email tools, docs, and collaboration apps through configurable domain matching
-- Display ticket title, type, status, priority, labels, sprint, versions, epic/parent, reporter, and assignee
-- Render the issue description, comments, and attachment previews
-- Show related pull requests and development signals
-- Edit supported issue fields directly from the popup and trigger Jira-backed actions like assign-to-me, sprint updates, and workflow transitions
-- Respect Jira-side options, workflows, and validation behavior instead of inventing its own rules
-- Let you drag and pin the ticket card while you work
-- Copy the issue key and title to the clipboard
-- Configure which domains are scanned and which Jira fields are visible
-- Add Jira custom fields to the top summary rows
+- ✨ Detect Jira issue keys on the pages you use most and turn them into rich hover cards
+- 🌐 Work across Git providers, email tools, docs, and collaboration apps through configurable domain matching
+- 🧾 Display ticket title, type, status, priority, labels, sprint, versions, epic/parent, reporter, and assignee
+- 💬 Render the issue description, comments, and attachment previews
+- 🔗 Show related pull requests and development signals
+- ✍️ Edit supported issue fields directly from the popup and trigger Jira-backed actions like assign-to-me, sprint updates, and workflow transitions
+- ✅ Respect Jira-side options, workflows, and validation behavior instead of inventing its own rules
+- 📌 Let you drag and pin the ticket card while you work
+- 📋 Copy the issue key and title to the clipboard
+- ⚙️ Configure which domains are scanned and which Jira fields are visible
+- 🧩 Add Jira custom fields to the top summary rows
 
-## Feature tour
+## Feature tour 🎬
 
 Imagine the moment a Jira key appears on screen:
 
@@ -101,9 +101,9 @@ Imagine the moment a Jira key appears on screen:
 7. Related pull requests and development signals help you connect discussion to delivery.
 8. If the ticket matters, you can pin the card, keep it nearby, and continue working.
 
-## Install in minutes
+## Install in minutes 📦
 
-### Install from the Chrome Web Store
+### Install from the Chrome Web Store 🛍️
 
 If the idea already clicks, install it here:
 
@@ -120,16 +120,16 @@ After installing:
 
 By default, GitHub is enabled, but that is only the starting point. You can add other Git providers and everyday tools such as Gmail, Outlook, Google Docs, Jira, and Confluence from the options page or directly from the extension action.
 
-## Privacy and authentication
+## Privacy and authentication 🔐
 
 Jira HotLinker uses your existing Jira login session in the browser. In plain terms, if you are already signed in to Jira in your browser, the extension can request issue data with that same authenticated session.
 
-- No separate Jira password is stored by the extension
-- No extra credential vault or external account link is required
-- Requests are made from your browser to your Jira instance using the access you already have
-- What you can view or update still depends on your Jira permissions, workflow rules, and field validation
+- 🔒 No separate Jira password is stored by the extension
+- 🚫 No extra credential vault or external account link is required
+- 🌐 Requests are made from your browser to your Jira instance using the access you already have
+- ✅ What you can view or update still depends on your Jira permissions, workflow rules, and field validation
 
-### Local development setup
+### Local development setup 🛠️
 
 ```bash
 npm install
@@ -150,14 +150,14 @@ Useful commands:
 - `npx webpack-cli` - creates a production build in `jira-plugin/`
 - `make build` - builds and creates a zip archive
 
-## Configuration highlights
+## Configuration highlights ⚙️
 
 - `Jira instance URL` points the extension at the Jira site used for issue metadata
 - `Allowed pages` controls where ticket detection is active
 - `Tooltip Layout` lets you choose which built-in fields appear in the hover card
 - `Custom Fields` lets you add Jira field IDs such as `customfield_12345` and place them in summary rows
 
-## Finding custom field IDs
+## Finding custom field IDs 🔎
 
 Want to surface a Jira custom field in the hover card? You will need the field ID, which usually looks like `customfield_12345`.
 
@@ -171,30 +171,30 @@ Here are the easiest ways to find it in your Jira instance:
 
 If the field ID is valid, the options page will try to resolve and display the field name for you.
 
-## Direct issue editing
+## Direct issue editing ✍️
 
 Jira HotLinker is not just a viewer. It can help you act on issues right from the preview.
 
-- Update supported fields such as sprint and versions from inline controls
-- Run quick actions like assigning the issue to yourself or moving it into progress when Jira allows it
-- Use Jira-provided values and transitions instead of hardcoded shortcuts
-- Stay aligned with workflow restrictions, field constraints, and validation behavior already defined in Jira
+- 🛠️ Update supported fields such as sprint and versions from inline controls
+- ⚡ Run quick actions like assigning the issue to yourself or moving it into progress when Jira allows it
+- 🔄 Use Jira-provided values and transitions instead of hardcoded shortcuts
+- ✅ Stay aligned with workflow restrictions, field constraints, and validation behavior already defined in Jira
 
-## In one sentence
+## In one sentence 🎉
 
 Jira HotLinker makes every Jira key on the web feel alive, actionable, and useful.
 
-## For developers
+## For developers 👩‍💻
 
 - `jira-plugin/src/` - content script, background logic, and UI behavior
 - `jira-plugin/options/` - options page UI and configuration flow
 - `jira-plugin/manifest.json` - Chrome extension manifest
 - `webpack.config.js` - build pipeline for the extension bundles
 
-## Thank you
+## Thank you 🙌
 
 Special thanks to the original extension author, Willem D'Haeseleer, for creating Jira HotLinker and laying the foundation for this project.
 
-## License
+## License 📄
 
 This project is released under the MIT License. See `LICENSE.md`.

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ Until the Chrome Web Store listing is ready, the simplest distribution path is a
 
 Download the current packaged build here:
 
-`https://github.com/dgebaei/Jira-Hot-Linker/releases/download/1.9.0/jira-plugin-build.zip`
+`https://github.com/dgebaei/Jira-Hot-Linker/releases/latest/download/jira-plugin-build.zip`
 
 Release page:
 
-`https://github.com/dgebaei/Jira-Hot-Linker/releases/tag/1.9.0`
+`https://github.com/dgebaei/Jira-Hot-Linker/releases/latest`
 
 Installation steps:
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Installation steps:
 
 - `Jira instance URL` points the extension at the Jira site used for issue metadata
 - `Allowed pages` controls where ticket detection is active
+- `Hover Behavior` lets you fine-tune when the tooltip appears:
+  - **Trigger depth** — choose how aggressively the extension looks for Jira keys around the cursor: `Exact` (only the element directly under the cursor), `Shallow` (element + immediate parent, the default), or `Deep` (up to 5 ancestor levels)
+  - **Modifier key** — optionally require a key press to activate the tooltip. Hover a Jira key and then press the modifier (Alt, Ctrl, or Shift) to show the popup on demand. You can also hold the key first and then hover. Set to `None` by default for automatic activation.
 - `Tooltip Layout` lets you choose which built-in fields appear in the hover card
 - `Custom Fields` lets you add Jira field IDs such as `customfield_12345` and place them in summary rows
 

--- a/README.md
+++ b/README.md
@@ -105,9 +105,7 @@ Imagine the moment a Jira key appears on screen:
 
 ### Install from the Chrome Web Store 🛍️
 
-If the idea already clicks, install it here:
-
-https://chrome.google.com/webstore/detail/jira-hotlinker/lbifpcpomdegljfpfhgfcjdabbeallhk
+Chrome Web Store listing: `TBD`
 
 Install it, point it at your Jira instance, and you can start hovering issue keys almost immediately.
 
@@ -119,6 +117,33 @@ After installing:
 4. Visit any allowed page that contains Jira issue keys.
 
 By default, GitHub is enabled, but that is only the starting point. You can add other Git providers and everyday tools such as Gmail, Outlook, Google Docs, Jira, and Confluence from the options page or directly from the extension action.
+
+### Install from GitHub for now 📥
+
+Until the Chrome Web Store listing is ready, the simplest distribution path is a GitHub release with a packaged build.
+
+Download the current packaged build here:
+
+`https://github.com/dgebaei/Jira-Hot-Linker/releases/download/1.9.0/jira-plugin-build.zip`
+
+Release page:
+
+`https://github.com/dgebaei/Jira-Hot-Linker/releases/tag/1.9.0`
+
+Installation steps:
+
+- Users download and unzip it locally
+- In Chrome or other Chromium browsers, open `chrome://extensions`
+- Enable `Developer mode`
+- Click `Load unpacked`
+- Select the unzipped `jira-plugin/` folder
+
+Why this is the best short-term option:
+
+- A plain zip is easy to distribute through GitHub Releases
+- Users can inspect exactly what they are installing
+- Chrome generally does not offer a smooth direct install flow for extensions outside the Web Store
+- `Load unpacked` is the most reliable option until store publishing is in place
 
 ## Privacy and authentication 🔐
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,200 @@
-## Jira Hot Linker
+# Jira HotLinker
 
-A Chrome plugin that will show Jira metadata when hovering over a Jira issue key on github.
+> Turn plain Jira issue keys into instant, rich previews and in-place actions across the tools your team already lives in.
 
-Now available trough the Chrome Store !  
+![Chrome Extension](https://img.shields.io/badge/Chrome-Extension-1f6feb?style=for-the-badge&logo=googlechrome&logoColor=white)
+![Manifest V3](https://img.shields.io/badge/Manifest-V3-0f766e?style=for-the-badge)
+![MIT License](https://img.shields.io/badge/License-MIT-f59e0b?style=for-the-badge)
+
+## See it in action
+
+Hover a Jira key and the extension brings the issue into view with context, actions, and linked development details right where you are already working.
+
+## The pitch
+
+Jira keys are everywhere, but the context usually is not. You see `PROJ-1842` in a pull request, an email, a doc, or a comment thread, and then the tab-hopping begins.
+
+Jira HotLinker brings that context to you instantly. Hover an issue key and get the title, status, priority, description, comments, attachments, related pull requests, and more - without leaving the page.
+
+And it does not stop at reading. The extension also lets you update issues directly from the hover card, using Jira's own available values, transitions, and rules so your edits stay aligned with the validation already configured in Jira.
+
+It is the kind of extension that feels small until you use it for a day - then you do not want to work without it.
+
+Another important detail: Jira HotLinker does not ask you to hand over Jira credentials to a separate service. It works through your existing browser session, sending requests from the browser with the Jira access you already have.
+
+## Why it feels great
+
+- Instant context exactly where the Jira key appears
+- Fewer tabs, fewer context switches, less waiting
+- Fast issue updates without losing your place
+- Works across the real tools teams use all day
+- Honors Jira workflows instead of fighting them
+- Does not rely on storing your Jira username or password in the extension
+
+## Why people install it
+
+- Stay in the conversation instead of bouncing between browser tabs
+- Understand a ticket before opening Jira
+- Make quick Jira updates in place instead of breaking focus to open the full issue page
+- Review code and product discussions with live Jira context nearby
+- Make Git providers, mail, docs, Jira, and Confluence all feel connected
+- Give your team fast access to the fields that actually matter
+
+## Without it / With it
+
+**Without Jira HotLinker**
+
+- You spot `PROJ-1842` in a PR, email, or doc
+- You open Jira in another tab
+- You wait for the issue to load
+- You hunt for status, priority, comments, and related work
+- You jump back to where you started and repeat the cycle again
+
+**With Jira HotLinker**
+
+- You hover `PROJ-1842`
+- The ticket comes to you instantly
+- You see the important context right on the page
+- You keep reading, reviewing, replying, or shipping
+- You stay in flow
+
+## Where it shines
+
+- Reviewing pull requests across GitHub, GitLab, Bitbucket, and other Git providers
+- Checking ticket status and priority during code review
+- Looking up descriptions, comments, and attachments without leaving the page you are on
+- Reading Jira references inside Gmail, Outlook, Google Docs, Jira, or Confluence
+- Following linked pull requests and related development activity faster
+- Surfacing custom Jira fields that matter to your team
+
+## Built for the messy real world
+
+- Git platforms: GitHub, GitLab, Bitbucket, and similar review or repo tools
+- Email and communication: Gmail, Outlook, and any web app where Jira keys appear in text
+- Documents and knowledge tools: Google Docs, Jira, Confluence, and other configurable pages
+- Team-specific workflows: any internal tool or custom domain you choose to enable
+
+## What it can do
+
+- Detect Jira issue keys on the pages you use most and turn them into rich hover cards
+- Work across Git providers, email tools, docs, and collaboration apps through configurable domain matching
+- Display ticket title, type, status, priority, labels, sprint, versions, epic/parent, reporter, and assignee
+- Render the issue description, comments, and attachment previews
+- Show related pull requests and development signals
+- Edit supported issue fields directly from the popup and trigger Jira-backed actions like assign-to-me, sprint updates, and workflow transitions
+- Respect Jira-side options, workflows, and validation behavior instead of inventing its own rules
+- Let you drag and pin the ticket card while you work
+- Copy the issue key and title to the clipboard
+- Configure which domains are scanned and which Jira fields are visible
+- Add Jira custom fields to the top summary rows
+
+## Feature tour
+
+Imagine the moment a Jira key appears on screen:
+
+1. You hover the issue key.
+2. A polished preview opens with the ticket title and triage details.
+3. Status, priority, labels, sprint, versions, and ownership are immediately visible.
+4. Description, comments, and attachments are right there when you need deeper context.
+5. When action is needed, you can update supported fields directly from the popup and use quick issue actions without losing your place.
+6. Those edits follow Jira's available options and workflow validation, so the extension fits the process your team already uses.
+7. Related pull requests and development signals help you connect discussion to delivery.
+8. If the ticket matters, you can pin the card, keep it nearby, and continue working.
+
+## Install in minutes
+
+### Install from the Chrome Web Store
+
+If the idea already clicks, install it here:
+
 https://chrome.google.com/webstore/detail/jira-hotlinker/lbifpcpomdegljfpfhgfcjdabbeallhk
 
-Make sure to configure your Jira instance url in the options page after installing. 
-You can find the settings by clicking on the extensions icon and selecting options !
+Install it, point it at your Jira instance, and you can start hovering issue keys almost immediately.
 
-The tooltip is enabled on github.com by default, 
-you can add new domains by clicking on the extension icon or in the option menu. 
+After installing:
 
-### Features
-- Title and link to Jira
-- Related pull requests
-- Descriptions
-- Attachments
-- Ticket Type / Status / Priority
-- Comments
-- Pin a ticket on the screen by dragging the title
-- Copy issue key and title to clipboard
+1. Open the extension options page.
+2. Enter your Jira instance URL, for example `https://your-company.atlassian.net/`.
+3. Save the configuration and grant the requested permissions.
+4. Visit any allowed page that contains Jira issue keys.
+
+By default, GitHub is enabled, but that is only the starting point. You can add other Git providers and everyday tools such as Gmail, Outlook, Google Docs, Jira, and Confluence from the options page or directly from the extension action.
+
+## Privacy and authentication
+
+Jira HotLinker uses your existing Jira login session in the browser. In plain terms, if you are already signed in to Jira in your browser, the extension can request issue data with that same authenticated session.
+
+- No separate Jira password is stored by the extension
+- No extra credential vault or external account link is required
+- Requests are made from your browser to your Jira instance using the access you already have
+- What you can view or update still depends on your Jira permissions, workflow rules, and field validation
+
+### Local development setup
+
+```bash
+npm install
+npx webpack-cli
+```
+
+Then load the unpacked extension from `jira-plugin/` in Chrome.
+
+For active development:
+
+```bash
+npm run dev
+```
+
+Useful commands:
+
+- `npm run dev` - rebuilds on file changes
+- `npx webpack-cli` - creates a production build in `jira-plugin/`
+- `make build` - builds and creates a zip archive
+
+## Configuration highlights
+
+- `Jira instance URL` points the extension at the Jira site used for issue metadata
+- `Allowed pages` controls where ticket detection is active
+- `Tooltip Layout` lets you choose which built-in fields appear in the hover card
+- `Custom Fields` lets you add Jira field IDs such as `customfield_12345` and place them in summary rows
+
+## Finding custom field IDs
+
+Want to surface a Jira custom field in the hover card? You will need the field ID, which usually looks like `customfield_12345`.
+
+Here are the easiest ways to find it in your Jira instance:
+
+- Use Jira issue search: when you search for a custom field in JQL, Jira often shows the field ID alongside the field name, which makes it easy to spot values like `customfield_12345`
+- Open a Jira issue, inspect the page or network requests, and look for field keys named like `customfield_12345`
+- Visit your Jira field metadata endpoint while signed in: `https://your-jira/rest/api/2/field`
+- Search the returned list for the field name you care about, then copy its `id`
+- Paste that value into the extension options page under `Custom Fields`
+
+If the field ID is valid, the options page will try to resolve and display the field name for you.
+
+## Direct issue editing
+
+Jira HotLinker is not just a viewer. It can help you act on issues right from the preview.
+
+- Update supported fields such as sprint and versions from inline controls
+- Run quick actions like assigning the issue to yourself or moving it into progress when Jira allows it
+- Use Jira-provided values and transitions instead of hardcoded shortcuts
+- Stay aligned with workflow restrictions, field constraints, and validation behavior already defined in Jira
+
+## In one sentence
+
+Jira HotLinker makes every Jira key on the web feel alive, actionable, and useful.
+
+## For developers
+
+- `jira-plugin/src/` - content script, background logic, and UI behavior
+- `jira-plugin/options/` - options page UI and configuration flow
+- `jira-plugin/manifest.json` - Chrome extension manifest
+- `webpack.config.js` - build pipeline for the extension bundles
+
+## Thank you
+
+Special thanks to the original extension author, Willem D'Haeseleer, for creating Jira HotLinker and laying the foundation for this project.
+
+## License
+
+This project is released under the MIT License. See `LICENSE.md`.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
 ![Manifest V3](https://img.shields.io/badge/Manifest-V3-0f766e?style=for-the-badge)
 ![MIT License](https://img.shields.io/badge/License-MIT-f59e0b?style=for-the-badge)
 
-## See it in action ✨
-
-Hover a Jira key and the extension brings the issue into view with context, actions, and linked development details right where you are already working.
-
 ## The pitch 🚀
 
 Jira keys are everywhere, but the context usually is not. You see `PROJ-1842` in a pull request, an email, a doc, or a comment thread, and then the tab-hopping begins.
@@ -20,54 +16,16 @@ And it does not stop at reading. The extension also lets you update issues direc
 
 It is the kind of extension that feels small until you use it for a day - then you do not want to work without it.
 
-Another important detail: Jira HotLinker does not ask you to hand over Jira credentials to a separate service. It works through your existing browser session, sending requests from the browser with the Jira access you already have.
-
-## Why it feels great 🎯
-
-- ✨ Instant context exactly where the Jira key appears
-- ⚡ Fewer tabs, fewer context switches, less waiting
-- ✍️ Fast issue updates without losing your place
-- 🌍 Works across the real tools teams use all day
-- ✅ Honors Jira workflows instead of fighting them
-- 🔐 Does not rely on storing your Jira username or password in the extension
-
 ## Why people install it 💡
 
-- 💬 Stay in the conversation instead of bouncing between browser tabs
-- 👀 Understand a ticket before opening Jira
-- ✍️ Make quick Jira updates in place instead of breaking focus to open the full issue page
-- 🔎 Review code and product discussions with live Jira context nearby
-- 🔗 Make Git providers, mail, docs, Jira, and Confluence all feel connected
-- 🎯 Give your team fast access to the fields that actually matter
-
-## Without it / With it 🔄
-
-**Without Jira HotLinker**
-
-- You spot `PROJ-1842` in a PR, email, or doc
-- You open Jira in another tab
-- You wait for the issue to load
-- You hunt for status, priority, comments, and related work
-- You jump back to where you started and repeat the cycle again
-
-**With Jira HotLinker**
-
-- You hover `PROJ-1842`
-- The ticket comes to you instantly
-- You see the important context right on the page
-- You keep reading, reviewing, replying, or shipping
-- You stay in flow
+- ✨ See Jira context exactly where the issue key appears
+- ⚡ Reduce tab switching and stay in flow
+- ✍️ Make quick updates without opening the full Jira issue
+- 🔎 Review work with more context before you click away
+- 🔗 Connect Git, docs, email, Jira, and Confluence more naturally
+- 🎯 Give each team the fields and workflow cues they actually need
 
 ## Where it shines 🌍
-
-- Reviewing pull requests across GitHub, GitLab, Bitbucket, and other Git providers
-- Checking ticket status and priority during code review
-- Looking up descriptions, comments, and attachments without leaving the page you are on
-- Reading Jira references inside Gmail, Outlook, Google Docs, Jira, or Confluence
-- Following linked pull requests and related development activity faster
-- Surfacing custom Jira fields that matter to your team
-
-## Built for the messy real world 🧩
 
 - Git platforms: GitHub, GitLab, Bitbucket, and similar review or repo tools
 - Email and communication: Gmail, Outlook, and any web app where Jira keys appear in text
@@ -76,74 +34,33 @@ Another important detail: Jira HotLinker does not ask you to hand over Jira cred
 
 ## What it can do ⚡
 
-- ✨ Detect Jira issue keys on the pages you use most and turn them into rich hover cards
-- 🌐 Work across Git providers, email tools, docs, and collaboration apps through configurable domain matching
-- 🧾 Display ticket title, type, status, priority, labels, sprint, versions, epic/parent, reporter, and assignee
-- 💬 Render the issue description, comments, and attachment previews
-- 🔗 Show related pull requests and development signals
-- ✍️ Edit supported issue fields directly from the popup and trigger Jira-backed actions like assign-to-me, sprint updates, and workflow transitions
-- ✅ Respect Jira-side options, workflows, and validation behavior instead of inventing its own rules
-- 📌 Let you drag and pin the ticket card while you work
-- 📋 Copy the issue key and title to the clipboard
-- ⚙️ Configure which domains are scanned and which Jira fields are visible
-- 🧩 Add Jira custom fields to the top summary rows
+- ✨ Detect Jira issue keys and turn them into rich hover cards
+- 🧾 Show core issue metadata like title, type, status, priority, labels, sprint, versions, epic/parent, reporter, and assignee
+- 💬 Render descriptions, comments, attachments, and related pull requests in the popup
+- ✍️ Support in-place editing, quick actions, and Jira-backed workflow transitions
+- 📌 Let you pin the popup while you keep working on the page
+- 📋 Copy issue details quickly when you need to share them
+- ⚙️ Control supported pages, visible fields, and custom field placement
+
+## Direct issue editing ✍️
+
+Jira HotLinker is not just a viewer. It helps you act on issues right from the preview, while still respecting how Jira is configured.
+
+- 🛠️ Edit supported fields such as sprint, versions, status, priority, assignee, labels, issue type, epic/parent, and supported custom fields
+- ⚡ Run quick actions like assigning the issue to yourself or moving it into progress when Jira allows it
+- 🔄 Use Jira-provided values and transitions instead of hardcoded shortcuts
+- ✅ Stay aligned with workflow restrictions, field constraints, and validation behavior already defined in Jira
 
 ## Feature tour 🎬
 
 Imagine the moment a Jira key appears on screen:
 
 1. You hover the issue key.
-2. A polished preview opens with the ticket title and triage details.
-3. Status, priority, labels, sprint, versions, and ownership are immediately visible.
-4. Description, comments, and attachments are right there when you need deeper context.
-5. When action is needed, you can update supported fields directly from the popup and use quick issue actions without losing your place.
-6. Those edits follow Jira's available options and workflow validation, so the extension fits the process your team already uses.
-7. Related pull requests and development signals help you connect discussion to delivery.
-8. If the ticket matters, you can pin the card, keep it nearby, and continue working.
-
-## Install in minutes 📦
-
-### Install from the Chrome Web Store 🛍️
-
-Chrome Web Store listing: `TBD`
-
-Install it, point it at your Jira instance, and you can start hovering issue keys almost immediately.
-
-After installing:
-
-1. Open the extension options page.
-2. Enter your Jira instance URL, for example `https://your-company.atlassian.net/`.
-3. Save the configuration and grant the requested permissions.
-4. Visit any allowed page that contains Jira issue keys.
-
-By default, GitHub is enabled, but that is only the starting point. You can add other Git providers and everyday tools such as Gmail, Outlook, Google Docs, Jira, and Confluence from the options page or directly from the extension action.
-
-### Install from GitHub for now 📥
-
-Until the Chrome Web Store listing is ready, the simplest distribution path is a GitHub release with a packaged build.
-
-Download the current packaged build here:
-
-`https://github.com/dgebaei/Jira-Hot-Linker/releases/latest/download/jira-plugin-build.zip`
-
-Release page:
-
-`https://github.com/dgebaei/Jira-Hot-Linker/releases/latest`
-
-Installation steps:
-
-- Users download and unzip it locally
-- In Chrome or other Chromium browsers, open `chrome://extensions`
-- Enable `Developer mode`
-- Click `Load unpacked`
-- Select the unzipped `jira-plugin/` folder
-
-Why this is the best short-term option:
-
-- A plain zip is easy to distribute through GitHub Releases
-- Users can inspect exactly what they are installing
-- Chrome generally does not offer a smooth direct install flow for extensions outside the Web Store
-- `Load unpacked` is the most reliable option until store publishing is in place
+2. The popup opens with the ticket summary and current status.
+3. You scan the important context without leaving the page.
+4. If needed, you open comments, attachments, or related pull requests.
+5. If action is needed, you edit the issue or trigger a quick Jira workflow action.
+6. You keep reading, reviewing, replying, or shipping without breaking focus.
 
 ## Privacy and authentication 🔐
 
@@ -153,6 +70,32 @@ Jira HotLinker uses your existing Jira login session in the browser. In plain te
 - 🚫 No extra credential vault or external account link is required
 - 🌐 Requests are made from your browser to your Jira instance using the access you already have
 - ✅ What you can view or update still depends on your Jira permissions, workflow rules, and field validation
+
+## Install 📦
+
+### Install from the Chrome Web Store 🛍️
+
+Chrome Web Store listing: `TBD`
+
+### Install from GitHub for now 📥
+
+Until the Chrome Web Store listing is ready, the simplest distribution path is a GitHub release with a packaged build.
+
+Download the current packaged build here:
+
+- [Download latest build](https://github.com/dgebaei/Jira-Hot-Linker/releases/latest/download/jira-plugin-build.zip)
+
+Release page:
+
+- [View latest release](https://github.com/dgebaei/Jira-Hot-Linker/releases/latest)
+
+Installation steps:
+
+- Users download and unzip it locally
+- In Chrome or other Chromium browsers, open `chrome://extensions`
+- Enable `Developer mode`
+- Click `Load unpacked`
+- Select the unzipped `jira-plugin/` folder
 
 ### Local development setup 🛠️
 
@@ -196,25 +139,16 @@ Here are the easiest ways to find it in your Jira instance:
 
 If the field ID is valid, the options page will try to resolve and display the field name for you.
 
-## Direct issue editing ✍️
-
-Jira HotLinker is not just a viewer. It can help you act on issues right from the preview.
-
-- 🛠️ Update supported fields such as sprint and versions from inline controls
-- ⚡ Run quick actions like assigning the issue to yourself or moving it into progress when Jira allows it
-- 🔄 Use Jira-provided values and transitions instead of hardcoded shortcuts
-- ✅ Stay aligned with workflow restrictions, field constraints, and validation behavior already defined in Jira
-
-## In one sentence 🎉
-
-Jira HotLinker makes every Jira key on the web feel alive, actionable, and useful.
-
 ## For developers 👩‍💻
 
 - `jira-plugin/src/` - content script, background logic, and UI behavior
 - `jira-plugin/options/` - options page UI and configuration flow
 - `jira-plugin/manifest.json` - Chrome extension manifest
 - `webpack.config.js` - build pipeline for the extension bundles
+
+## In one sentence 🎉
+
+Jira HotLinker makes every Jira key on the web feel alive, actionable, and useful.
 
 ## Thank you 🙌
 

--- a/README.md
+++ b/README.md
@@ -97,27 +97,6 @@ Installation steps:
 - Click `Load unpacked`
 - Select the unzipped `jira-plugin/` folder
 
-### Local development setup 🛠️
-
-```bash
-npm install
-npx webpack-cli
-```
-
-Then load the unpacked extension from `jira-plugin/` in Chrome.
-
-For active development:
-
-```bash
-npm run dev
-```
-
-Useful commands:
-
-- `npm run dev` - rebuilds on file changes
-- `npx webpack-cli` - creates a production build in `jira-plugin/`
-- `make build` - builds and creates a zip archive
-
 ## Configuration highlights ⚙️
 
 - `Jira instance URL` points the extension at the Jira site used for issue metadata
@@ -125,7 +104,7 @@ Useful commands:
 - `Tooltip Layout` lets you choose which built-in fields appear in the hover card
 - `Custom Fields` lets you add Jira field IDs such as `customfield_12345` and place them in summary rows
 
-## Finding custom field IDs 🔎
+### Finding custom field IDs 🔎
 
 Want to surface a Jira custom field in the hover card? You will need the field ID, which usually looks like `customfield_12345`.
 
@@ -138,17 +117,6 @@ Here are the easiest ways to find it in your Jira instance:
 - Paste that value into the extension options page under `Custom Fields`
 
 If the field ID is valid, the options page will try to resolve and display the field name for you.
-
-## For developers 👩‍💻
-
-- `jira-plugin/src/` - content script, background logic, and UI behavior
-- `jira-plugin/options/` - options page UI and configuration flow
-- `jira-plugin/manifest.json` - Chrome extension manifest
-- `webpack.config.js` - build pipeline for the extension bundles
-
-## In one sentence 🎉
-
-Jira HotLinker makes every Jira key on the web feel alive, actionable, and useful.
 
 ## Thank you 🙌
 

--- a/jira-plugin/manifest.json
+++ b/jira-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Jira HotLinker",
   "description": "Jira HotLinker, quick access to Jira metadata when hovering over ticket numbers!",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "manifest_version": 3,
   "icons": {
     "128": "resources/jiralink128.png"

--- a/jira-plugin/manifest.json
+++ b/jira-plugin/manifest.json
@@ -27,7 +27,8 @@
     "storage"
   ],
   "options_ui": {
-    "page": "options/options.html"
+    "page": "options/options.html",
+    "open_in_tab": true
   },
   "action": {
     "default_title": "Click to always search for tickets on this page"

--- a/jira-plugin/manifest.json
+++ b/jira-plugin/manifest.json
@@ -32,9 +32,13 @@
   "action": {
     "default_title": "Click to always search for tickets on this page"
   },
-  "content_security_policy": {},
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; base-uri 'self'"
+  },
   "host_permissions": [
-    "https://github.com/",
+    "https://github.com/*"
+  ],
+  "optional_host_permissions": [
     "*://*/*"
   ]
 }

--- a/jira-plugin/options/config.js
+++ b/jira-plugin/options/config.js
@@ -5,6 +5,8 @@ export default {
   instanceUrl: '',
   v15upgrade: false,
   customFields: [],
+  hoverDepth: 'shallow',
+  hoverModifierKey: 'none',
   displayFields: {
     issueType: true,
     status: true,

--- a/jira-plugin/options/config.js
+++ b/jira-plugin/options/config.js
@@ -4,6 +4,7 @@ export default {
   ],
   instanceUrl: '',
   v15upgrade: false,
+  customFields: [],
   displayFields: {
     issueType: true,
     status: true,
@@ -12,7 +13,6 @@ export default {
     fixVersions: true,
     affects: true,
     labels: true,
-    account: true,
     epicParent: true,
     attachments: true,
     comments: true,
@@ -22,4 +22,3 @@ export default {
     pullRequests: true
   }
 };
-

--- a/jira-plugin/options/config.js
+++ b/jira-plugin/options/config.js
@@ -3,6 +3,23 @@ export default {
     'https://github.com/'
   ],
   instanceUrl: '',
-  v15upgrade: false
+  v15upgrade: false,
+  displayFields: {
+    issueType: true,
+    status: true,
+    priority: true,
+    sprint: true,
+    fixVersions: true,
+    affects: true,
+    labels: true,
+    account: true,
+    epicParent: true,
+    attachments: true,
+    comments: true,
+    description: true,
+    reporter: true,
+    assignee: true,
+    pullRequests: true
+  }
 };
 

--- a/jira-plugin/options/declarative.js
+++ b/jira-plugin/options/declarative.js
@@ -1,6 +1,6 @@
 /*global chrome */
 import defaultConfig from 'options/config';
-import {uniqueId} from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 import regexEscape from 'escape-string-regexp';
 import {storageGet} from 'src/chrome';
 

--- a/jira-plugin/options/options.html
+++ b/jira-plugin/options/options.html
@@ -4,9 +4,12 @@
     <title>Jira Hotlinker Options</title>
     <style type="text/css">
         body {
-            min-height: 200px;
-            min-width: 200px;
-            padding: 10px;
+            background: radial-gradient(circle at top, #f7efe3 0%, #eef3fb 46%, #f5f7fb 100%);
+            box-sizing: border-box;
+            margin: 0;
+            min-height: 100vh;
+            min-width: 320px;
+            padding: 0;
         }
     </style>
 </head>

--- a/jira-plugin/options/options.jsx
+++ b/jira-plugin/options/options.jsx
@@ -1,6 +1,7 @@
 /*global chrome */
-import defaultConfig from 'options/config';
+import React, {useEffect, useState} from 'react';
 import ReactDOM from 'react-dom';
+import defaultConfig from 'options/config';
 import {storageGet, storageSet, permissionsRequest} from 'src/chrome';
 import {hasPathSlash, resetDeclarativeMapping, toMatchUrl} from 'options/declarative';
 
@@ -20,7 +21,6 @@ const FIELD_OPTIONS = [
   {key: 'fixVersions', label: 'Fix Version'},
   {key: 'affects', label: 'Affects Version'},
   {key: 'labels', label: 'Labels'},
-  {key: 'account', label: 'Account'},
   {key: 'epicParent', label: 'Epic/Parent'},
   {key: 'attachments', label: 'Attachments'},
   {key: 'comments', label: 'Comments'},
@@ -30,135 +30,407 @@ const FIELD_OPTIONS = [
   {key: 'pullRequests', label: 'Related Pull Requests'}
 ];
 
-function getDisplayFieldValuesFromForm() {
-  const values = {};
-  FIELD_OPTIONS.forEach(({key}) => {
-    const node = document.getElementById(`displayField_${key}`);
-    values[key] = !!(node && node.checked);
-  });
-  return values;
+const FIELD_GROUPS = [
+  {
+    title: 'Top bar - row 1',
+    description: 'Issue identity and triage context shown in the first summary row.',
+    keys: ['issueType', 'status', 'priority', 'epicParent']
+  },
+  {
+    title: 'Top bar - row 2',
+    description: 'Planning and release context shown in the second summary row.',
+    keys: ['sprint', 'affects', 'fixVersions']
+  },
+  {
+    title: 'Top bar - row 3',
+    description: 'Metadata chips shown in the third summary row.',
+    keys: ['labels']
+  },
+  {
+    title: 'Description block',
+    description: 'Rich issue description shown below the summary rows.',
+    keys: ['description']
+  },
+  {
+    title: 'Attachments block',
+    description: 'Image previews and attachment indicators in the body area.',
+    keys: ['attachments']
+  },
+  {
+    title: 'Comments block',
+    description: 'Rendered Jira comments in the body area.',
+    keys: ['comments']
+  },
+  {
+    title: 'People',
+    description: 'Reporter and assignee avatars shown in the title area.',
+    keys: ['reporter', 'assignee']
+  },
+  {
+    title: 'Related development',
+    description: 'Pull request summary table appended beneath the issue content.',
+    keys: ['pullRequests']
+  }
+];
+
+function normalizeInstanceUrl(instanceUrl) {
+  let normalized = String(instanceUrl || '').trim();
+  if (!normalized) {
+    return '';
+  }
+  if (!hasPathSlash.test(normalized)) {
+    normalized += '/';
+  }
+  if (normalized.indexOf('://') === -1) {
+    normalized = 'https://' + normalized;
+  }
+  return normalized;
 }
 
-async function saveOptions() {
-  const status = document.getElementById('status');
-  const setStatus = (message) => {
-    status.textContent = message;
-  };
-  const domains = document.getElementById('domains')
-    .value
-    .split(',')
-    .map(x => x.trim())
-    .filter(x => !!x);
-  let instanceUrl = document.getElementById('instanceUrl').value.trim();
-
-  if (!instanceUrl) {
-    setStatus('You must provide your Jira instance URL.');
-    return;
+function normalizeCustomFields(customFields) {
+  if (!Array.isArray(customFields)) {
+    return [];
   }
-  if (!hasPathSlash.test(instanceUrl)) {
-    instanceUrl = instanceUrl + '/';
-  }
-  if (instanceUrl.indexOf('://') === -1) {
-    instanceUrl = 'https://' + instanceUrl;
-  }
-  document.getElementById('instanceUrl').value = instanceUrl;
-  const permissionDomains = domains.concat([instanceUrl]);
-  const currentInstanceUrl = await storageGet(defaultConfig);
-  if (!currentInstanceUrl.instanceUrl) {
-    domains.push(instanceUrl);
-  }
-
-  let granted;
-  try {
-    granted = await permissionsRequest({'origins': permissionDomains.map(toMatchUrl)});
-  } catch (ex) {
-    setStatus(ex.message);
-    return;
-  }
-
-  if (granted) {
-    await storageSet({
-      instanceUrl,
-      domains,
-      v15upgrade: true,
-      displayFields: getDisplayFieldValuesFromForm()
+  const seen = {};
+  return customFields
+    .map(field => ({
+      fieldId: String(field && field.fieldId || '').trim(),
+      row: Math.min(3, Math.max(1, Number(field && field.row) || 3))
+    }))
+    .filter(field => {
+      if (!field.fieldId || seen[field.fieldId]) {
+        return false;
+      }
+      seen[field.fieldId] = true;
+      return true;
     });
-    resetDeclarativeMapping();
-    setStatus('Options saved.');
-    setTimeout(function () {
-      status.textContent = '';
-    }, 2000);
-  } else {
-    setStatus('Options not saved.');
-    return;
+}
+
+async function fetchFieldCatalog(instanceUrl) {
+  if (!instanceUrl) {
+    return {};
   }
-  document.getElementById('domains').value = domains && domains.join(', ');
-  document.getElementById('upgradeWarning').style.display = 'none';
+  try {
+    const response = await fetch(instanceUrl + 'rest/api/2/field', {
+      credentials: 'include'
+    });
+    if (!response.ok) {
+      return {};
+    }
+    const fields = await response.json();
+    if (!Array.isArray(fields)) {
+      return {};
+    }
+    return fields.reduce((acc, field) => {
+      if (field && field.id) {
+        acc[field.id] = field.name || field.id;
+      }
+      return acc;
+    }, {});
+  } catch (ex) {
+    return {};
+  }
+}
+
+function getCustomFieldError(fieldId, fieldCatalog) {
+  const trimmed = String(fieldId || '').trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (!/^customfield_\d+$/i.test(trimmed)) {
+    return 'Use a Jira custom field ID in the form customfield_12345.';
+  }
+  if (Object.keys(fieldCatalog).length && !fieldCatalog[trimmed]) {
+    return 'This field ID was not found in Jira.';
+  }
+  return '';
 }
 
 async function main() {
   ReactDOM.render(
-    ConfigPage(await storageGet(defaultConfig)), document.getElementById('container')
+    <ConfigPage {...await storageGet(defaultConfig)} />,
+    document.getElementById('container')
   );
 }
 
 function ConfigPage(props) {
-  const displayFields = {
+  const [instanceUrl, setInstanceUrl] = useState(props.instanceUrl || '');
+  const [domainsText, setDomainsText] = useState((props.domains || []).join(', '));
+  const [displayFields, setDisplayFields] = useState({
     ...defaultConfig.displayFields,
     ...(props.displayFields || {})
+  });
+  const [customFields, setCustomFields] = useState(normalizeCustomFields(props.customFields));
+  const [fieldCatalog, setFieldCatalog] = useState({});
+  const [status, setStatus] = useState('');
+  const [statusTone, setStatusTone] = useState('neutral');
+  const [isSaving, setIsSaving] = useState(false);
+  const customFieldErrors = customFields.map(field => getCustomFieldError(field.fieldId, fieldCatalog));
+  const hasInvalidCustomFields = customFieldErrors.some(Boolean);
+
+  useEffect(() => {
+    let cancelled = false;
+    const normalizedInstanceUrl = normalizeInstanceUrl(instanceUrl || props.instanceUrl);
+    fetchFieldCatalog(normalizedInstanceUrl).then(catalog => {
+      if (!cancelled) {
+        setFieldCatalog(catalog);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [instanceUrl, props.instanceUrl]);
+
+  const setDisplayFieldValue = (key, checked) => {
+    setDisplayFields(current => ({
+      ...current,
+      [key]: checked
+    }));
   };
+
+  const updateCustomField = (index, patch) => {
+    setCustomFields(current => current.map((field, fieldIndex) => {
+      if (fieldIndex !== index) {
+        return field;
+      }
+      return {
+        ...field,
+        ...patch
+      };
+    }));
+  };
+
+  const addCustomField = () => {
+    setCustomFields(current => current.concat({fieldId: '', row: 3}));
+  };
+
+  const removeCustomField = (index) => {
+    setCustomFields(current => current.filter((field, fieldIndex) => fieldIndex !== index));
+  };
+
+  const saveOptions = async () => {
+    const domains = domainsText
+      .split(',')
+      .map(x => x.trim())
+      .filter(x => !!x);
+    const normalizedInstanceUrl = normalizeInstanceUrl(instanceUrl);
+
+    if (!normalizedInstanceUrl) {
+      setStatusTone('error');
+      setStatus('You must provide your Jira instance URL.');
+      return;
+    }
+
+    setInstanceUrl(normalizedInstanceUrl);
+
+    const permissionDomains = domains.concat([normalizedInstanceUrl]);
+    const currentInstanceUrl = await storageGet(defaultConfig);
+    if (!currentInstanceUrl.instanceUrl) {
+      domains.push(normalizedInstanceUrl);
+    }
+
+    setIsSaving(true);
+    setStatusTone('neutral');
+    setStatus('Saving changes...');
+
+    let granted;
+    try {
+      granted = await permissionsRequest({'origins': permissionDomains.map(toMatchUrl)});
+    } catch (ex) {
+      setIsSaving(false);
+      setStatusTone('error');
+      setStatus(ex.message);
+      return;
+    }
+
+    if (!granted) {
+      setIsSaving(false);
+      setStatusTone('error');
+      setStatus('Options not saved.');
+      return;
+    }
+
+    await storageSet({
+      instanceUrl: normalizedInstanceUrl,
+      domains,
+      v15upgrade: true,
+      displayFields,
+      customFields: normalizeCustomFields(customFields)
+    });
+    resetDeclarativeMapping();
+    setDomainsText(domains.join(', '));
+    setIsSaving(false);
+    setStatusTone('success');
+    setStatus('Options saved successfully.');
+    setTimeout(() => {
+      setStatusTone('neutral');
+      setStatus('');
+    }, 2500);
+  };
+
   return (
-    <div>
-      {(() => {
-        if (!props.v15upgrade) {
-          return (
-            <label id="upgradeWarning" className='upgradeWarning'>If you recently upgraded the extension make sure to
-              click Save to activate
-              the new reduced permissions !
-              <br/><br/></label>);
-        }
-      })()}
-      <label>
-        Your full Jira instance url: <br/>
-        <input
-          id="instanceUrl"
-          type="text"
-          defaultValue={props.instanceUrl}
-          placeholder="https://your-company.atlassian.net/"/>
-      </label>
-      <br/>
-      <label>
-        Locations where the plugin should be activated, comma separated: <br/>
-        This can be a domain a url or any valid {' '}
-        <strong><a href='https://developer.chrome.com/extensions/match_patterns'>match pattern</a>
-        </strong>.
-        <br/>
-        <textarea id="domains" defaultValue={props.domains && props.domains.join(', ')} placeholder="1 site per line"/>
-        <br/>
-        You can also add new domains at any time by clicking on the extension icon !
-      </label>
-      <div id='status'></div>
-      <br/>
-      <label>
-        Tooltip fields to show:
-      </label>
-      <div className='displayFields'>
-        {FIELD_OPTIONS.map(({key, label}) => (
-          <label key={key} className='displayFieldOption'>
+    <div className='optionsPage'>
+      <header className='heroCard'>
+        <div>
+          <div className='eyebrow'>Jira HotLinker</div>
+          <h1 className='heroTitle'>Extension Options</h1>
+          <p className='heroCopy'>
+            Configure where the extension runs, which built-in ticket fields are visible in the hover card,
+            and any Jira custom fields you want surfaced in rows 1, 2, or 3.
+          </p>
+        </div>
+        <div className='heroMeta'>
+          <div className={'statusPill' + (status ? ' statusPillActive' : '')}>
+            {status || (hasInvalidCustomFields ? 'Fix invalid custom field IDs before saving.' : 'Changes are local until you save them.')}
+          </div>
+          {!props.v15upgrade && (
+            <div className='upgradeNotice'>
+              After upgrading the extension, click Save once to refresh its permissions.
+            </div>
+          )}
+        </div>
+      </header>
+
+      <div className='settingsGrid'>
+        <section className='settingsCard settingsCardWide'>
+          <div className='sectionHeading'>
+            <div>
+              <h2>Connection</h2>
+              <p>Tell the extension which Jira instance to query and where it should activate.</p>
+            </div>
+          </div>
+
+          <label className='formField'>
+            <span className='fieldLabel'>Jira instance URL</span>
             <input
-              id={`displayField_${key}`}
-              type='checkbox'
-              defaultChecked={!!displayFields[key]}
-            />
-            <span>{label}</span>
+              id='instanceUrl'
+              type='text'
+              value={instanceUrl}
+              onChange={event => setInstanceUrl(event.target.value)}
+              placeholder='https://your-company.atlassian.net/'/>
+            <span className='fieldHelp'>Used for issue metadata, field discovery, and link targets.</span>
           </label>
-        ))}
+
+          <label className='formField'>
+            <span className='fieldLabel'>Allowed pages</span>
+            <textarea
+              id='domains'
+              value={domainsText}
+              onChange={event => setDomainsText(event.target.value)}
+              placeholder='github.com, outlook.office.com'/>
+            <span className='fieldHelp'>
+              Comma-separated domains, URLs, or valid <a href='https://developer.chrome.com/extensions/match_patterns'>match patterns</a>.
+              You can also add a page directly from the extension icon.
+            </span>
+          </label>
+        </section>
+
+        <section className='settingsCard settingsCardWide'>
+          <div className='sectionHeading'>
+            <div>
+              <h2>Tooltip Layout</h2>
+              <p>Choose which built-in Jira fields appear in each part of the hover card.</p>
+            </div>
+          </div>
+          <div className='fieldLayoutGroups'>
+            {FIELD_GROUPS.map(group => (
+              <div key={group.title} className='fieldGroupCard'>
+                <div className='fieldGroupHeader'>
+                  <h3>{group.title}</h3>
+                  <p>{group.description}</p>
+                </div>
+                <div className='displayFields'>
+                  {group.keys.map(key => {
+                    const option = FIELD_OPTIONS.find(field => field.key === key);
+                    return (
+                      <label key={key} className='displayFieldOption'>
+                        <input
+                          id={'displayField_' + key}
+                          type='checkbox'
+                          checked={!!displayFields[key]}
+                          onChange={event => setDisplayFieldValue(key, event.target.checked)}
+                        />
+                        <span>{option ? option.label : key}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className='settingsCard settingsCardWide'>
+          <div className='sectionHeading sectionHeadingSplit'>
+            <div>
+              <h2>Custom Fields</h2>
+              <p>Add Jira field IDs and choose where each one appears in the hover summary.</p>
+            </div>
+            <button type='button' className='secondaryButton' onClick={addCustomField}>Add another field</button>
+          </div>
+
+          {customFields.length === 0 ? (
+            <div className='emptyState'>
+              No custom fields configured yet. Add one if you want to surface plugin-provided Jira data in the hover card.
+            </div>
+          ) : (
+            <div className='customFieldsSection'>
+              {customFields.map((field, index) => (
+                <div key={index} className='customFieldRow'>
+                  <div className='customFieldHeader'>Custom field {index + 1}</div>
+                  <label className='customFieldLabel'>
+                    <span className='fieldLabel'>Field ID</span>
+                    <input
+                      type='text'
+                      value={field.fieldId}
+                      onChange={event => updateCustomField(index, {fieldId: event.target.value})}
+                      placeholder='customfield_12345'/>
+                  </label>
+                  <label className='customFieldLabel'>
+                    <span className='fieldLabel'>Location</span>
+                    <select
+                      value={field.row}
+                      onChange={event => updateCustomField(index, {row: Number(event.target.value)})}>
+                      <option value={1}>Top bar - row 1</option>
+                      <option value={2}>Top bar - row 2</option>
+                      <option value={3}>Top bar - row 3</option>
+                    </select>
+                  </label>
+                  <div className={'customFieldMeta' + (customFieldErrors[index] ? ' customFieldMetaError' : '')}>
+                    {customFieldErrors[index]
+                      ? customFieldErrors[index]
+                      : field.fieldId
+                        ? `Resolved field name: ${fieldCatalog[field.fieldId] || 'Waiting for Jira field metadata.'}`
+                        : 'The field name will appear here after Jira returns metadata for this ID.'}
+                  </div>
+                  <button type='button' className='ghostButton customFieldRemove' onClick={() => removeCustomField(index)}>
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
       </div>
-      <br/>
-      <button onClick={saveOptions} id="save">Save</button>
+
+      <footer className='actionBar'>
+        <div className='actionCopy'>
+          <strong>Save changes</strong>
+          <span>Applies the current Jira URL, allowed pages, built-in tooltip fields, and configured custom fields.</span>
+        </div>
+        <div className='actionControls'>
+          {(status || hasInvalidCustomFields) && (
+            <div className={'saveNotice saveNotice' + ((hasInvalidCustomFields && !status) ? 'Error' : statusTone.charAt(0).toUpperCase() + statusTone.slice(1))}>
+              {status || 'Fix invalid custom field IDs before saving.'}
+            </div>
+          )}
+          <button onClick={saveOptions} id='save' className='primaryButton' disabled={isSaving || hasInvalidCustomFields}>
+            {isSaving ? 'Saving...' : 'Save changes'}
+          </button>
+        </div>
+      </footer>
     </div>
   );
 }
 
 document.addEventListener('DOMContentLoaded', main);
-

--- a/jira-plugin/options/options.jsx
+++ b/jira-plugin/options/options.jsx
@@ -160,6 +160,8 @@ function ConfigPage(props) {
     ...defaultConfig.displayFields,
     ...(props.displayFields || {})
   });
+  const [hoverDepth, setHoverDepth] = useState(props.hoverDepth || 'shallow');
+  const [hoverModifierKey, setHoverModifierKey] = useState(props.hoverModifierKey || 'none');
   const [customFields, setCustomFields] = useState(normalizeCustomFields(props.customFields));
   const [fieldCatalog, setFieldCatalog] = useState({});
   const [status, setStatus] = useState('');
@@ -254,6 +256,8 @@ function ConfigPage(props) {
       instanceUrl: normalizedInstanceUrl,
       domains,
       v15upgrade: true,
+      hoverDepth,
+      hoverModifierKey,
       displayFields,
       customFields: normalizeCustomFields(customFields)
     });
@@ -292,7 +296,7 @@ function ConfigPage(props) {
       </header>
 
       <div className='settingsGrid'>
-        <section className='settingsCard settingsCardWide'>
+        <section className='settingsCard'>
           <div className='sectionHeading'>
             <div>
               <h2>Connection</h2>
@@ -321,6 +325,42 @@ function ConfigPage(props) {
             <span className='fieldHelp'>
               Comma-separated domains, URLs, or valid <a href='https://developer.chrome.com/extensions/match_patterns'>match patterns</a>.
               You can also add a page directly from the extension icon.
+            </span>
+          </label>
+        </section>
+
+        <section className='settingsCard'>
+          <div className='sectionHeading'>
+            <div>
+              <h2>Hover Behavior</h2>
+              <p>Control when the tooltip appears as you move the mouse.</p>
+            </div>
+          </div>
+
+          <label className='formField'>
+            <span className='fieldLabel'>Trigger depth</span>
+            <select value={hoverDepth} onChange={event => setHoverDepth(event.target.value)}>
+              <option value='exact' title='Triggers only when the cursor is directly over text or a link containing a Jira key. Least sensitive — best for dense pages.'>Exact — only the hovered element itself</option>
+              <option value='shallow' title='Checks the hovered element and its immediate parent. Good balance between precision and convenience.'>Shallow — hovered element + immediate parent</option>
+              <option value='deep' title='Walks up to 5 levels of parent elements looking for Jira keys. Most sensitive — may trigger on nearby text you did not intend to hover.'>Deep — walk up to 5 ancestor levels (most sensitive)</option>
+            </select>
+            <span className='fieldHelp'>
+              How aggressively the extension searches surrounding DOM elements for Jira issue keys.
+              Use "Exact" if the tooltip triggers too often on pages with dense text.
+            </span>
+          </label>
+
+          <label className='formField'>
+            <span className='fieldLabel'>Modifier key</span>
+            <select value={hoverModifierKey} onChange={event => setHoverModifierKey(event.target.value)}>
+              <option value='none' title='The tooltip appears automatically whenever the cursor rests on a Jira key. No extra keys needed.'>None — hover alone triggers the tooltip</option>
+              <option value='alt' title='Hover over a Jira key, then press Alt to show the tooltip. You can also hold Alt before hovering.'>Alt — press Alt after hovering</option>
+              <option value='ctrl' title='Hover over a Jira key, then press Ctrl to show the tooltip. You can also hold Ctrl before hovering.'>Ctrl — press Ctrl after hovering</option>
+              <option value='shift' title='Hover over a Jira key, then press Shift to show the tooltip. You can also hold Shift before hovering.'>Shift — press Shift after hovering</option>
+            </select>
+            <span className='fieldHelp'>
+              When set, hover over a Jira key and then press the chosen key to reveal the tooltip.
+              You can also hold the key first and then hover. Useful for on-demand activation instead of automatic popups.
             </span>
           </label>
         </section>

--- a/jira-plugin/options/options.jsx
+++ b/jira-plugin/options/options.jsx
@@ -9,11 +9,41 @@ import 'options/options.scss';
 const errorText = document.createElement('div');
 document.body.appendChild(errorText);
 window.onerror = function (msg, file, line, column, error) {
-  errorText.innerHTML = error.stack;
+  errorText.textContent = (error && error.stack) ? error.stack : String(msg || 'Unknown error');
 };
+
+const FIELD_OPTIONS = [
+  {key: 'issueType', label: 'Issue Type'},
+  {key: 'status', label: 'Status'},
+  {key: 'priority', label: 'Priority'},
+  {key: 'sprint', label: 'Sprint'},
+  {key: 'fixVersions', label: 'Fix Version'},
+  {key: 'affects', label: 'Affects Version'},
+  {key: 'labels', label: 'Labels'},
+  {key: 'account', label: 'Account'},
+  {key: 'epicParent', label: 'Epic/Parent'},
+  {key: 'attachments', label: 'Attachments'},
+  {key: 'comments', label: 'Comments'},
+  {key: 'description', label: 'Description'},
+  {key: 'reporter', label: 'Reporter'},
+  {key: 'assignee', label: 'Assignee'},
+  {key: 'pullRequests', label: 'Related Pull Requests'}
+];
+
+function getDisplayFieldValuesFromForm() {
+  const values = {};
+  FIELD_OPTIONS.forEach(({key}) => {
+    const node = document.getElementById(`displayField_${key}`);
+    values[key] = !!(node && node.checked);
+  });
+  return values;
+}
 
 async function saveOptions() {
   const status = document.getElementById('status');
+  const setStatus = (message) => {
+    status.textContent = message;
+  };
   const domains = document.getElementById('domains')
     .value
     .split(',')
@@ -22,7 +52,7 @@ async function saveOptions() {
   let instanceUrl = document.getElementById('instanceUrl').value.trim();
 
   if (!instanceUrl) {
-    status.innerHTML = '<br /><strong>You must provide your jira instance url.</strong>';
+    setStatus('You must provide your Jira instance URL.');
     return;
   }
   if (!hasPathSlash.test(instanceUrl)) {
@@ -42,19 +72,24 @@ async function saveOptions() {
   try {
     granted = await permissionsRequest({'origins': permissionDomains.map(toMatchUrl)});
   } catch (ex) {
-    status.innerHTML = `<br /><strong>${ex.message}</strong>`;
+    setStatus(ex.message);
     return;
   }
 
   if (granted) {
-    await storageSet({instanceUrl, domains, v15upgrade: true});
+    await storageSet({
+      instanceUrl,
+      domains,
+      v15upgrade: true,
+      displayFields: getDisplayFieldValuesFromForm()
+    });
     resetDeclarativeMapping();
-    status.innerHTML = '<br />Options <strong>saved.</strong>';
+    setStatus('Options saved.');
     setTimeout(function () {
       status.textContent = '';
     }, 2000);
   } else {
-    status.innerHTML = '<br /> Options <strong>Not</strong> saved.';
+    setStatus('Options not saved.');
     return;
   }
   document.getElementById('domains').value = domains && domains.join(', ');
@@ -68,6 +103,10 @@ async function main() {
 }
 
 function ConfigPage(props) {
+  const displayFields = {
+    ...defaultConfig.displayFields,
+    ...(props.displayFields || {})
+  };
   return (
     <div>
       {(() => {
@@ -99,6 +138,22 @@ function ConfigPage(props) {
         You can also add new domains at any time by clicking on the extension icon !
       </label>
       <div id='status'></div>
+      <br/>
+      <label>
+        Tooltip fields to show:
+      </label>
+      <div className='displayFields'>
+        {FIELD_OPTIONS.map(({key, label}) => (
+          <label key={key} className='displayFieldOption'>
+            <input
+              id={`displayField_${key}`}
+              type='checkbox'
+              defaultChecked={!!displayFields[key]}
+            />
+            <span>{label}</span>
+          </label>
+        ))}
+      </div>
       <br/>
       <button onClick={saveOptions} id="save">Save</button>
     </div>

--- a/jira-plugin/options/options.scss
+++ b/jira-plugin/options/options.scss
@@ -1,44 +1,437 @@
-  input, textarea {
-  width: 400px;
-  margin: 0px;
-  margin-top: 10px;
-  padding: 5px;
+:root {
+  color: #182230;
+  font-family: 'Segoe UI Variable Text', 'Aptos', 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+}
+
+#container {
+  max-width: 1160px;
+  margin: 0 auto;
+}
+
+.optionsPage {
+  padding: 32px;
+}
+
+.heroCard,
+.settingsCard,
+.actionBar {
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid #d8e0e8;
+  border-radius: 24px;
+  box-shadow: 0 18px 42px rgba(21, 39, 57, 0.08);
+}
+
+.heroCard {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.8fr);
+  gap: 24px;
+  padding: 28px;
+  margin-bottom: 24px;
+  background: linear-gradient(135deg, rgba(255, 250, 240, 0.98), rgba(236, 244, 255, 0.98));
+}
+
+.eyebrow {
+  color: #8b5e34;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.heroTitle {
+  font-size: 34px;
+  line-height: 1.05;
+  margin: 0 0 12px;
+}
+
+.heroCopy {
+  color: #4e5f73;
+  font-size: 15px;
+  line-height: 1.6;
+  margin: 0;
+  max-width: 700px;
+}
+
+.heroMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: flex-start;
+}
+
+.statusPill {
+  align-items: center;
+  background: rgba(24, 34, 48, 0.06);
+  border-radius: 999px;
+  color: #4e5f73;
+  display: inline-flex;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  padding: 10px 14px;
+}
+
+.statusPillActive {
+  background: #dff5e5;
+  color: #135c2b;
+}
+
+.upgradeNotice {
+  background: rgba(255, 240, 204, 0.8);
+  border: 1px solid #f2d38a;
+  border-radius: 16px;
+  color: #6f4c13;
+  font-size: 13px;
+  line-height: 1.5;
+  padding: 14px 16px;
+}
+
+.settingsGrid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.settingsCard {
+  padding: 24px;
+}
+
+.settingsCardWide {
+  grid-column: 1 / -1;
+}
+
+.sectionHeading {
+  margin-bottom: 18px;
+}
+
+.sectionHeading h2 {
+  font-size: 22px;
+  margin: 0 0 6px;
+}
+
+.sectionHeading p {
+  color: #5b6b7f;
+  font-size: 14px;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.sectionHeadingSplit {
+  align-items: start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.formField,
+.customFieldLabel {
+  display: block;
+  width: 100%;
+}
+
+.formField + .formField {
+  margin-top: 18px;
+}
+
+.fieldLabel {
+  color: #213548;
+  display: block;
+  font-size: 13px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.fieldHelp {
+  color: #66778c;
+  display: block;
+  font-size: 13px;
+  line-height: 1.55;
+  margin-top: 8px;
+}
+
+input,
+textarea,
+select {
+  background: #ffffff;
+  border: 1px solid #c8d3df;
+  border-radius: 14px;
+  box-sizing: border-box;
+  color: #182230;
+  font: inherit;
+  margin: 0;
+  min-height: 52px;
+  padding: 12px 14px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+  width: 100%;
+}
+
+select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='none' stroke='%23455a72' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.6' d='M1 1.5l5 5 5-5'/%3E%3C/svg%3E");
+  background-position: right 16px center;
+  background-repeat: no-repeat;
+  background-size: 12px 8px;
+  padding-right: 42px;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: #2f80ed;
+  box-shadow: 0 0 0 4px rgba(47, 128, 237, 0.14);
+  outline: none;
 }
 
 textarea {
-  $base: 20px;
-  $lineColor: #e2e2e2;
-  border-color: $lineColor;
-  line-height: $base + 1;
-  padding: 1px 5px;
-  height: 20 * 7 + 6px;
+  min-height: 150px;
+  resize: vertical;
 }
 
-label {
-  display: block;
-  width: 400px;
+.fieldLayoutGroups {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.upgradeWarning {
-  color: #dd445c;
+.fieldGroupCard {
+  background: #f7f9fc;
+  border: 1px solid #dae3ec;
+  border-radius: 18px;
+  padding: 16px;
+}
+
+.fieldGroupHeader {
+  margin-bottom: 12px;
+}
+
+.fieldGroupHeader h3 {
+  font-size: 16px;
+  margin: 0 0 4px;
+}
+
+.fieldGroupHeader p {
+  color: #66778c;
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0;
 }
 
 .displayFields {
   display: grid;
-  grid-template-columns: repeat(2, minmax(180px, 1fr));
-  gap: 6px 18px;
-  max-width: 640px;
-  margin-top: 8px;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .displayFieldOption {
   align-items: center;
+  background: #f6f8fb;
+  border: 1px solid #d9e1ea;
+  border-radius: 16px;
+  cursor: pointer;
   display: flex;
-  gap: 8px;
+  gap: 10px;
+  min-height: 48px;
+  padding: 0 14px;
+  transition: transform 0.15s ease, border-color 0.15s ease, background 0.15s ease;
   width: auto;
+}
+
+.displayFieldOption:hover {
+  background: #eef4ff;
+  border-color: #b8c9f0;
+  transform: translateY(-1px);
 }
 
 .displayFieldOption input {
   margin: 0;
   width: auto;
+}
+
+.customFieldsSection {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.customFieldRow {
+  align-items: start;
+  background: #f7f9fc;
+  border: 1px solid #dae3ec;
+  border-radius: 18px;
+  display: grid;
+  gap: 12px 14px;
+  grid-template-columns: minmax(240px, 1.5fr) 180px auto;
+  padding: 16px;
+}
+
+.customFieldHeader {
+  color: #5a6a7e;
+  font-size: 12px;
+  font-weight: 700;
+  grid-column: 1 / -1;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.customFieldMeta {
+  grid-column: 1 / 3;
+  color: #64758a;
+  font-size: 13px;
+  line-height: 1.55;
+  margin-top: 2px;
+}
+
+.customFieldMetaError {
+  color: #9d2335;
+}
+
+.customFieldRemove {
+  align-self: center;
+  grid-column: 3;
+  grid-row: 2;
+}
+
+.emptyState {
+  background: linear-gradient(180deg, #fffdf7, #fff7e8);
+  border: 1px dashed #e0c98f;
+  border-radius: 18px;
+  color: #6b5520;
+  font-size: 14px;
+  line-height: 1.6;
+  padding: 18px;
+}
+
+button {
+  appearance: none;
+  border: none;
+  border-radius: 14px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  line-height: 1;
+  padding: 13px 16px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+.primaryButton {
+  background: linear-gradient(135deg, #1f7a5d, #15513f);
+  box-shadow: 0 12px 28px rgba(21, 81, 63, 0.2);
+  color: #ffffff;
+}
+
+.secondaryButton {
+  background: #edf4ff;
+  border: 1px solid #c4d7f7;
+  color: #244f92;
+}
+
+.ghostButton {
+  background: #ffffff;
+  border: 1px solid #d6dee8;
+  color: #415466;
+}
+
+.actionBar {
+  align-items: center;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  margin-top: 22px;
+  padding: 18px 22px;
+  position: sticky;
+  bottom: 20px;
+}
+
+.actionCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.actionCopy strong {
+  font-size: 15px;
+}
+
+.actionCopy span {
+  color: #5f6f83;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+@media (max-width: 960px) {
+  .optionsPage {
+    padding: 18px;
+  }
+
+  .heroCard,
+  .settingsGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .fieldLayoutGroups,
+  .displayFields {
+    grid-template-columns: 1fr;
+  }
+
+  .customFieldRow {
+    grid-template-columns: 1fr;
+  }
+
+  .customFieldMeta,
+  .customFieldRemove {
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .sectionHeadingSplit,
+  .actionBar,
+  .actionControls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
+
+.actionControls {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
+.saveNotice {
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.4;
+  padding: 10px 14px;
+}
+
+.saveNoticeNeutral {
+  background: rgba(24, 34, 48, 0.06);
+  color: #4e5f73;
+}
+
+.saveNoticeSuccess {
+  background: #dff5e5;
+  color: #135c2b;
+}
+
+.saveNoticeError {
+  background: #fde7ea;
+  color: #9d2335;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.78;
+  transform: none;
 }

--- a/jira-plugin/options/options.scss
+++ b/jira-plugin/options/options.scss
@@ -22,3 +22,23 @@ label {
 .upgradeWarning {
   color: #dd445c;
 }
+
+.displayFields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(180px, 1fr));
+  gap: 6px 18px;
+  max-width: 640px;
+  margin-top: 8px;
+}
+
+.displayFieldOption {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  width: auto;
+}
+
+.displayFieldOption input {
+  margin: 0;
+  width: auto;
+}

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -8,7 +8,7 @@
             <img class="_JX_title_user _JX_title_user_assignee" title="Assignee: {{displayName}}" src="{{avatarUrls.48x48}}">
             {{/assignee}}
         </div>
-        <a class="_JX_copyable_link" id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}" target="_blank" rel="noopener noreferrer">{{urlTitle}}</a>
+        <a class="_JX_copyable_link" id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}" target="_blank" rel="noopener noreferrer" title="{{urlHoverTitle}}">{{urlTitle}}</a>
         <button class="_JX_title_copy _JX_copy_link" data-url="{{copyUrl}}" data-ticket="{{copyTicket}}" data-title="{{copyTitle}}">
             <svg width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><path d="M10 19h8V8h-8v11zM8 7.992C8 6.892 8.902 6 10.009 6h7.982C19.101 6 20 6.893 20 7.992v11.016c0 1.1-.902 1.992-2.009 1.992H10.01A2.001 2.001 0 0 1 8 19.008V7.992z"></path><path d="M5 16V4.992C5 3.892 5.902 3 7.009 3H15v13H5zm2 0h8V5H7v11z"></path></g></svg>
         </button>
@@ -18,7 +18,7 @@
         <div class="_JX_status_row _JX_status_row_primary">
             <div class="_JX_status_row_main">
                 {{#row1Chips}}
-                {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</a>{{/linkUrl}}
+                {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</a>{{/linkUrl}}
                 {{^linkUrl}}<span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/linkUrl}}
                 {{/row1Chips}}
             </div>
@@ -34,7 +34,7 @@
         {{#row2Chips.length}}
         <div class="_JX_status_row">
             {{#row2Chips}}
-            {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}">{{text}}</a>{{/linkUrl}}
+            {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{text}}</a>{{/linkUrl}}
             {{^linkUrl}}<span class="_JX_field_chip">{{text}}</span>{{/linkUrl}}
             {{/row2Chips}}
         </div>
@@ -42,7 +42,7 @@
         {{#row3Chips.length}}
         <div class="_JX_status_row">
             {{#row3Chips}}
-            {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}">{{text}}</a>{{/linkUrl}}
+            {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{text}}</a>{{/linkUrl}}
             {{^linkUrl}}<span class="_JX_field_chip">{{text}}</span>{{/linkUrl}}
             {{/row3Chips}}
         </div>
@@ -61,8 +61,8 @@
             <div class="_JX_section_title">Attachments</div>
             {{#previewAttachments}}
             <div data-mime-type="{{mimeType}}" data-url="{{content}}" data-preview-src="{{content}}" class="_JX_thumb">
-                <a href="{{content}}" target="_blank">
-                    <img class="_JX_previewable" data-jx-preview-src="{{content}}" title="{{filename}}" src="{{thumbnail}}">
+                <a href="{{content}}" target="_blank" rel="noopener noreferrer" title="{{linkTitle}}">
+                    <img class="_JX_previewable" data-jx-preview-src="{{content}}" title="{{linkTitle}}" src="{{thumbnail}}">
                     <div class="_JX_thumb_filename">{{filename}}</div>
                     <img class="_JX_file_loader" src="{{loaderGifUrl}}">
                 </a>
@@ -85,7 +85,7 @@
                 <tbody>
                 {{#prs}}
                 <tr>
-                    <td><a href="{{url}}" target="_blank" rel="noopener noreferrer">{{title}}</a></td>
+                    <td><a href="{{url}}" target="_blank" rel="noopener noreferrer" title="{{linkTitle}}">{{title}}</a></td>
                     <td>{{authorName}}</td>
                     <td>{{branchText}}</td>
                     <td><div class="_JX_PR_STATUS _JX_PR_{{status}}">{{status}}</div></td>
@@ -113,3 +113,4 @@
         {{/emptyBodyText}}
     </div>
 </div>
+

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -1,7 +1,7 @@
 <div class="_JX_annotation">
     <div class="_JX_title">
         <img class="_JX_title_user" title="{{reporter.displayName}}" src="{{reporter.avatarUrls.48x48}}">
-        <a id="_JX_title_link" href="{{url}}">{{urlTitle}}</a>
+        <a id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}">{{urlTitle}}</a>
         <button class="_JX_title_copy">
             <svg width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><path d="M10 19h8V8h-8v11zM8 7.992C8 6.892 8.902 6 10.009 6h7.982C19.101 6 20 6.893 20 7.992v11.016c0 1.1-.902 1.992-2.009 1.992H10.01A2.001 2.001 0 0 1 8 19.008V7.992z"></path><path d="M5 16V4.992C5 3.892 5.902 3 7.009 3H15v13H5zm2 0h8V5H7v11z"></path></g></svg>
         </button>
@@ -13,16 +13,16 @@
         <span class="_JX_field_chip">
             {{#status.iconUrl}}<img class="_JX_status_icon" src="{{status.iconUrl}}">{{/status.iconUrl}}{{statusText}}
         </span>
+        <span class="_JX_field_chip">{{sprintText}}</span>
+        <span class="_JX_field_chip">{{fixVersionText}}</span>
+        {{#attachmentChips}}
+        <span class="_JX_field_chip">{{icon}} {{count}}</span>
+        {{/attachmentChips}}
         {{#hasComments}}
         <a class="_JX_field_chip _JX_field_chip_link" target="_blank" href="{{commentUrl}}">
             💬 {{commentsTotal}}
         </a>
         {{/hasComments}}
-        <span class="_JX_field_chip">{{fixVersionText}}</span>
-        <span class="_JX_field_chip">{{sprintText}}</span>
-        {{#attachmentChips}}
-        <span class="_JX_field_chip">{{icon}} {{count}}</span>
-        {{/attachmentChips}}
     </div>
 
     {{#hasBodyContent}}
@@ -35,9 +35,9 @@
         {{#previewAttachments.length}}
         <div class="_JX_description_attachments">
             {{#previewAttachments}}
-            <div data-mime-type="{{mimeType}}" data-url="{{content}}" class="_JX_thumb">
+            <div data-mime-type="{{mimeType}}" data-url="{{content}}" data-preview-src="{{content}}" class="_JX_thumb">
                 <a href="{{content}}" target="_blank">
-                    <img title="{{filename}}" src="{{thumbnail}}">
+                    <img class="_JX_previewable" data-jx-preview-src="{{content}}" title="{{filename}}" src="{{thumbnail}}">
                     <div class="_JX_thumb_filename">{{filename}}</div>
                     <img class="_JX_file_loader" src="{{loaderGifUrl}}">
                 </a>
@@ -45,6 +45,18 @@
             {{/previewAttachments}}
         </div>
         {{/previewAttachments.length}}
+        {{#commentsForDisplay.length}}
+        <div class="_JX_comments">
+            {{#commentsForDisplay}}
+            <div class="_JX_comment">
+                <div class="_JX_comment_meta">
+                    <span class="_JX_comment_author">{{author}}</span> | <span class="_JX_comment_time">{{created}}</span>
+                </div>
+                <div class="_JX_comment_body">{{{bodyHtml}}}</div>
+            </div>
+            {{/commentsForDisplay}}
+        </div>
+        {{/commentsForDisplay.length}}
     </div>
     {{/hasBodyContent}}
 

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -233,8 +233,64 @@
         {{#row3Chips.length}}
         <div class="_JX_status_row">
             {{#row3Chips}}
+            {{#isEditable}}
+            <div class="_JX_field_chip _JX_field_chip_editable_group{{#isEditing}} is-editing{{/isEditing}}">
+                {{#linkUrl}}
+                {{^isEditing}}<a class="_JX_field_chip_link _JX_field_chip_content" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{text}}</a>{{/isEditing}}
+                {{#isEditing}}<span class="_JX_field_chip_content">{{text}}</span>{{/isEditing}}
+                {{/linkUrl}}
+                {{^linkUrl}}<span class="_JX_field_chip_content">{{text}}</span>{{/linkUrl}}
+                <button class="_JX_field_chip_edit" type="button" data-field-key="{{fieldKey}}" title="{{editTitle}}" aria-label="{{editTitle}}">
+                    <svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>
+                </button>
+                {{#isEditing}}
+                <div class="_JX_edit_popover{{#isRightAligned}} _JX_edit_popover_right{{/isRightAligned}}" data-field-key="{{fieldKey}}">
+                    <div class="_JX_edit_field_label">{{editLabel}}</div>
+                    <div class="_JX_edit_input_shell">
+                        <input class="_JX_edit_input" data-field-key="{{fieldKey}}" value="{{inputValue}}" placeholder="{{inputPlaceholder}}" autocomplete="off" {{#inputDisabled}}disabled{{/inputDisabled}}>
+                        {{^showActionButtons}}<button class="_JX_edit_cancel" type="button" data-field-key="{{fieldKey}}" title="Cancel edit">Cancel</button>{{/showActionButtons}}
+                    </div>
+                    {{#showSelectedValues}}
+                    <div class="_JX_edit_selected_values">
+                        {{#selectedValues}}
+                        <span class="_JX_edit_selected_chip" title="{{title}}">{{label}}</span>
+                        {{/selectedValues}}
+                    </div>
+                    {{/showSelectedValues}}
+                    {{#loadingText}}<div class="_JX_edit_hint">{{loadingText}}</div>{{/loadingText}}
+                    <div class="_JX_edit_dropdown">
+                        {{#hasOptions}}
+                        {{#options}}
+                        <button class="_JX_edit_option{{#isSelected}} is-selected{{/isSelected}}" type="button" data-field-key="{{fieldKey}}" data-option-id="{{id}}" title="{{title}}">
+                            {{#isMultiSelect}}<span class="_JX_edit_option_check">{{#isSelected}}✓{{/isSelected}}{{^isSelected}}&nbsp;{{/isSelected}}</span>{{/isMultiSelect}}
+                            {{#avatarUrl}}<img class="_JX_edit_option_avatar" src="{{avatarUrl}}" alt="">{{/avatarUrl}}
+                            {{#iconUrl}}<img class="_JX_edit_option_icon" src="{{iconUrl}}" alt="">{{/iconUrl}}
+                            <span class="_JX_edit_option_text">
+                                <span class="_JX_edit_option_label">{{label}}</span>
+                                {{#metaText}}<span class="_JX_edit_option_meta">{{metaText}}</span>{{/metaText}}
+                            </span>
+                        </button>
+                        {{/options}}
+                        {{/hasOptions}}
+                        {{^hasOptions}}
+                        <div class="_JX_edit_empty">{{editEmptyText}}</div>
+                        {{/hasOptions}}
+                    </div>
+                    {{#showActionButtons}}
+                    <div class="_JX_edit_actions">
+                        <button class="_JX_edit_discard" type="button" data-field-key="{{fieldKey}}" {{#discardDisabled}}disabled{{/discardDisabled}}>Discard</button>
+                        <button class="_JX_edit_save" type="button" data-field-key="{{fieldKey}}" {{#saveDisabled}}disabled{{/saveDisabled}}>Save</button>
+                    </div>
+                    {{/showActionButtons}}
+                    {{#editError}}<div class="_JX_edit_error">{{editError}}</div>{{/editError}}
+                </div>
+                {{/isEditing}}
+            </div>
+            {{/isEditable}}
+            {{^isEditable}}
             {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{text}}</a>{{/linkUrl}}
             {{^linkUrl}}<span class="_JX_field_chip">{{text}}</span>{{/linkUrl}}
+            {{/isEditable}}
             {{/row3Chips}}
         </div>
         {{/row3Chips.length}}

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -35,6 +35,28 @@
     </div>
     {{/description}}
 
+    {{#fixVersions.length}}
+    <div class="_JX_field_group">
+        <div class="_JX_field_label">Fix Version(s)</div>
+        <div class="_JX_field_values">
+            {{#fixVersions}}
+            <span class="_JX_field_chip">{{name}}</span>
+            {{/fixVersions}}
+        </div>
+    </div>
+    {{/fixVersions.length}}
+
+    {{#sprints.length}}
+    <div class="_JX_field_group">
+        <div class="_JX_field_label">Sprint</div>
+        <div class="_JX_field_values">
+            {{#sprints}}
+            <span class="_JX_field_chip">{{name}}{{#state}} ({{state}}){{/state}}</span>
+            {{/sprints}}
+        </div>
+    </div>
+    {{/sprints.length}}
+
     {{#prs.length}}
     <div class="_JX_related_pr">
     <table>

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -9,9 +9,27 @@
             {{/assignee}}
         </div>
         <a class="_JX_copyable_link" id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}" target="_blank" rel="noopener noreferrer">{{urlTitle}}</a>
-        <button class="_JX_title_copy _JX_copy_link" data-url="{{copyUrl}}" data-ticket="{{copyTicket}}" data-title="{{copyTitle}}">
-            <svg width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><path d="M10 19h8V8h-8v11zM8 7.992C8 6.892 8.902 6 10.009 6h7.982C19.101 6 20 6.893 20 7.992v11.016c0 1.1-.902 1.992-2.009 1.992H10.01A2.001 2.001 0 0 1 8 19.008V7.992z"></path><path d="M5 16V4.992C5 3.892 5.902 3 7.009 3H15v13H5zm2 0h8V5H7v11z"></path></g></svg>
-        </button>
+        <div class="_JX_title_controls">
+            <button class="_JX_control_button _JX_title_copy _JX_copy_link" type="button" title="Copy pretty link" aria-label="Copy pretty link" data-url="{{copyUrl}}" data-ticket="{{copyTicket}}" data-title="{{copyTitle}}">
+                <svg width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><path d="M10 19h8V8h-8v11zM8 7.992C8 6.892 8.902 6 10.009 6h7.982C19.101 6 20 6.893 20 7.992v11.016c0 1.1-.902 1.992-2.009 1.992H10.01A2.001 2.001 0 0 1 8 19.008V7.992z"></path><path d="M5 16V4.992C5 3.892 5.902 3 7.009 3H15v13H5zm2 0h8V5H7v11z"></path></g></svg>
+            </button>
+            {{#hasQuickActions}}
+            <div class="_JX_actions">
+                <button class="_JX_control_button _JX_actions_toggle{{#actionsOpen}} is-open{{/actionsOpen}}" type="button" title="Quick actions" aria-label="Quick actions" aria-haspopup="menu" aria-expanded="{{#actionsOpen}}true{{/actionsOpen}}{{^actionsOpen}}false{{/actionsOpen}}">
+                    <svg class="_JX_actions_toggle_icon" width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><circle cx="6" cy="12" r="1.8"></circle><circle cx="12" cy="12" r="1.8"></circle><circle cx="18" cy="12" r="1.8"></circle></g></svg>
+                    <svg class="_JX_actions_toggle_chevron" width="12" height="12" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"></path></svg>
+                </button>
+                {{#actionsOpen}}
+                <div class="_JX_actions_menu" role="menu">
+                    {{#quickActions}}
+                    {{#showDividerBefore}}<div class="_JX_action_divider" role="separator" aria-hidden="true"></div>{{/showDividerBefore}}
+                    <button class="_JX_action_item{{#disabled}} is-disabled{{/disabled}}{{#isLoading}} is-loading{{/isLoading}}" type="button" role="menuitem" data-action-key="{{key}}" {{disabledAttr}}>{{labelText}}</button>
+                    {{/quickActions}}
+                </div>
+                {{/actionsOpen}}
+            </div>
+            {{/hasQuickActions}}
+        </div>
     </div>
     <div class="_JX_status">
         {{#row1Chips.length}}
@@ -47,7 +65,10 @@
             {{/row3Chips}}
         </div>
         {{/row3Chips.length}}
-    </div>
+        </div>
+    {{#hasActionNotice}}
+    <div class="_JX_action_notice {{actionNoticeClass}}">{{actionNoticeText}}</div>
+    {{/hasActionNotice}}
 
     <div class="_JX_description">
         {{#description}}
@@ -113,3 +134,6 @@
         {{/emptyBodyText}}
     </div>
 </div>
+
+
+

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -95,9 +95,10 @@
             </table>
         </div>
         {{/prs.length}}
-        {{#commentsForDisplay.length}}
+        {{#showCommentsSection}}
         <div class="_JX_comments">
             <div class="_JX_section_title">Comments</div>
+            <div class="_JX_comment_list">
             {{#commentsForDisplay}}
             <div class="_JX_comment">
                 <div class="_JX_comment_meta">
@@ -106,10 +107,25 @@
                 <div class="_JX_comment_body">{{{bodyHtml}}}</div>
             </div>
             {{/commentsForDisplay}}
+            </div>
+            {{^commentsForDisplay.length}}
+            <div class="_JX_comments_empty">No comments yet.</div>
+            {{/commentsForDisplay.length}}
+            {{#showCommentComposer}}
+            <div class="_JX_comment_compose" data-saving="false">
+                <textarea class="_JX_comment_input" rows="3" placeholder="Add a comment"></textarea>
+                <div class="_JX_comment_error"></div>
+                <div class="_JX_comment_actions">
+                    <button class="_JX_comment_discard" type="button" disabled>Discard</button>
+                    <button class="_JX_comment_save" type="button" disabled>Save</button>
+                </div>
+            </div>
+            {{/showCommentComposer}}
         </div>
-        {{/commentsForDisplay.length}}
+        {{/showCommentsSection}}
         {{#emptyBodyText}}
         <div class="_JX_empty_body">{{emptyBodyText}}</div>
         {{/emptyBodyText}}
     </div>
 </div>
+

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -53,12 +53,14 @@
 
     <div class="_JX_description">
         {{#description}}
+        <div class="_JX_section_title">Description</div>
         <div class="_JX_description_text">
             {{{description}}}
         </div>
         {{/description}}
         {{#previewAttachments.length}}
         <div class="_JX_description_attachments">
+            <div class="_JX_section_title">Attachments</div>
             {{#previewAttachments}}
             <div data-mime-type="{{mimeType}}" data-url="{{content}}" data-preview-src="{{content}}" class="_JX_thumb">
                 <a href="{{content}}" target="_blank">
@@ -72,6 +74,7 @@
         {{/previewAttachments.length}}
         {{#commentsForDisplay.length}}
         <div class="_JX_comments">
+            <div class="_JX_section_title">Comments</div>
             {{#commentsForDisplay}}
             <div class="_JX_comment">
                 <div class="_JX_comment_meta">

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -14,41 +14,27 @@
         </button>
     </div>
     <div class="_JX_status">
-        {{#statusChips}}
-        <span class="_JX_field_chip">{{text}}</span>
-        {{/statusChips}}
-        {{#epicParentChips}}
-        <span class="_JX_field_chip">{{text}}</span>
-        {{/epicParentChips}}
-        {{#affectsText}}
-        <span class="_JX_field_chip">{{affectsText}}</span>
-        {{/affectsText}}
-        {{#sprintChips}}
-        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
-        {{/sprintChips}}
-        {{#sprintFallbackText}}
-        <span class="_JX_field_chip">{{sprintFallbackText}}</span>
-        {{/sprintFallbackText}}
-        {{#fixVersionChips}}
-        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
-        {{/fixVersionChips}}
-        {{#fixVersionFallbackText}}
-        <span class="_JX_field_chip">{{fixVersionFallbackText}}</span>
-        {{/fixVersionFallbackText}}
-        {{#labelChips}}
-        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
-        {{/labelChips}}
-        {{#accountChips}}
-        <span class="_JX_field_chip">{{text}}</span>
-        {{/accountChips}}
-        {{#attachmentChips}}
-        <span class="_JX_field_chip">{{icon}} {{count}}</span>
-        {{/attachmentChips}}
-        {{#hasComments}}
-        <span class="_JX_field_chip">
-            💬 {{commentsTotal}}
-        </span>
-        {{/hasComments}}
+        {{#row1Chips.length}}
+        <div class="_JX_status_row">
+            {{#row1Chips}}
+            <span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>
+            {{/row1Chips}}
+        </div>
+        {{/row1Chips.length}}
+        {{#row2Chips.length}}
+        <div class="_JX_status_row">
+            {{#row2Chips}}
+            <span class="_JX_field_chip">{{text}}</span>
+            {{/row2Chips}}
+        </div>
+        {{/row2Chips.length}}
+        {{#row3Chips.length}}
+        <div class="_JX_status_row">
+            {{#row3Chips}}
+            <span class="_JX_field_chip">{{text}}</span>
+            {{/row3Chips}}
+        </div>
+        {{/row3Chips.length}}
     </div>
 
     <div class="_JX_description">

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -380,8 +380,14 @@
                 </div>
                 <div class="_JX_comment_error"></div>
                 <div class="_JX_comment_actions">
-                    <button class="_JX_comment_discard" type="button" disabled>Discard</button>
-                    <button class="_JX_comment_save" type="button" disabled>Save</button>
+                    <button type="button" class="_JX_footer_settings _JX_open_options" title="Extension settings">
+                        <svg width="12" height="12" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M19.14 12.94a7.07 7.07 0 0 0 .06-.94c0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.49.49 0 0 0-.59-.22l-2.39.96a7.04 7.04 0 0 0-1.62-.94l-.36-2.54a.48.48 0 0 0-.48-.41h-3.84a.48.48 0 0 0-.48.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.48.48 0 0 0-.59.22L2.74 8.87a.48.48 0 0 0 .12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.37 1.03.7 1.62.94l.36 2.54c.05.24.26.41.48.41h3.84c.24 0 .44-.17.48-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32a.49.49 0 0 0-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1 1 12 8.4a3.6 3.6 0 0 1 0 7.2z"></path></svg>
+                        Extension Settings
+                    </button>
+                    <span class="_JX_comment_actions_buttons">
+                        <button class="_JX_comment_discard" type="button" disabled>Discard</button>
+                        <button class="_JX_comment_save" type="button" disabled>Save</button>
+                    </span>
                 </div>
             </div>
             {{/showCommentComposer}}

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -15,23 +15,35 @@
     </div>
     <div class="_JX_status">
         {{#row1Chips.length}}
-        <div class="_JX_status_row">
-            {{#row1Chips}}
-            <span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>
-            {{/row1Chips}}
+        <div class="_JX_status_row _JX_status_row_primary">
+            <div class="_JX_status_row_main">
+                {{#row1Chips}}
+                {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</a>{{/url}}
+                {{^url}}<span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/url}}
+                {{/row1Chips}}
+            </div>
+            {{#activityIndicators.length}}
+            <div class="_JX_activity_strip">
+                {{#activityIndicators}}
+                <span class="_JX_activity_item" title="{{title}}">{{icon}} <strong>{{count}}</strong></span>
+                {{/activityIndicators}}
+            </div>
+            {{/activityIndicators.length}}
         </div>
         {{/row1Chips.length}}
         {{#row2Chips.length}}
         <div class="_JX_status_row">
             {{#row2Chips}}
-            <span class="_JX_field_chip">{{text}}</span>
+            {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>{{/url}}
+            {{^url}}<span class="_JX_field_chip">{{text}}</span>{{/url}}
             {{/row2Chips}}
         </div>
         {{/row2Chips.length}}
         {{#row3Chips.length}}
         <div class="_JX_status_row">
             {{#row3Chips}}
-            <span class="_JX_field_chip">{{text}}</span>
+            {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>{{/url}}
+            {{^url}}<span class="_JX_field_chip">{{text}}</span>{{/url}}
             {{/row3Chips}}
         </div>
         {{/row3Chips.length}}
@@ -58,6 +70,31 @@
             {{/previewAttachments}}
         </div>
         {{/previewAttachments.length}}
+        {{#prs.length}}
+        <div class="_JX_related_pr">
+            <div class="_JX_section_title">Pull Requests</div>
+            <table>
+                <thead>
+                <tr>
+                    <td>Title</td>
+                    <td>Author</td>
+                    <td>Branch</td>
+                    <td>Status</td>
+                </tr>
+                </thead>
+                <tbody>
+                {{#prs}}
+                <tr>
+                    <td><a href="{{url}}" target="_blank" rel="noopener noreferrer">{{title}}</a></td>
+                    <td>{{authorName}}</td>
+                    <td>{{branchText}}</td>
+                    <td><div class="_JX_PR_STATUS _JX_PR_{{status}}">{{status}}</div></td>
+                </tr>
+                {{/prs}}
+                </tbody>
+            </table>
+        </div>
+        {{/prs.length}}
         {{#commentsForDisplay.length}}
         <div class="_JX_comments">
             <div class="_JX_section_title">Comments</div>
@@ -75,34 +112,4 @@
         <div class="_JX_empty_body">{{emptyBodyText}}</div>
         {{/emptyBodyText}}
     </div>
-
-    {{#prs.length}}
-    <div class="_JX_related_pr">
-    <table>
-        <thead>
-        <tr>
-            <td>#</td>
-            <td>title</td>
-            <td>author</td>
-            <td>status</td>
-        </tr>
-        </thead>
-        <tbody>
-        {{#prs}}
-        <tr>
-            <td><a href="{{url}}">{{id}}</a></td>
-            <td><a href="{{url}}">{{name}}</a></td>
-            <td>
-            <img class="_JX_avatar" title="{{author.name}}" src="{{author.avatar}}">
-            </td>
-            <td>
-            <div class="_JX_PR_STATUS _JX_PR_{{status}}">{{status}}</div>
-            </td>
-        </tr>
-        {{/prs}}
-        </tbody>
-    </table>
-    </div>
-    {{/prs.length}}
-
 </div>

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -1,12 +1,71 @@
 <div class="_JX_annotation">
     <div class="_JX_title">
         <div class="_JX_title_users">
-            {{#reporter}}
-            <img class="_JX_title_user" title="Reporter: {{displayName}}" src="{{avatarUrls.48x48}}">
-            {{/reporter}}
-            {{#assignee}}
-            <img class="_JX_title_user _JX_title_user_assignee" title="Assignee: {{displayName}}" src="{{avatarUrls.48x48}}">
-            {{/assignee}}
+            {{#reporterView}}
+            {{#avatarUrl}}
+            <img class="_JX_title_user" title="{{titleText}}" src="{{avatarUrl}}">
+            {{/avatarUrl}}
+            {{^avatarUrl}}
+            <span class="_JX_title_user _JX_title_user_placeholder" title="{{titleText}}">{{initials}}</span>
+            {{/avatarUrl}}
+            {{/reporterView}}
+            {{#assigneeView}}
+            <div class="_JX_title_assignee_slot{{#isEditable}} is-editable{{/isEditable}}{{#isEditing}} is-editing{{/isEditing}}">
+                {{#avatarUrl}}
+                <img class="_JX_title_user _JX_title_user_assignee" title="{{titleText}}" src="{{avatarUrl}}">
+                {{/avatarUrl}}
+                {{^avatarUrl}}
+                <span class="_JX_title_user _JX_title_user_assignee _JX_title_user_placeholder" title="{{titleText}}">{{initials}}</span>
+                {{/avatarUrl}}
+                {{#isEditable}}
+                <button class="_JX_field_chip_edit _JX_assignee_edit_button" type="button" data-field-key="assignee" title="{{editTitle}}" aria-label="{{editTitle}}">
+                    <svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>
+                </button>
+                {{/isEditable}}
+                {{#isEditing}}
+                <div class="_JX_edit_popover _JX_assignee_edit_popover" data-field-key="assignee">
+                    <div class="_JX_edit_field_label">{{editLabel}}</div>
+                    <div class="_JX_edit_input_shell">
+                        <input class="_JX_edit_input" data-field-key="assignee" value="{{inputValue}}" placeholder="{{inputPlaceholder}}" autocomplete="off" {{#inputDisabled}}disabled{{/inputDisabled}}>
+                        {{^showActionButtons}}<button class="_JX_edit_cancel" type="button" data-field-key="assignee" title="Cancel edit">Cancel</button>{{/showActionButtons}}
+                    </div>
+                    {{#showSelectedValues}}
+                    <div class="_JX_edit_selected_values">
+                        {{#selectedValues}}
+                        <span class="_JX_edit_selected_chip" title="{{title}}">{{label}}</span>
+                        {{/selectedValues}}
+                    </div>
+                    {{/showSelectedValues}}
+                    {{#loadingText}}<div class="_JX_edit_hint">{{loadingText}}</div>{{/loadingText}}
+                    <div class="_JX_edit_dropdown">
+                        {{#hasOptions}}
+                        {{#options}}
+                        <button class="_JX_edit_option{{#isSelected}} is-selected{{/isSelected}}" type="button" data-field-key="assignee" data-option-id="{{id}}" title="{{title}}">
+                            {{#isMultiSelect}}<span class="_JX_edit_option_check">{{#isSelected}}✓{{/isSelected}}{{^isSelected}}&nbsp;{{/isSelected}}</span>{{/isMultiSelect}}
+                            {{#avatarUrl}}<img class="_JX_edit_option_avatar" src="{{avatarUrl}}" alt="">{{/avatarUrl}}
+                            {{#iconUrl}}<img class="_JX_edit_option_icon" src="{{iconUrl}}" alt="">{{/iconUrl}}
+                            <span class="_JX_edit_option_text">
+                                <span class="_JX_edit_option_label">{{label}}</span>
+                                {{#metaText}}<span class="_JX_edit_option_meta">{{metaText}}</span>{{/metaText}}
+                            </span>
+                        </button>
+                        {{/options}}
+                        {{/hasOptions}}
+                        {{^hasOptions}}
+                        <div class="_JX_edit_empty">{{editEmptyText}}</div>
+                        {{/hasOptions}}
+                    </div>
+                    {{#showActionButtons}}
+                    <div class="_JX_edit_actions">
+                        <button class="_JX_edit_discard" type="button" data-field-key="assignee" {{#discardDisabled}}disabled{{/discardDisabled}}>Discard</button>
+                        <button class="_JX_edit_save" type="button" data-field-key="assignee" {{#saveDisabled}}disabled{{/saveDisabled}}>Save</button>
+                    </div>
+                    {{/showActionButtons}}
+                    {{#editError}}<div class="_JX_edit_error">{{editError}}</div>{{/editError}}
+                </div>
+                {{/isEditing}}
+            </div>
+            {{/assigneeView}}
         </div>
         <a class="_JX_copyable_link" id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}" target="_blank" rel="noopener noreferrer" title="{{urlHoverTitle}}">{{urlTitle}}</a>
         <div class="_JX_title_controls">
@@ -33,11 +92,69 @@
     </div>
     <div class="_JX_status">
         {{#row1Chips.length}}
-        <div class="_JX_status_row _JX_status_row_primary">
+            <div class="_JX_status_row _JX_status_row_primary">
             <div class="_JX_status_row_main">
                 {{#row1Chips}}
+                {{#isEditable}}
+                <div class="_JX_field_chip _JX_field_chip_editable_group{{#isEditing}} is-editing{{/isEditing}}">
+                    {{#linkUrl}}
+                    {{^isEditing}}<a class="_JX_field_chip_link _JX_field_chip_content" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</a>{{/isEditing}}
+                    {{#isEditing}}<span class="_JX_field_chip_content">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/isEditing}}
+                    {{/linkUrl}}
+                    {{^linkUrl}}<span class="_JX_field_chip_content">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/linkUrl}}
+                    {{^hideInlineEditButton}}
+                    <button class="_JX_field_chip_edit" type="button" data-field-key="{{fieldKey}}" title="{{editTitle}}" aria-label="{{editTitle}}">
+                        <svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>
+                    </button>
+                    {{/hideInlineEditButton}}
+                    {{#isEditing}}
+                    <div class="_JX_edit_popover{{#isRightAligned}} _JX_edit_popover_right{{/isRightAligned}}" data-field-key="{{fieldKey}}">
+                        <div class="_JX_edit_field_label">{{editLabel}}</div>
+                        <div class="_JX_edit_input_shell">
+                            <input class="_JX_edit_input" data-field-key="{{fieldKey}}" value="{{inputValue}}" placeholder="{{inputPlaceholder}}" autocomplete="off" {{#inputDisabled}}disabled{{/inputDisabled}}>
+                            {{^showActionButtons}}<button class="_JX_edit_cancel" type="button" data-field-key="{{fieldKey}}" title="Cancel edit">Cancel</button>{{/showActionButtons}}
+                        </div>
+                        {{#showSelectedValues}}
+                        <div class="_JX_edit_selected_values">
+                            {{#selectedValues}}
+                            <span class="_JX_edit_selected_chip" title="{{title}}">{{label}}</span>
+                            {{/selectedValues}}
+                        </div>
+                        {{/showSelectedValues}}
+                        {{#loadingText}}<div class="_JX_edit_hint">{{loadingText}}</div>{{/loadingText}}
+                        <div class="_JX_edit_dropdown">
+                            {{#hasOptions}}
+                            {{#options}}
+                            <button class="_JX_edit_option{{#isSelected}} is-selected{{/isSelected}}" type="button" data-field-key="{{fieldKey}}" data-option-id="{{id}}" title="{{title}}">
+                                {{#isMultiSelect}}<span class="_JX_edit_option_check">{{#isSelected}}✓{{/isSelected}}{{^isSelected}}&nbsp;{{/isSelected}}</span>{{/isMultiSelect}}
+                                {{#avatarUrl}}<img class="_JX_edit_option_avatar" src="{{avatarUrl}}" alt="">{{/avatarUrl}}
+                                {{#iconUrl}}<img class="_JX_edit_option_icon" src="{{iconUrl}}" alt="">{{/iconUrl}}
+                                <span class="_JX_edit_option_text">
+                                    <span class="_JX_edit_option_label">{{label}}</span>
+                                    {{#metaText}}<span class="_JX_edit_option_meta">{{metaText}}</span>{{/metaText}}
+                                </span>
+                            </button>
+                            {{/options}}
+                            {{/hasOptions}}
+                            {{^hasOptions}}
+                            <div class="_JX_edit_empty">{{editEmptyText}}</div>
+                            {{/hasOptions}}
+                        </div>
+                        {{#showActionButtons}}
+                        <div class="_JX_edit_actions">
+                            <button class="_JX_edit_discard" type="button" data-field-key="{{fieldKey}}" {{#discardDisabled}}disabled{{/discardDisabled}}>Discard</button>
+                            <button class="_JX_edit_save" type="button" data-field-key="{{fieldKey}}" {{#saveDisabled}}disabled{{/saveDisabled}}>Save</button>
+                        </div>
+                        {{/showActionButtons}}
+                        {{#editError}}<div class="_JX_edit_error">{{editError}}</div>{{/editError}}
+                    </div>
+                    {{/isEditing}}
+                </div>
+                {{/isEditable}}
+                {{^isEditable}}
                 {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</a>{{/linkUrl}}
                 {{^linkUrl}}<span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/linkUrl}}
+                {{/isEditable}}
                 {{/row1Chips}}
             </div>
             {{#activityIndicators.length}}
@@ -82,7 +199,12 @@
                         {{#options}}
                         <button class="_JX_edit_option{{#isSelected}} is-selected{{/isSelected}}" type="button" data-field-key="{{fieldKey}}" data-option-id="{{id}}" title="{{title}}">
                             {{#isMultiSelect}}<span class="_JX_edit_option_check">{{#isSelected}}✓{{/isSelected}}{{^isSelected}}&nbsp;{{/isSelected}}</span>{{/isMultiSelect}}
-                            <span class="_JX_edit_option_label">{{label}}</span>
+                            {{#avatarUrl}}<img class="_JX_edit_option_avatar" src="{{avatarUrl}}" alt="">{{/avatarUrl}}
+                            {{#iconUrl}}<img class="_JX_edit_option_icon" src="{{iconUrl}}" alt="">{{/iconUrl}}
+                            <span class="_JX_edit_option_text">
+                                <span class="_JX_edit_option_label">{{label}}</span>
+                                {{#metaText}}<span class="_JX_edit_option_meta">{{metaText}}</span>{{/metaText}}
+                            </span>
                         </button>
                         {{/options}}
                         {{/hasOptions}}

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -73,6 +73,9 @@
             <button class="_JX_control_button _JX_title_copy _JX_copy_link" type="button" title="Copy issue link" aria-label="Copy issue link" data-url="{{copyUrl}}" data-ticket="{{copyTicket}}" data-title="{{copyTitle}}">
                 <svg width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><path d="M10 19h8V8h-8v11zM8 7.992C8 6.892 8.902 6 10.009 6h7.982C19.101 6 20 6.893 20 7.992v11.016c0 1.1-.902 1.992-2.009 1.992H10.01A2.001 2.001 0 0 1 8 19.008V7.992z"></path><path d="M5 16V4.992C5 3.892 5.902 3 7.009 3H15v13H5zm2 0h8V5H7v11z"></path></g></svg>
             </button>
+            <button class="_JX_control_button _JX_pin_button" type="button" title="Pin tooltip" aria-label="Pin tooltip">
+                <svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z"></path></svg>
+            </button>
             {{#hasQuickActions}}
             <div class="_JX_actions">
                 <button class="_JX_control_button _JX_actions_toggle{{#actionsOpen}} is-open{{/actionsOpen}}" type="button" title="Quick actions" aria-label="Quick actions" aria-haspopup="menu" aria-expanded="{{#actionsOpen}}true{{/actionsOpen}}{{^actionsOpen}}false{{/actionsOpen}}">
@@ -89,6 +92,9 @@
                 {{/actionsOpen}}
             </div>
             {{/hasQuickActions}}
+            <button class="_JX_control_button _JX_close_button" type="button" title="Close (Esc)" aria-label="Close tooltip">
+                <svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M18.3 5.71a1 1 0 0 0-1.41 0L12 10.59 7.11 5.7A1 1 0 0 0 5.7 7.11L10.59 12 5.7 16.89a1 1 0 1 0 1.41 1.41L12 13.41l4.89 4.89a1 1 0 0 0 1.41-1.41L13.41 12l4.89-4.89a1 1 0 0 0 0-1.4z"></path></svg>
+            </button>
         </div>
     </div>
     <div class="_JX_status">

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -7,55 +7,46 @@
         </button>
     </div>
     <div class="_JX_status">
-        {{#issuetype}}
-        <div title="Issue Type">
-            <img class="_JX_status_icon" src="{{iconUrl}}"> {{name}}
-        </div>
-        {{/issuetype}}
-        {{#status}}
-        <div title="Status">
-            <img class="_JX_status_icon" src="{{iconUrl}}"> {{name}}
-        </div>
-        {{/status}}
-        {{#priority}}
-        <div title="Priority">
-            <img class="_JX_status_icon" src="{{iconUrl}}"> {{name}}
-        </div>
-        {{/priority}}
-        {{#comment.total}}
-        <a title="{{comments}}" target="_blank" style="display: block" href="{{commentUrl}}">
-            💬 &nbsp; {{comment.total}}
+        <span class="_JX_field_chip">
+            {{#issuetype.iconUrl}}<img class="_JX_status_icon" src="{{issuetype.iconUrl}}">{{/issuetype.iconUrl}}{{issueTypeText}}
+        </span>
+        <span class="_JX_field_chip">
+            {{#status.iconUrl}}<img class="_JX_status_icon" src="{{status.iconUrl}}">{{/status.iconUrl}}{{statusText}}
+        </span>
+        {{#hasComments}}
+        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" href="{{commentUrl}}">
+            💬 {{commentsTotal}}
         </a>
-        {{/comment.total}}
+        {{/hasComments}}
+        <span class="_JX_field_chip">{{fixVersionText}}</span>
+        <span class="_JX_field_chip">{{sprintText}}</span>
+        {{#attachmentChips}}
+        <span class="_JX_field_chip">{{icon}} {{count}}</span>
+        {{/attachmentChips}}
     </div>
 
-    {{#description}}
+    {{#hasBodyContent}}
     <div class="_JX_description">
-      {{{description}}}
-    </div>
-    {{/description}}
-
-    {{#fixVersions.length}}
-    <div class="_JX_field_group">
-        <div class="_JX_field_label">Fix Version(s)</div>
-        <div class="_JX_field_values">
-            {{#fixVersions}}
-            <span class="_JX_field_chip">{{name}}</span>
-            {{/fixVersions}}
+        {{#description}}
+        <div class="_JX_description_text">
+            {{{description}}}
         </div>
-    </div>
-    {{/fixVersions.length}}
-
-    {{#sprints.length}}
-    <div class="_JX_field_group">
-        <div class="_JX_field_label">Sprint</div>
-        <div class="_JX_field_values">
-            {{#sprints}}
-            <span class="_JX_field_chip">{{name}}{{#state}} ({{state}}){{/state}}</span>
-            {{/sprints}}
+        {{/description}}
+        {{#previewAttachments.length}}
+        <div class="_JX_description_attachments">
+            {{#previewAttachments}}
+            <div data-mime-type="{{mimeType}}" data-url="{{content}}" class="_JX_thumb">
+                <a href="{{content}}" target="_blank">
+                    <img title="{{filename}}" src="{{thumbnail}}">
+                    <div class="_JX_thumb_filename">{{filename}}</div>
+                    <img class="_JX_file_loader" src="{{loaderGifUrl}}">
+                </a>
+            </div>
+            {{/previewAttachments}}
         </div>
+        {{/previewAttachments.length}}
     </div>
-    {{/sprints.length}}
+    {{/hasBodyContent}}
 
     {{#prs.length}}
     <div class="_JX_related_pr">
@@ -85,19 +76,5 @@
     </table>
     </div>
     {{/prs.length}}
-
-    {{#attachments.length}}
-    <div class="_JX_attachments">
-    {{#attachments}}
-    <div data-mime-type="{{mimeType}}" data-url="{{content}}" class="_JX_thumb">
-        <a href="{{content}}" target="_blank">
-        <img title="{{filename}}" src="{{thumbnail}}">
-        <div class="_JX_thumb_filename">{{filename}}</div>
-        <img class="_JX_file_loader" src="{{loaderGifUrl}}">
-        </a>
-    </div>
-    {{/attachments}}
-    </div>
-    {{/attachments.length}}
 
 </div>

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -34,8 +34,43 @@
         {{#row2Chips.length}}
         <div class="_JX_status_row">
             {{#row2Chips}}
+            {{#isEditable}}
+            <div class="_JX_field_chip _JX_field_chip_editable_group{{#isEditing}} is-editing{{/isEditing}}">
+                {{#linkUrl}}
+                {{^isEditing}}<a class="_JX_field_chip_link _JX_field_chip_content" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{text}}</a>{{/isEditing}}
+                {{#isEditing}}<span class="_JX_field_chip_content">{{text}}</span>{{/isEditing}}
+                {{/linkUrl}}
+                {{^linkUrl}}<span class="_JX_field_chip_content">{{text}}</span>{{/linkUrl}}
+                <button class="_JX_field_chip_edit" type="button" data-field-key="{{fieldKey}}" title="{{editTitle}}" aria-label="{{editTitle}}">
+                    <svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>
+                </button>
+                {{#isEditing}}
+                <div class="_JX_edit_popover{{#isRightAligned}} _JX_edit_popover_right{{/isRightAligned}}" data-field-key="{{fieldKey}}">
+                    <div class="_JX_edit_field_label">{{editLabel}}</div>
+                    <div class="_JX_edit_input_shell">
+                        <input class="_JX_edit_input" data-field-key="{{fieldKey}}" value="{{inputValue}}" placeholder="{{inputPlaceholder}}" autocomplete="off" {{#inputDisabled}}disabled{{/inputDisabled}}>
+                        <button class="_JX_edit_cancel" type="button" data-field-key="{{fieldKey}}" title="Cancel edit">Cancel</button>
+                    </div>
+                    {{#loadingText}}<div class="_JX_edit_hint">{{loadingText}}</div>{{/loadingText}}
+                    <div class="_JX_edit_dropdown">
+                        {{#hasOptions}}
+                        {{#options}}
+                        <button class="_JX_edit_option{{#isSelected}} is-selected{{/isSelected}}" type="button" data-field-key="{{fieldKey}}" data-option-id="{{id}}" title="{{title}}">{{label}}</button>
+                        {{/options}}
+                        {{/hasOptions}}
+                        {{^hasOptions}}
+                        <div class="_JX_edit_empty">{{editEmptyText}}</div>
+                        {{/hasOptions}}
+                    </div>
+                    {{#editError}}<div class="_JX_edit_error">{{editError}}</div>{{/editError}}
+                </div>
+                {{/isEditing}}
+            </div>
+            {{/isEditable}}
+            {{^isEditable}}
             {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{text}}</a>{{/linkUrl}}
             {{^linkUrl}}<span class="_JX_field_chip">{{text}}</span>{{/linkUrl}}
+            {{/isEditable}}
             {{/row2Chips}}
         </div>
         {{/row2Chips.length}}
@@ -113,4 +148,3 @@
         {{/emptyBodyText}}
     </div>
 </div>
-

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -67,19 +67,35 @@
                     <div class="_JX_edit_field_label">{{editLabel}}</div>
                     <div class="_JX_edit_input_shell">
                         <input class="_JX_edit_input" data-field-key="{{fieldKey}}" value="{{inputValue}}" placeholder="{{inputPlaceholder}}" autocomplete="off" {{#inputDisabled}}disabled{{/inputDisabled}}>
-                        <button class="_JX_edit_cancel" type="button" data-field-key="{{fieldKey}}" title="Cancel edit">Cancel</button>
+                        {{^showActionButtons}}<button class="_JX_edit_cancel" type="button" data-field-key="{{fieldKey}}" title="Cancel edit">Cancel</button>{{/showActionButtons}}
                     </div>
+                    {{#showSelectedValues}}
+                    <div class="_JX_edit_selected_values">
+                        {{#selectedValues}}
+                        <span class="_JX_edit_selected_chip" title="{{title}}">{{label}}</span>
+                        {{/selectedValues}}
+                    </div>
+                    {{/showSelectedValues}}
                     {{#loadingText}}<div class="_JX_edit_hint">{{loadingText}}</div>{{/loadingText}}
                     <div class="_JX_edit_dropdown">
                         {{#hasOptions}}
                         {{#options}}
-                        <button class="_JX_edit_option{{#isSelected}} is-selected{{/isSelected}}" type="button" data-field-key="{{fieldKey}}" data-option-id="{{id}}" title="{{title}}">{{label}}</button>
+                        <button class="_JX_edit_option{{#isSelected}} is-selected{{/isSelected}}" type="button" data-field-key="{{fieldKey}}" data-option-id="{{id}}" title="{{title}}">
+                            {{#isMultiSelect}}<span class="_JX_edit_option_check">{{#isSelected}}✓{{/isSelected}}{{^isSelected}}&nbsp;{{/isSelected}}</span>{{/isMultiSelect}}
+                            <span class="_JX_edit_option_label">{{label}}</span>
+                        </button>
                         {{/options}}
                         {{/hasOptions}}
                         {{^hasOptions}}
                         <div class="_JX_edit_empty">{{editEmptyText}}</div>
                         {{/hasOptions}}
                     </div>
+                    {{#showActionButtons}}
+                    <div class="_JX_edit_actions">
+                        <button class="_JX_edit_discard" type="button" data-field-key="{{fieldKey}}" {{#discardDisabled}}disabled{{/discardDisabled}}>Discard</button>
+                        <button class="_JX_edit_save" type="button" data-field-key="{{fieldKey}}" {{#saveDisabled}}disabled{{/saveDisabled}}>Save</button>
+                    </div>
+                    {{/showActionButtons}}
                     {{#editError}}<div class="_JX_edit_error">{{editError}}</div>{{/editError}}
                 </div>
                 {{/isEditing}}

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -1,27 +1,53 @@
 <div class="_JX_annotation">
     <div class="_JX_title">
-        <img class="_JX_title_user" title="{{reporter.displayName}}" src="{{reporter.avatarUrls.48x48}}">
-        <a id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}">{{urlTitle}}</a>
-        <button class="_JX_title_copy">
+        <div class="_JX_title_users">
+            {{#reporter}}
+            <img class="_JX_title_user" title="Reporter: {{displayName}}" src="{{avatarUrls.48x48}}">
+            {{/reporter}}
+            {{#assignee}}
+            <img class="_JX_title_user _JX_title_user_assignee" title="Assignee: {{displayName}}" src="{{avatarUrls.48x48}}">
+            {{/assignee}}
+        </div>
+        <a class="_JX_copyable_link" id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}" target="_blank" rel="noopener noreferrer">{{urlTitle}}</a>
+        <button class="_JX_title_copy _JX_copy_link" data-url="{{copyUrl}}" data-ticket="{{copyTicket}}" data-title="{{copyTitle}}">
             <svg width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><path d="M10 19h8V8h-8v11zM8 7.992C8 6.892 8.902 6 10.009 6h7.982C19.101 6 20 6.893 20 7.992v11.016c0 1.1-.902 1.992-2.009 1.992H10.01A2.001 2.001 0 0 1 8 19.008V7.992z"></path><path d="M5 16V4.992C5 3.892 5.902 3 7.009 3H15v13H5zm2 0h8V5H7v11z"></path></g></svg>
         </button>
     </div>
     <div class="_JX_status">
-        <span class="_JX_field_chip">
-            {{#issuetype.iconUrl}}<img class="_JX_status_icon" src="{{issuetype.iconUrl}}">{{/issuetype.iconUrl}}{{issueTypeText}}
-        </span>
-        <span class="_JX_field_chip">
-            {{#status.iconUrl}}<img class="_JX_status_icon" src="{{status.iconUrl}}">{{/status.iconUrl}}{{statusText}}
-        </span>
-        <span class="_JX_field_chip">{{sprintText}}</span>
-        <span class="_JX_field_chip">{{fixVersionText}}</span>
+        {{#statusChips}}
+        <span class="_JX_field_chip">{{text}}</span>
+        {{/statusChips}}
+        {{#epicParentChips}}
+        <span class="_JX_field_chip">{{text}}</span>
+        {{/epicParentChips}}
+        {{#affectsText}}
+        <span class="_JX_field_chip">{{affectsText}}</span>
+        {{/affectsText}}
+        {{#sprintChips}}
+        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
+        {{/sprintChips}}
+        {{#sprintFallbackText}}
+        <span class="_JX_field_chip">{{sprintFallbackText}}</span>
+        {{/sprintFallbackText}}
+        {{#fixVersionChips}}
+        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
+        {{/fixVersionChips}}
+        {{#fixVersionFallbackText}}
+        <span class="_JX_field_chip">{{fixVersionFallbackText}}</span>
+        {{/fixVersionFallbackText}}
+        {{#labelChips}}
+        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>
+        {{/labelChips}}
+        {{#accountChips}}
+        <span class="_JX_field_chip">{{text}}</span>
+        {{/accountChips}}
         {{#attachmentChips}}
         <span class="_JX_field_chip">{{icon}} {{count}}</span>
         {{/attachmentChips}}
         {{#hasComments}}
-        <a class="_JX_field_chip _JX_field_chip_link" target="_blank" href="{{commentUrl}}">
+        <span class="_JX_field_chip">
             💬 {{commentsTotal}}
-        </a>
+        </span>
         {{/hasComments}}
     </div>
 

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -113,7 +113,10 @@
             {{/commentsForDisplay.length}}
             {{#showCommentComposer}}
             <div class="_JX_comment_compose" data-saving="false">
-                <textarea class="_JX_comment_input" rows="3" placeholder="Add a comment"></textarea>
+                <div class="_JX_comment_input_wrap">
+                    <textarea class="_JX_comment_input" rows="3" placeholder="Add a comment. Type @ to mention someone"></textarea>
+                    <div class="_JX_comment_mentions" hidden></div>
+                </div>
                 <div class="_JX_comment_error"></div>
                 <div class="_JX_comment_actions">
                     <button class="_JX_comment_discard" type="button" disabled>Discard</button>
@@ -128,4 +131,5 @@
         {{/emptyBodyText}}
     </div>
 </div>
+
 

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -18,8 +18,8 @@
         <div class="_JX_status_row _JX_status_row_primary">
             <div class="_JX_status_row_main">
                 {{#row1Chips}}
-                {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</a>{{/url}}
-                {{^url}}<span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/url}}
+                {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</a>{{/linkUrl}}
+                {{^linkUrl}}<span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/linkUrl}}
                 {{/row1Chips}}
             </div>
             {{#activityIndicators.length}}
@@ -34,16 +34,16 @@
         {{#row2Chips.length}}
         <div class="_JX_status_row">
             {{#row2Chips}}
-            {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>{{/url}}
-            {{^url}}<span class="_JX_field_chip">{{text}}</span>{{/url}}
+            {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}">{{text}}</a>{{/linkUrl}}
+            {{^linkUrl}}<span class="_JX_field_chip">{{text}}</span>{{/linkUrl}}
             {{/row2Chips}}
         </div>
         {{/row2Chips.length}}
         {{#row3Chips.length}}
         <div class="_JX_status_row">
             {{#row3Chips}}
-            {{#url}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{url}}">{{text}}</a>{{/url}}
-            {{^url}}<span class="_JX_field_chip">{{text}}</span>{{/url}}
+            {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}">{{text}}</a>{{/linkUrl}}
+            {{^linkUrl}}<span class="_JX_field_chip">{{text}}</span>{{/linkUrl}}
             {{/row3Chips}}
         </div>
         {{/row3Chips.length}}

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -51,7 +51,6 @@
         {{/hasComments}}
     </div>
 
-    {{#hasBodyContent}}
     <div class="_JX_description">
         {{#description}}
         <div class="_JX_description_text">
@@ -83,8 +82,10 @@
             {{/commentsForDisplay}}
         </div>
         {{/commentsForDisplay.length}}
+        {{#emptyBodyText}}
+        <div class="_JX_empty_body">{{emptyBodyText}}</div>
+        {{/emptyBodyText}}
     </div>
-    {{/hasBodyContent}}
 
     {{#prs.length}}
     <div class="_JX_related_pr">

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -19,7 +19,8 @@
                 {{/avatarUrl}}
                 {{#isEditable}}
                 <button class="_JX_field_chip_edit _JX_assignee_edit_button" type="button" data-field-key="assignee" title="{{editTitle}}" aria-label="{{editTitle}}">
-                    <svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>
+                    {{^isEditing}}<svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>{{/isEditing}}
+                    {{#isEditing}}<svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M18.3 5.71 12 12l6.3 6.29-1.41 1.41L10.59 13.41 4.29 19.7 2.88 18.29 9.17 12 2.88 5.71 4.29 4.3l6.3 6.29 6.29-6.3z"></path></svg>{{/isEditing}}
                 </button>
                 {{/isEditable}}
                 {{#isEditing}}
@@ -69,7 +70,7 @@
         </div>
         <a class="_JX_copyable_link" id="_JX_title_link" data-ticket="{{ticketKey}}" data-title="{{ticketTitle}}" href="{{url}}" target="_blank" rel="noopener noreferrer" title="{{urlHoverTitle}}">{{urlTitle}}</a>
         <div class="_JX_title_controls">
-            <button class="_JX_control_button _JX_title_copy _JX_copy_link" type="button" title="Copy pretty link" aria-label="Copy pretty link" data-url="{{copyUrl}}" data-ticket="{{copyTicket}}" data-title="{{copyTitle}}">
+            <button class="_JX_control_button _JX_title_copy _JX_copy_link" type="button" title="Copy issue link" aria-label="Copy issue link" data-url="{{copyUrl}}" data-ticket="{{copyTicket}}" data-title="{{copyTitle}}">
                 <svg width="16" height="16" viewBox="0 0 24 24" focusable="false" role="presentation"><g fill="currentColor"><path d="M10 19h8V8h-8v11zM8 7.992C8 6.892 8.902 6 10.009 6h7.982C19.101 6 20 6.893 20 7.992v11.016c0 1.1-.902 1.992-2.009 1.992H10.01A2.001 2.001 0 0 1 8 19.008V7.992z"></path><path d="M5 16V4.992C5 3.892 5.902 3 7.009 3H15v13H5zm2 0h8V5H7v11z"></path></g></svg>
             </button>
             {{#hasQuickActions}}
@@ -104,7 +105,8 @@
                     {{^linkUrl}}<span class="_JX_field_chip_content">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/linkUrl}}
                     {{^hideInlineEditButton}}
                     <button class="_JX_field_chip_edit" type="button" data-field-key="{{fieldKey}}" title="{{editTitle}}" aria-label="{{editTitle}}">
-                        <svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>
+                        {{^isEditing}}<svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>{{/isEditing}}
+                        {{#isEditing}}<svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M18.3 5.71 12 12l6.3 6.29-1.41 1.41L10.59 13.41 4.29 19.7 2.88 18.29 9.17 12 2.88 5.71 4.29 4.3l6.3 6.29 6.29-6.3z"></path></svg>{{/isEditing}}
                     </button>
                     {{/hideInlineEditButton}}
                     {{#isEditing}}
@@ -153,7 +155,7 @@
                 {{/isEditable}}
                 {{^isEditable}}
                 {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</a>{{/linkUrl}}
-                {{^linkUrl}}<span class="_JX_field_chip">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/linkUrl}}
+                {{^linkUrl}}<span class="_JX_field_chip" title="{{chipTitle}}">{{#iconUrl}}<img class="_JX_status_icon" src="{{iconUrl}}">{{/iconUrl}}{{text}}</span>{{/linkUrl}}
                 {{/isEditable}}
                 {{/row1Chips}}
             </div>
@@ -177,7 +179,8 @@
                 {{/linkUrl}}
                 {{^linkUrl}}<span class="_JX_field_chip_content">{{text}}</span>{{/linkUrl}}
                 <button class="_JX_field_chip_edit" type="button" data-field-key="{{fieldKey}}" title="{{editTitle}}" aria-label="{{editTitle}}">
-                    <svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>
+                    {{^isEditing}}<svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>{{/isEditing}}
+                    {{#isEditing}}<svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M18.3 5.71 12 12l6.3 6.29-1.41 1.41L10.59 13.41 4.29 19.7 2.88 18.29 9.17 12 2.88 5.71 4.29 4.3l6.3 6.29 6.29-6.3z"></path></svg>{{/isEditing}}
                 </button>
                 {{#isEditing}}
                 <div class="_JX_edit_popover{{#isRightAligned}} _JX_edit_popover_right{{/isRightAligned}}" data-field-key="{{fieldKey}}">
@@ -225,7 +228,7 @@
             {{/isEditable}}
             {{^isEditable}}
             {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{text}}</a>{{/linkUrl}}
-            {{^linkUrl}}<span class="_JX_field_chip">{{text}}</span>{{/linkUrl}}
+            {{^linkUrl}}<span class="_JX_field_chip" title="{{chipTitle}}">{{text}}</span>{{/linkUrl}}
             {{/isEditable}}
             {{/row2Chips}}
         </div>
@@ -241,7 +244,8 @@
                 {{/linkUrl}}
                 {{^linkUrl}}<span class="_JX_field_chip_content">{{text}}</span>{{/linkUrl}}
                 <button class="_JX_field_chip_edit" type="button" data-field-key="{{fieldKey}}" title="{{editTitle}}" aria-label="{{editTitle}}">
-                    <svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>
+                    {{^isEditing}}<svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zm17.71-10.04a.996.996 0 0 0 0-1.41L18.2 3.29a.996.996 0 1 0-1.41 1.41l2.51 2.51a.996.996 0 0 0 1.41 0z"></path></svg>{{/isEditing}}
+                    {{#isEditing}}<svg width="14" height="14" viewBox="0 0 24 24" focusable="false" role="presentation"><path fill="currentColor" d="M18.3 5.71 12 12l6.3 6.29-1.41 1.41L10.59 13.41 4.29 19.7 2.88 18.29 9.17 12 2.88 5.71 4.29 4.3l6.3 6.29 6.29-6.3z"></path></svg>{{/isEditing}}
                 </button>
                 {{#isEditing}}
                 <div class="_JX_edit_popover{{#isRightAligned}} _JX_edit_popover_right{{/isRightAligned}}" data-field-key="{{fieldKey}}">
@@ -289,7 +293,7 @@
             {{/isEditable}}
             {{^isEditable}}
             {{#linkUrl}}<a class="_JX_field_chip _JX_field_chip_link" target="_blank" rel="noopener noreferrer" href="{{linkUrl}}" title="{{linkTitle}}">{{text}}</a>{{/linkUrl}}
-            {{^linkUrl}}<span class="_JX_field_chip">{{text}}</span>{{/linkUrl}}
+            {{^linkUrl}}<span class="_JX_field_chip" title="{{chipTitle}}">{{text}}</span>{{/linkUrl}}
             {{/isEditable}}
             {{/row3Chips}}
         </div>

--- a/jira-plugin/resources/annotation.html
+++ b/jira-plugin/resources/annotation.html
@@ -116,6 +116,7 @@
                 <div class="_JX_comment_input_wrap">
                     <textarea class="_JX_comment_input" rows="3" placeholder="Add a comment. Type @ to mention someone"></textarea>
                     <div class="_JX_comment_mentions" hidden></div>
+                    <div class="_JX_comment_uploads" hidden></div>
                 </div>
                 <div class="_JX_comment_error"></div>
                 <div class="_JX_comment_actions">
@@ -126,10 +127,9 @@
             {{/showCommentComposer}}
         </div>
         {{/showCommentsSection}}
-        {{#emptyBodyText}}
-        <div class="_JX_empty_body">{{emptyBodyText}}</div>
-        {{/emptyBodyText}}
+
     </div>
 </div>
+
 
 

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -80,13 +80,14 @@ async function notifyTab(tabId, message) {
   return false;
 }
 
-async function fetchWithCredentials(url) {
+async function fetchWithCredentials(url, init = {}) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
   try {
     const response = await fetch(url, {
       credentials: 'include',
+      ...init,
       signal: controller.signal
     });
     if (!response.ok) {
@@ -160,6 +161,42 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     return SEND_RESPONSE_IS_ASYNC;
   }
 
+  if (request.action === 'requestJson') {
+    const method = String(request.method || 'POST').toUpperCase();
+    const allowedMethods = ['POST', 'PUT', 'PATCH', 'DELETE'];
+    if (allowedMethods.indexOf(method) === -1) {
+      sendResponse({error: 'Unsupported request method'});
+      return false;
+    }
+
+    assertAllowedRequestUrl(request.url)
+      .then(url => fetchWithCredentials(url, {
+        method,
+        headers: {
+          'Accept': 'application/json, text/plain, */*',
+          'Content-Type': 'application/json'
+        },
+        body: typeof request.body === 'undefined' ? undefined : JSON.stringify(request.body)
+      }))
+      .then(async response => {
+        const raw = await response.text();
+        if (!raw) {
+          sendResponse({ result: null });
+          return;
+        }
+
+        try {
+          sendResponse({ result: JSON.parse(raw) });
+        } catch (ex) {
+          sendResponse({ result: raw });
+        }
+      })
+      .catch(error => {
+        sendResponse({ error: error.message });
+      });
+    return SEND_RESPONSE_IS_ASYNC;
+  }
+
   return false;
 });
 
@@ -202,6 +239,4 @@ async function browserOnClicked (tab) {
     browserOnClicked(tab).catch(() => {});
   });
 })();
-
-
 

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -7,9 +7,28 @@ const executeScript = promisifyChrome(chrome.scripting, 'executeScript');
 const sendMessage = promisifyChrome(chrome.tabs, 'sendMessage');
 
 var SEND_RESPONSE_IS_ASYNC = true;
+
+async function fetchWithCredentials(url) {
+  const response = await fetch(url, {credentials: 'include'});
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} - ${response.statusText}`);
+  }
+  return response;
+}
+
+async function blobToDataUrl(blob) {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return `data:${blob.type || 'application/octet-stream'};base64,${btoa(binary)}`;
+}
+
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.action === 'get') {
-    fetch(request.url)
+    fetchWithCredentials(request.url)
       .then(async response => {
         if (!response.ok) {
           throw new Error(`HTTP ${response.status} – ${response.statusText}`);
@@ -22,6 +41,22 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
           ? await response.json()
           : await response.text();
         sendResponse({ result });
+      })
+      .catch(error => {
+        sendResponse({ error: error.message });
+      });
+    return SEND_RESPONSE_IS_ASYNC;
+  }
+
+  if (request.action === 'getImageDataUrl') {
+    fetchWithCredentials(request.url)
+      .then(async response => {
+        const contentType = response.headers.get('Content-Type') || '';
+        if (!contentType.startsWith('image/')) {
+          throw new Error(`Expected image content but got: ${contentType || 'unknown'}`);
+        }
+        const dataUrl = await blobToDataUrl(await response.blob());
+        sendResponse({ result: dataUrl });
       })
       .catch(error => {
         sendResponse({ error: error.message });

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -8,7 +8,7 @@ const sendMessage = promisifyChrome(chrome.tabs, 'sendMessage');
 
 var SEND_RESPONSE_IS_ASYNC = true;
 const EXTENSION_ORIGIN = new URL(chrome.runtime.getURL('')).origin;
-const FETCH_TIMEOUT_MS = 1000;
+const FETCH_TIMEOUT_MS = 10000;
 
 async function getInstanceOrigin() {
   const {instanceUrl} = await storageGet(defaultConfig);
@@ -199,9 +199,9 @@ async function browserOnClicked (tab) {
   });
 
   chrome.action.onClicked.addListener(tab => {
-    browserOnClicked(tab).catch( (err) => {
-      console.log('Error: ', err)
-    });
+    browserOnClicked(tab).catch(() => {});
   });
 })();
+
+
 

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -98,7 +98,7 @@ async function browserOnClicked (tab) {
     await storageSet(config);
     await resetDeclarativeMapping();
     await executeScript({
-      target: {tabId: null},
+      target: {tabId: tab.id},
       files: [contentScript]
     });
     await sendMessage(tab.id, {

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -247,6 +247,12 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     return SEND_RESPONSE_IS_ASYNC;
   }
 
+  if (request.action === 'openOptionsPage') {
+    chrome.runtime.openOptionsPage();
+    sendResponse({result: true});
+    return false;
+  }
+
   return false;
 });
 

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -114,6 +114,19 @@ async function blobToDataUrl(blob) {
   return `data:${blob.type || 'application/octet-stream'};base64,${btoa(binary)}`;
 }
 
+function attachmentBytesToBlob(bytes, type = 'application/octet-stream') {
+  if (Array.isArray(bytes)) {
+    return new Blob([Uint8Array.from(bytes)], {type});
+  }
+  if (ArrayBuffer.isView(bytes)) {
+    return new Blob([bytes], {type});
+  }
+  if (bytes instanceof ArrayBuffer) {
+    return new Blob([bytes], {type});
+  }
+  throw new Error('Attachment payload must be a byte array');
+}
+
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   try {
     validateMessageSender(sender);
@@ -154,6 +167,43 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         }
         const dataUrl = await blobToDataUrl(await response.blob());
         sendResponse({ result: dataUrl });
+      })
+      .catch(error => {
+        sendResponse({ error: error.message });
+      });
+    return SEND_RESPONSE_IS_ASYNC;
+  }
+
+  if (request.action === 'uploadAttachment') {
+    assertAllowedRequestUrl(request.url)
+      .then(url => {
+        const formData = new FormData();
+        formData.append(
+          'file',
+          attachmentBytesToBlob(request.bytes, request.contentType || 'application/octet-stream'),
+          request.fileName || 'pasted-image.png'
+        );
+        return fetchWithCredentials(url, {
+          method: 'POST',
+          headers: {
+            'Accept': 'application/json, text/plain, */*',
+            'X-Atlassian-Token': 'no-check'
+          },
+          body: formData
+        });
+      })
+      .then(async response => {
+        const raw = await response.text();
+        if (!raw) {
+          sendResponse({ result: null });
+          return;
+        }
+
+        try {
+          sendResponse({ result: JSON.parse(raw) });
+        } catch (ex) {
+          sendResponse({ result: raw });
+        }
       })
       .catch(error => {
         sendResponse({ error: error.message });
@@ -239,4 +289,5 @@ async function browserOnClicked (tab) {
     browserOnClicked(tab).catch(() => {});
   });
 })();
+
 

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -7,6 +7,77 @@ const executeScript = promisifyChrome(chrome.scripting, 'executeScript');
 const sendMessage = promisifyChrome(chrome.tabs, 'sendMessage');
 
 var SEND_RESPONSE_IS_ASYNC = true;
+const EXTENSION_ORIGIN = new URL(chrome.runtime.getURL('')).origin;
+
+async function getInstanceOrigin() {
+  const {instanceUrl} = await storageGet(defaultConfig);
+  if (!instanceUrl) {
+    return null;
+  }
+  try {
+    return new URL(instanceUrl).origin;
+  } catch (ex) {
+    return null;
+  }
+}
+
+async function assertAllowedRequestUrl(rawUrl, {allowExtension = false} = {}) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch (ex) {
+    throw new Error('Invalid request URL');
+  }
+
+  if (allowExtension && parsed.origin === EXTENSION_ORIGIN) {
+    return parsed.toString();
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error('Unsupported URL protocol');
+  }
+
+  const instanceOrigin = await getInstanceOrigin();
+  if (!instanceOrigin || parsed.origin !== instanceOrigin) {
+    throw new Error('URL is outside configured Jira instance');
+  }
+
+  return parsed.toString();
+}
+
+function validateMessageSender(sender) {
+  if (!sender || sender.id !== chrome.runtime.id) {
+    throw new Error('Rejected sender');
+  }
+}
+
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+async function ensureContentScriptReady(tabId) {
+  await executeScript({
+    target: {tabId},
+    files: [contentScript]
+  });
+}
+
+async function notifyTab(tabId, message) {
+  const maxAttempts = 3;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      if (attempt > 0) {
+        await ensureContentScriptReady(tabId);
+      }
+      await sendMessage(tabId, {
+        action: 'message',
+        message
+      });
+      return true;
+    } catch (ex) {
+      await delay(80);
+    }
+  }
+  return false;
+}
 
 async function fetchWithCredentials(url) {
   const response = await fetch(url, {credentials: 'include'});
@@ -27,8 +98,16 @@ async function blobToDataUrl(blob) {
 }
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+  try {
+    validateMessageSender(sender);
+  } catch (error) {
+    sendResponse({error: error.message});
+    return false;
+  }
+
   if (request.action === 'get') {
-    fetchWithCredentials(request.url)
+    assertAllowedRequestUrl(request.url, {allowExtension: true})
+      .then(fetchWithCredentials)
       .then(async response => {
         if (!response.ok) {
           throw new Error(`HTTP ${response.status} – ${response.statusText}`);
@@ -49,7 +128,8 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   }
 
   if (request.action === 'getImageDataUrl') {
-    fetchWithCredentials(request.url)
+    assertAllowedRequestUrl(request.url)
+      .then(fetchWithCredentials)
       .then(async response => {
         const contentType = response.headers.get('Content-Type') || '';
         if (!contentType.startsWith('image/')) {
@@ -63,9 +143,14 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       });
     return SEND_RESPONSE_IS_ASYNC;
   }
+
+  return false;
 });
 
 async function browserOnClicked (tab) {
+  if (!tab || !tab.id || !tab.url || !/^https?:\/\//i.test(tab.url)) {
+    return;
+  }
   const config = await storageGet(defaultConfig);
   if (!config.instanceUrl || !config.v15upgrade) {
     chrome.runtime.openOptionsPage();
@@ -76,35 +161,14 @@ async function browserOnClicked (tab) {
   if (granted) {
     const config = await storageGet(defaultConfig);
     if (config.domains.indexOf(origin) !== -1) {
-      try {
-        await sendMessage(tab.id, {
-          action: 'message',
-          message: origin + ' is already added.'
-        });
-      } catch (ex) {
-        // extension was just installed and not injected on this tab yet
-        await executeScript({
-          target: {tabId: tab.id},
-          files: [contentScript]
-        });
-        await sendMessage(tab.id, {
-          action: 'message',
-          message: 'Jira HotLinker enabled successfully !'
-        });
-      }
+      await notifyTab(tab.id, origin + ' is already added.');
       return;
     }
     config.domains.push(origin);
     await storageSet(config);
     await resetDeclarativeMapping();
-    await executeScript({
-      target: {tabId: tab.id},
-      files: [contentScript]
-    });
-    await sendMessage(tab.id, {
-      action: 'message',
-      message: origin + ' added successfully !'
-    });
+    await ensureContentScriptReady(tab.id);
+    await notifyTab(tab.id, origin + ' added successfully !');
   }
 }
 

--- a/jira-plugin/src/background.js
+++ b/jira-plugin/src/background.js
@@ -8,6 +8,7 @@ const sendMessage = promisifyChrome(chrome.tabs, 'sendMessage');
 
 var SEND_RESPONSE_IS_ASYNC = true;
 const EXTENSION_ORIGIN = new URL(chrome.runtime.getURL('')).origin;
+const FETCH_TIMEOUT_MS = 1000;
 
 async function getInstanceOrigin() {
   const {instanceUrl} = await storageGet(defaultConfig);
@@ -80,11 +81,26 @@ async function notifyTab(tabId, message) {
 }
 
 async function fetchWithCredentials(url) {
-  const response = await fetch(url, {credentials: 'include'});
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status} - ${response.statusText}`);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      credentials: 'include',
+      signal: controller.signal
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} - ${response.statusText}`);
+    }
+    return response;
+  } catch (error) {
+    if (error && error.name === 'AbortError') {
+      throw new Error(`Request timed out after ${FETCH_TIMEOUT_MS}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
   }
-  return response;
 }
 
 async function blobToDataUrl(blob) {
@@ -188,3 +204,4 @@ async function browserOnClicked (tab) {
     });
   });
 })();
+

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -206,6 +206,8 @@ async function mainAsyncLocal() {
     pullRequests: true,
     ...(config.displayFields || {})
   };
+  const hoverDepth = config.hoverDepth || 'shallow';
+  const hoverModifierKey = config.hoverModifierKey || 'none';
   const customFields = normalizeCustomFields(config.customFields);
   let jiraProjects = [];
   let getJiraKeys = buildFallbackJiraKeyMatcher();
@@ -4958,6 +4960,122 @@ async function mainAsyncLocal() {
       clearTimeout(hideTimeOut);
     }
   });
+  function extractKeysFromNode(node) {
+    let keys = getJiraKeys(getShallowText(node));
+    if (!size(keys) && node.children.length < 10) {
+      const fullText = (node.textContent || '');
+      if (fullText.length < 200) {
+        keys = getJiraKeys(fullText);
+      }
+    }
+    if (!size(keys) && node.href) {
+      keys = getJiraKeys(getRelativeHref(node.href));
+    }
+    return keys;
+  }
+
+  function detectJiraKeysAtPoint(element) {
+    let keys = extractKeysFromNode(element);
+    if (!size(keys) && element.parentElement && element.parentElement.href) {
+      keys = getJiraKeys(getRelativeHref(element.parentElement.href));
+    }
+    if (hoverDepth === 'exact') {
+      return keys;
+    }
+    const maxAncestors = hoverDepth === 'deep' ? 5 : 1;
+    if (!size(keys)) {
+      let ancestor = element.parentElement;
+      for (let i = 0; i < maxAncestors && ancestor && !size(keys); i++) {
+        if (ancestor === document.body) break;
+        keys = getJiraKeys(getShallowText(ancestor));
+        if (!size(keys) && ancestor.children.length < 20) {
+          const ancestorText = (ancestor.textContent || '');
+          if (ancestorText.length < 300) {
+            keys = getJiraKeys(ancestorText);
+          }
+        }
+        if (!size(keys) && ancestor.href) {
+          keys = getJiraKeys(getRelativeHref(ancestor.href));
+        }
+        ancestor = ancestor.parentElement;
+      }
+    }
+    return keys;
+  }
+
+  let pendingHover = null;
+
+  function isModifierSatisfied(e) {
+    if (hoverModifierKey === 'alt') return e.altKey;
+    if (hoverModifierKey === 'ctrl') return e.ctrlKey;
+    if (hoverModifierKey === 'shift') return e.shiftKey;
+    return true;
+  }
+
+  function triggerPopupForKey(key, pointerX, pointerY) {
+    clearTimeout(hoverDelayTimeout);
+    lastHoveredKey = key;
+    pendingHover = null;
+    hoverDelayTimeout = setTimeout(function () {
+      (async function (cancelToken) {
+        const issueData = await getIssueMetaData(key);
+        await normalizeIssueImages(issueData);
+        let pullRequests = [];
+        if (displayFields.pullRequests) {
+          try {
+            const pullRequestResponse = await getPullRequestDataCached(issueData.id);
+            pullRequests = normalizePullRequests(pullRequestResponse);
+          } catch (ex) {
+            console.log('[Jira HotLinker] Pull request fetch failed', {
+              issueKey: key,
+              issueId: issueData.id,
+              error: ex?.message || String(ex)
+            });
+          }
+        }
+
+        if (cancelToken.cancel) {
+          return;
+        }
+        let quickActions = [];
+        try {
+          quickActions = await resolveQuickActions(issueData);
+        } catch (ex) {
+          quickActions = [];
+        }
+
+        popupState = {
+          key,
+          issueData,
+          pullRequests,
+          pointerX,
+          pointerY,
+          quickActions,
+          actionsOpen: false,
+          actionLoadingKey: '',
+          actionError: '',
+          lastActionSuccess: '',
+          editState: null
+        };
+        await renderIssuePopup(popupState);
+      })(cancelToken).catch((error) => {
+        notifyJiraConnectionFailure(INSTANCE_URL, error);
+        lastHoveredKey = '';
+      });
+    }, 400);
+  }
+
+  if (hoverModifierKey !== 'none') {
+    document.addEventListener('keydown', function (e) {
+      if (!pendingHover || containerPinned) {
+        return;
+      }
+      if (isModifierSatisfied(e)) {
+        triggerPopupForKey(pendingHover.key, pendingHover.pointerX, pendingHover.pointerY);
+      }
+    });
+  }
+
   $(document.body).on('mousemove', debounce(function (e) {
     if (e.buttons || cancelToken.cancel) {
       return;
@@ -4969,40 +5087,18 @@ async function mainAsyncLocal() {
       return;
     }
     if (element) {
-      let keys = getJiraKeys(getShallowText(element));
-      if (!size(keys) && element.children.length < 10) {
-        const fullText = (element.textContent || '');
-        if (fullText.length < 200) {
-          keys = getJiraKeys(fullText);
-        }
-      }
-      if (!size(keys) && element.href) {
-        keys = getJiraKeys(getRelativeHref(element.href));
-      }
-      if (!size(keys) && element.parentElement && element.parentElement.href) {
-        keys = getJiraKeys(getRelativeHref(element.parentElement.href));
-      }
-      if (!size(keys)) {
-        let ancestor = element.parentElement;
-        for (let i = 0; i < 5 && ancestor && !size(keys); i++) {
-          if (ancestor === document.body) break;
-          keys = getJiraKeys(getShallowText(ancestor));
-          if (!size(keys) && ancestor.children.length < 20) {
-            const ancestorText = (ancestor.textContent || '');
-            if (ancestorText.length < 300) {
-              keys = getJiraKeys(ancestorText);
-            }
-          }
-          if (!size(keys) && ancestor.href) {
-            keys = getJiraKeys(getRelativeHref(ancestor.href));
-          }
-          ancestor = ancestor.parentElement;
-        }
-      }
+      const keys = detectJiraKeysAtPoint(element);
 
       if (size(keys)) {
-        clearTimeout(hideTimeOut);
         const key = keys[0].replace(' ', '-');
+
+        if (hoverModifierKey !== 'none' && !isModifierSatisfied(e)) {
+          pendingHover = {key, pointerX: e.pageX, pointerY: e.pageY};
+          return;
+        }
+        pendingHover = null;
+
+        clearTimeout(hideTimeOut);
         if (lastHoveredKey === key && container.html()) {
           if (popupState) {
             popupState = {
@@ -5016,58 +5112,9 @@ async function mainAsyncLocal() {
           }
           return;
         }
-        clearTimeout(hoverDelayTimeout);
-        lastHoveredKey = key;
-        const pointerX = e.pageX;
-        const pointerY = e.pageY;
-        hoverDelayTimeout = setTimeout(function () {
-          (async function (cancelToken) {
-            const issueData = await getIssueMetaData(key);
-            await normalizeIssueImages(issueData);
-            let pullRequests = [];
-            if (displayFields.pullRequests) {
-              try {
-                const pullRequestResponse = await getPullRequestDataCached(issueData.id);
-                pullRequests = normalizePullRequests(pullRequestResponse);
-              } catch (ex) {
-                console.log('[Jira HotLinker] Pull request fetch failed', {
-                  issueKey: key,
-                  issueId: issueData.id,
-                  error: ex?.message || String(ex)
-                });
-              }
-            }
-
-            if (cancelToken.cancel) {
-              return;
-            }
-            let quickActions = [];
-            try {
-              quickActions = await resolveQuickActions(issueData);
-            } catch (ex) {
-              quickActions = [];
-            }
-
-            popupState = {
-              key,
-              issueData,
-              pullRequests,
-              pointerX,
-              pointerY,
-              quickActions,
-              actionsOpen: false,
-              actionLoadingKey: '',
-              actionError: '',
-              lastActionSuccess: '',
-              editState: null
-            };
-            await renderIssuePopup(popupState);
-          })(cancelToken).catch((error) => {
-            notifyJiraConnectionFailure(INSTANCE_URL, error);
-            lastHoveredKey = '';
-          });
-        }, 400);
+        triggerPopupForKey(key, e.pageX, e.pageY);
       } else if (!containerPinned) {
+        pendingHover = null;
         clearTimeout(hoverDelayTimeout);
         lastHoveredKey = '';
         hideTimeOut = setTimeout(hideContainer, 250);

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -15,54 +15,53 @@ const getInstanceUrl = async () => (await storageGet({
 })).instanceUrl;
 
 const getConfig = async () => (await storageGet(config));
-let sprintFieldIdsPromise;
-let epicLinkFieldIdsPromise;
+let allFieldsPromise;
 
-async function getSprintFieldIds(instanceUrl) {
-  if (sprintFieldIdsPromise) {
-    return sprintFieldIdsPromise;
+function getAllFields(instanceUrl) {
+  if (!allFieldsPromise) {
+    allFieldsPromise = get(instanceUrl + 'rest/api/2/field')
+      .then(fields => (Array.isArray(fields) ? fields : []))
+      .catch(() => []);
   }
-  sprintFieldIdsPromise = get(instanceUrl + 'rest/api/2/field')
-    .then(fields => {
-      if (!Array.isArray(fields)) {
-        return [];
-      }
-      return fields
-        .filter(field => {
-          const name = (field.name || '').toLowerCase();
-          const schemaCustom = ((field.schema && field.schema.custom) || '').toLowerCase();
-          const schemaType = ((field.schema && field.schema.type) || '').toLowerCase();
-          return name.includes('sprint') ||
-            schemaCustom.includes('gh-sprint') ||
-            schemaType === 'sprint';
-        })
-        .map(field => field.id);
-    })
-    .catch(() => []);
-  return sprintFieldIdsPromise;
+  return allFieldsPromise;
 }
 
-async function getEpicLinkFieldIds(instanceUrl) {
-  if (epicLinkFieldIdsPromise) {
-    return epicLinkFieldIdsPromise;
-  }
-  epicLinkFieldIdsPromise = get(instanceUrl + 'rest/api/2/field')
-    .then(fields => {
-      if (!Array.isArray(fields)) {
-        return [];
-      }
-      return fields
-        .filter(field => {
-          const name = (field.name || '').toLowerCase();
-          const schemaCustom = ((field.schema && field.schema.custom) || '').toLowerCase();
-          return name === 'epic link' || name === 'epic' || schemaCustom.includes('gh-epic-link');
-        })
-        .map(field => field.id);
-    })
-    .catch(() => []);
-  return epicLinkFieldIdsPromise;
+function getFieldIdsByFilter(instanceUrl, filterFn) {
+  return getAllFields(instanceUrl).then(fields => fields.filter(filterFn).map(field => field.id));
 }
 
+function getSprintFieldIds(instanceUrl) {
+  return getFieldIdsByFilter(instanceUrl, field => {
+    const name = (field.name || '').toLowerCase();
+    const schemaCustom = ((field.schema && field.schema.custom) || '').toLowerCase();
+    const schemaType = ((field.schema && field.schema.type) || '').toLowerCase();
+    return name.includes('sprint') ||
+      schemaCustom.includes('gh-sprint') ||
+      schemaType === 'sprint';
+  });
+}
+
+function getEpicLinkFieldIds(instanceUrl) {
+  return getFieldIdsByFilter(instanceUrl, field => {
+    const name = (field.name || '').toLowerCase();
+    const schemaCustom = ((field.schema && field.schema.custom) || '').toLowerCase();
+    return name === 'epic link' || name === 'epic' || schemaCustom.includes('gh-epic-link');
+  });
+}
+
+
+function buildRegexMatcher(regex) {
+  return function (text) {
+    const input = text || '';
+    const result = [];
+    let matches;
+    while ((matches = regex.exec(input)) !== null) {
+      result.push(matches[0]);
+    }
+    regex.lastIndex = 0;
+    return result;
+  };
+}
 
 /**
  * Returns a function that will return an array of jira tickets for any given string
@@ -79,33 +78,11 @@ function buildJiraKeyMatcher(projectKeys) {
     };
   }
   const projectMatches = escapedKeys.join('|');
-  const jiraTicketRegex = new RegExp('(?:' + projectMatches + ')[- ]\\d+', 'ig');
-
-  return function (text) {
-    let matches;
-    const result = [];
-
-    while ((matches = jiraTicketRegex.exec(text)) !== null) {
-      result.push(matches[0]);
-    }
-    return result;
-  };
+  return buildRegexMatcher(new RegExp('(?:' + projectMatches + ')[- ]\\d+', 'ig'));
 }
 
 function buildFallbackJiraKeyMatcher() {
-  const jiraTicketRegex = /\b[A-Z][A-Z0-9]{1,14}[- ]\d+\b/g;
-
-  return function (text) {
-    let matches;
-    const result = [];
-    const input = text || '';
-
-    while ((matches = jiraTicketRegex.exec(input)) !== null) {
-      result.push(matches[0]);
-    }
-    jiraTicketRegex.lastIndex = 0;
-    return result;
-  };
+  return buildRegexMatcher(/\b[A-Z][A-Z0-9]{1,14}[- ]\d+\b/g);
 }
 
 chrome.runtime.onMessage.addListener(function (msg) {
@@ -134,35 +111,25 @@ storageGet({'ui_tips_shown': []}).then(function ({ui_tips_shown}) {
   ui_tips_shown_local = ui_tips_shown;
 });
 
-async function get(url) {
-  const response = await sendMessage({action: 'get', url: url});
-  if (response.result) {
-    return response.result;
-  } else if (response.error) {
-    const err = new Error(response.error);
-    err.inner = response.error;
-    throw err;
-  }
-}
-
-async function getImageDataUrl(url) {
-  const response = await sendMessage({action: 'getImageDataUrl', url});
-  if (response.result) {
-    return response.result;
-  } else if (response.error) {
-    const err = new Error(response.error);
-    err.inner = response.error;
-    throw err;
-  }
-}
-async function requestJson(method, url, body) {
-  const response = await sendMessage({action: 'requestJson', method, url, body});
+function unwrapResponse(response, defaultError = 'Request failed') {
   if (Object.prototype.hasOwnProperty.call(response, 'result')) {
     return response.result;
   }
-  const err = new Error(response.error || 'Request failed');
+  const err = new Error(response.error || defaultError);
   err.inner = response.error;
   throw err;
+}
+
+async function get(url) {
+  return unwrapResponse(await sendMessage({action: 'get', url: url}));
+}
+
+async function getImageDataUrl(url) {
+  return unwrapResponse(await sendMessage({action: 'getImageDataUrl', url}));
+}
+
+async function requestJson(method, url, body) {
+  return unwrapResponse(await sendMessage({action: 'requestJson', method, url, body}));
 }
 async function uploadAttachment(url, file) {
   const bytes = Array.from(new Uint8Array(await file.arrayBuffer()));
@@ -173,12 +140,7 @@ async function uploadAttachment(url, file) {
     fileName: file.name,
     url
   });
-  if (Object.prototype.hasOwnProperty.call(response, 'result')) {
-    return response.result;
-  }
-  const err = new Error(response.error || 'Attachment upload failed');
-  err.inner = response.error;
-  throw err;
+  return unwrapResponse(response, 'Attachment upload failed');
 }
 
 
@@ -531,18 +493,16 @@ async function mainAsyncLocal() {
       }
     });
 
-    const result = [];
-    for (const comment of comments) {
+    return Promise.all(comments.map(async comment => {
       const rendered = renderedById[comment.id];
       const baseHtml = rendered || textToLinkedHtml(comment.body || '');
       const bodyHtml = await normalizeRichHtml(baseHtml, {imageMaxHeight: 100});
-      result.push({
+      return {
         author: comment.author?.displayName || 'Unknown',
         created: formatRelativeDate(comment.created),
         bodyHtml
-      });
-    }
-    return result;
+      };
+    }));
   }
 
   async function getCurrentUserInfo() {
@@ -1198,30 +1158,30 @@ async function mainAsyncLocal() {
       {label: 'latest details gitlabselfmanaged', url: `${INSTANCE_URL}rest/dev-status/latest/issue/detail?issueId=${issueId}&applicationType=gitlabselfmanaged&dataType=pullrequest`}
     ];
 
-    const results = [];
-    for (const probe of probes) {
-      try {
-        const response = await get(probe.url);
-        results.push({
-          label: probe.label,
-          url: probe.url,
-          ok: true,
-          topLevelKeys: Object.keys(response || {}),
-          hasSummary: Array.isArray(response?.summary),
-          hasDetail: Array.isArray(response?.detail),
-          summaryCount: Array.isArray(response?.summary) ? response.summary.length : null,
-          detailCount: Array.isArray(response?.detail) ? response.detail.length : null
-        });
-      } catch (ex) {
-        results.push({
-          label: probe.label,
-          url: probe.url,
-          ok: false,
-          error: ex?.message || String(ex)
-        });
+    const settled = await Promise.allSettled(probes.map(async probe => {
+      const response = await get(probe.url);
+      return {
+        label: probe.label,
+        url: probe.url,
+        ok: true,
+        topLevelKeys: Object.keys(response || {}),
+        hasSummary: Array.isArray(response?.summary),
+        hasDetail: Array.isArray(response?.detail),
+        summaryCount: Array.isArray(response?.summary) ? response.summary.length : null,
+        detailCount: Array.isArray(response?.detail) ? response.detail.length : null
+      };
+    }));
+    return settled.map((result, i) => {
+      if (result.status === 'fulfilled') {
+        return result.value;
       }
-    }
-    return results;
+      return {
+        label: probes[i].label,
+        url: probes[i].url,
+        ok: false,
+        error: result.reason?.message || String(result.reason)
+      };
+    });
   }
 
   async function getCachedValue(cache, key, buildValue) {

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -256,6 +256,7 @@ async function mainAsyncLocal() {
     maybeNormalizeAvatar(issueData.fields.assignee);
     maybeNormalizeIcon(issueData.fields.issuetype);
     maybeNormalizeIcon(issueData.fields.status);
+    maybeNormalizeIcon(issueData.fields.priority);
 
     (issueData.fields.attachment || []).forEach(attachment => {
       attachment.content = toAbsoluteJiraUrl(attachment.content);
@@ -625,35 +626,6 @@ async function mainAsyncLocal() {
     return `${INSTANCE_URL}issues/?jql=${encodeURIComponent(jql)}`;
   }
 
-  function toSearchChip(fieldName, value, label = value) {
-    if (!value) {
-      return null;
-    }
-    const jql = `${fieldName} = ${encodeJqlValue(value)}`;
-    return {
-      text: label,
-      url: buildJqlUrl(jql)
-    };
-  }
-
-  function toIssueSearchChip(issueTypeName, statusName, value, label = value) {
-    if (!value) {
-      return null;
-    }
-    const criteria = [];
-    if (issueTypeName) {
-      criteria.push(`issuetype = ${encodeJqlValue(issueTypeName)}`);
-    }
-    if (statusName) {
-      criteria.push(`status = ${encodeJqlValue(statusName)}`);
-    }
-    criteria.push(`text ~ ${encodeJqlValue(value)}`);
-    return {
-      text: label,
-      url: buildJqlUrl(criteria.join(' AND '))
-    };
-  }
-
   function buildAttachmentChips(attachments) {
     const totals = {
       image: 0,
@@ -969,42 +941,38 @@ async function mainAsyncLocal() {
           const statusName = issueData.fields.status?.name;
           const priorityName = issueData.fields.priority?.name;
 
-          const statusChips = [
-            displayFields.issueType ? {text: issueTypeName || 'No type'} : null,
-            displayFields.status ? {text: statusName || 'No status'} : null,
-            displayFields.priority ? {text: priorityName || 'No priority'} : null
+          const row1Chips = [
+            displayFields.issueType ? {
+              text: issueTypeName || 'No type',
+              iconUrl: issueData.fields.issuetype?.iconUrl || ''
+            } : null,
+            displayFields.status ? {
+              text: statusName || 'No status',
+              iconUrl: issueData.fields.status?.iconUrl || ''
+            } : null,
+            displayFields.priority ? {
+              text: priorityName || 'No priority',
+              iconUrl: issueData.fields.priority?.iconUrl || ''
+            } : null,
+            displayFields.epicParent ? {
+              text: epicOrParent
+                ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
+                : 'Parent: --'
+            } : null
           ].filter(Boolean);
 
-          const sprintChips = displayFields.sprint ? sprints
-            .map(sprint => {
-              const label = sprint.state ? `${sprint.name} (${sprint.state})` : sprint.name;
-              return toSearchChip('Sprint', sprint.name, label);
-            })
-            .filter(Boolean) : [];
-          const sprintFallbackText = displayFields.sprint && !sprintChips.length ? 'Sprint: --' : '';
+          const row2Chips = [
+            displayFields.sprint ? {text: `Sprint: ${formatSprintText(sprints) || '--'}`} : null,
+            displayFields.affects ? {
+              text: `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`
+            } : null,
+            displayFields.fixVersions ? {text: `Fix version: ${formatFixVersionText(fixVersions) || '--'}`} : null
+          ].filter(Boolean);
 
-          const fixVersionChips = displayFields.fixVersions ? fixVersions
-            .map(version => toSearchChip('fixVersion', version.name))
-            .filter(Boolean) : [];
-          const fixVersionFallbackText = displayFields.fixVersions && !fixVersionChips.length ? 'Fix version: --' : '';
-
-          const labelChips = displayFields.labels ? labels
-            .map(label => toIssueSearchChip(issueTypeName, statusName, label))
-            .filter(Boolean) : [];
-
-          const accountChips = displayFields.account ? accountValues
-            .map(accountValue => ({text: accountValue}))
-            .filter(Boolean) : [];
-
-          const epicParentChips = displayFields.epicParent && epicOrParent
-            ? [{
-              text: `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`,
-            }]
-            : [];
-
-          const affectsText = displayFields.affects
-            ? `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`
-            : '';
+          const row3Chips = [
+            displayFields.labels ? {text: `Labels: ${labels.filter(Boolean).join(', ') || '--'}`} : null,
+            displayFields.account ? {text: `Account: ${accountValues.filter(Boolean).join(', ') || '--'}`} : null
+          ].filter(Boolean);
 
           const copyTicketMeta = (ticket) => ({
             copyUrl: ticket.url,
@@ -1038,30 +1006,16 @@ async function mainAsyncLocal() {
             statusText: displayFields.status ? (statusName || 'No status') : '',
             sprintText: displayFields.sprint ? (formatSprintText(sprints) || 'No sprint') : '',
             fixVersionText: displayFields.fixVersions ? (formatFixVersionText(fixVersions) || 'No fix version') : '',
-            statusChips,
-            epicParentChips,
-            sprintChips,
-            sprintFallbackText,
-            fixVersionChips,
-            fixVersionFallbackText,
-            labelChips,
-            accountChips,
-            affectsText,
+            row1Chips,
+            row2Chips,
+            row3Chips,
             hasComments: displayFields.comments && commentsTotal > 0,
             commentsTotal: displayFields.comments ? commentsTotal : 0,
             attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
             reporter: displayFields.reporter ? issueData.fields.reporter : null,
             assignee: displayFields.assignee ? issueData.fields.assignee : null,
             commentUrl: INSTANCE_URL + 'browse/' + key,
-            hasFieldSummary: statusChips.length > 0 ||
-              epicParentChips.length > 0 ||
-              !!affectsText ||
-              sprintChips.length > 0 ||
-              !!sprintFallbackText ||
-              fixVersionChips.length > 0 ||
-              !!fixVersionFallbackText ||
-              labelChips.length > 0 ||
-              accountChips.length > 0,
+            hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
             loaderGifUrl,
           };
           if (issueData.fields.comment?.comments?.[0]?.id) {

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -133,6 +133,15 @@ async function getImageDataUrl(url) {
     throw err;
   }
 }
+async function requestJson(method, url, body) {
+  const response = await sendMessage({action: 'requestJson', method, url, body});
+  if (Object.prototype.hasOwnProperty.call(response, 'result')) {
+    return response.result;
+  }
+  const err = new Error(response.error || 'Request failed');
+  err.inner = response.error;
+  throw err;
+}
 
 function isJiraConnectionFailure(error) {
   const message = String(error?.message || error?.inner || error || '');
@@ -199,6 +208,8 @@ async function mainAsyncLocal() {
   const cacheTtlMs = 60 * 1000;
   const issueCache = new Map();
   const pullRequestCache = new Map();
+  let currentUserPromise;
+  let activeCommentContext = null;
 
   function toAbsoluteJiraUrl(url) {
     if (!url) {
@@ -424,6 +435,143 @@ async function mainAsyncLocal() {
     return result;
   }
 
+  async function getCurrentUserInfo() {
+    if (currentUserPromise) {
+      return currentUserPromise;
+    }
+
+    currentUserPromise = (async () => {
+      try {
+        const myself = await get(INSTANCE_URL + 'rest/api/2/myself');
+        return {
+          displayName: myself?.displayName || myself?.name || myself?.username || 'You'
+        };
+      } catch (primaryError) {
+        const session = await get(INSTANCE_URL + 'rest/auth/1/session');
+        const user = session?.user || {};
+        return {
+          displayName: user.displayName || user.name || user.username || 'You'
+        };
+      }
+    })().catch(error => {
+      currentUserPromise = null;
+      throw error;
+    });
+
+    return currentUserPromise;
+  }
+
+  function getCommentComposerElements() {
+    return {
+      root: container.find('._JX_comment_compose'),
+      input: container.find('._JX_comment_input'),
+      save: container.find('._JX_comment_save'),
+      discard: container.find('._JX_comment_discard'),
+      error: container.find('._JX_comment_error')
+    };
+  }
+
+  function syncCommentComposerState() {
+    const elements = getCommentComposerElements();
+    if (!elements.root.length) {
+      return;
+    }
+    const isSaving = elements.root.attr('data-saving') === 'true';
+    const hasText = !!elements.input.val().trim();
+    elements.input.prop('disabled', isSaving);
+    elements.save.prop('disabled', !hasText || isSaving).text(isSaving ? 'Saving...' : 'Save');
+    elements.discard.prop('disabled', !hasText || isSaving);
+  }
+
+  function setCommentComposerError(message) {
+    const {error} = getCommentComposerElements();
+    if (!error.length) {
+      return;
+    }
+    error.text(message || '');
+  }
+
+  function updateCommentActivityCount(delta) {
+    const activityItem = container.find('._JX_activity_item').eq(1);
+    if (!activityItem.length) {
+      return;
+    }
+    const countNode = activityItem.find('strong');
+    const currentCount = Number(countNode.text()) || 0;
+    const nextCount = Math.max(0, currentCount + delta);
+    countNode.text(String(nextCount));
+    activityItem.attr('title', `${nextCount} comments`);
+  }
+
+  async function appendCommentToPopup(commentText) {
+    const commentsRoot = container.find('._JX_comments');
+    if (!commentsRoot.length) {
+      return;
+    }
+
+    commentsRoot.find('._JX_comments_empty').remove();
+    container.find('._JX_empty_body').remove();
+    const currentUser = await getCurrentUserInfo().catch(() => ({displayName: 'You'}));
+    const bodyHtml = textToLinkedHtml(commentText || '');
+    const commentHtml = `
+      <div class="_JX_comment">
+        <div class="_JX_comment_meta">
+          <span class="_JX_comment_author">${escapeHtml(currentUser.displayName || 'You')}</span> | <span class="_JX_comment_time">Just now</span>
+        </div>
+        <div class="_JX_comment_body">${bodyHtml}</div>
+      </div>
+    `;
+
+    const commentList = commentsRoot.find('._JX_comment_list');
+    if (commentList.length) {
+      commentList.append(commentHtml);
+    } else {
+      commentsRoot.append(`<div class="_JX_comment_list">${commentHtml}</div>`);
+    }
+    updateCommentActivityCount(1);
+  }
+
+  async function handleCommentSave() {
+    if (!activeCommentContext?.issueKey) {
+      return;
+    }
+
+    const elements = getCommentComposerElements();
+    const commentText = elements.input.val().trim();
+    if (!commentText) {
+      syncCommentComposerState();
+      return;
+    }
+
+    elements.root.attr('data-saving', 'true');
+    setCommentComposerError('');
+    syncCommentComposerState();
+
+    try {
+      await requestJson('POST', `${INSTANCE_URL}rest/api/2/issue/${activeCommentContext.issueKey}/comment`, {
+        body: commentText
+      });
+      await appendCommentToPopup(commentText);
+      elements.input.val('');
+      elements.root.attr('data-saving', 'false');
+      setCommentComposerError('');
+      syncCommentComposerState();
+    } catch (error) {
+      elements.root.attr('data-saving', 'false');
+      setCommentComposerError(error?.message || error?.inner || 'Could not save comment');
+      syncCommentComposerState();
+    }
+  }
+
+  function handleCommentDiscard() {
+    const elements = getCommentComposerElements();
+    if (!elements.root.length || elements.root.attr('data-saving') === 'true') {
+      return;
+    }
+    elements.input.val('');
+    setCommentComposerError('');
+    syncCommentComposerState();
+  }
   /***
    * Retrieve only the text that is directly owned by the node
    * @param node
@@ -989,6 +1137,19 @@ async function mainAsyncLocal() {
     copyPrettyLink(e.currentTarget).catch(() => snackBar('There was an error!'));
   });
 
+  $(document.body).on('input', '._JX_comment_input', function () {
+    syncCommentComposerState();
+  });
+
+  $(document.body).on('click', '._JX_comment_save', function (e) {
+    e.preventDefault();
+    handleCommentSave().catch(() => {});
+  });
+
+  $(document.body).on('click', '._JX_comment_discard', function (e) {
+    e.preventDefault();
+    handleCommentDiscard();
+  });
   function closePreviewOverlay() {
     previewOverlay.removeClass('is-open');
     previewOverlay.find('img').attr('src', '');
@@ -1028,6 +1189,7 @@ async function mainAsyncLocal() {
 
   function hideContainer() {
     lastHoveredKey = '';
+    activeCommentContext = null;
     containerPinned = false;
     container.css({
       left: -5000,
@@ -1225,6 +1387,8 @@ async function mainAsyncLocal() {
             attachments,
             previewAttachments: visibleAttachments,
             commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
+            showCommentsSection: displayFields.comments || commentsForDisplay.length > 0,
+            showCommentComposer: displayFields.comments,
             issuetype: issueData.fields.issuetype,
             status: issueData.fields.status,
             priority: issueData.fields.priority,
@@ -1271,6 +1435,8 @@ async function mainAsyncLocal() {
           );
           // TODO: fix scrolling in google docs
           container.html(Mustache.render(annotationTemplate, displayData));
+          activeCommentContext = displayFields.comments ? { issueKey: key, issueId: issueData.id } : null;
+          syncCommentComposerState();
           if (!containerPinned) {
             container.css(computeVisibleContainerPosition(pointerX, pointerY));
           }
@@ -1291,14 +1457,4 @@ if (!window.__JX__script_injected__) {
 }
 
 window.__JX__script_injected__ = true;
-
-
-
-
-
-
-
-
-
-
 

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -10,11 +10,16 @@ import config from 'options/config.js';
 
 waitForDocument(() => require('src/content.scss'));
 
+// ── Config ──────────────────────────────────────────────────────
+
 const getInstanceUrl = async () => (await storageGet({
   instanceUrl: config.instanceUrl
 })).instanceUrl;
 
 const getConfig = async () => (await storageGet(config));
+
+// ── Field ID Resolution ─────────────────────────────────────────
+
 let allFieldsPromise;
 
 function getAllFields(instanceUrl) {
@@ -49,6 +54,7 @@ function getEpicLinkFieldIds(instanceUrl) {
   });
 }
 
+// ── Jira Key Matching ───────────────────────────────────────────
 
 function buildRegexMatcher(regex) {
   return function (text) {
@@ -85,6 +91,8 @@ function buildFallbackJiraKeyMatcher() {
   return buildRegexMatcher(/\b[A-Z][A-Z0-9]{1,14}[- ]\d+\b/g);
 }
 
+// ── Tips & Notifications ────────────────────────────────────────
+
 chrome.runtime.onMessage.addListener(function (msg) {
   if (msg.action === 'message') {
     snackBar(msg.message);
@@ -110,6 +118,8 @@ async function showTip(tipName, tipMessage) {
 storageGet({'ui_tips_shown': []}).then(function ({ui_tips_shown}) {
   ui_tips_shown_local = ui_tips_shown;
 });
+
+// ── Network / API ───────────────────────────────────────────────
 
 function unwrapResponse(response, defaultError = 'Request failed') {
   if (Object.prototype.hasOwnProperty.call(response, 'result')) {
@@ -144,6 +154,8 @@ async function uploadAttachment(url, file) {
 }
 
 
+// ── Connection Error Detection ──────────────────────────────────
+
 function isJiraConnectionFailure(error) {
   const message = String(error?.message || error?.inner || error || '');
   return CONNECTION_ERROR_PATTERN.test(message);
@@ -165,9 +177,15 @@ function notifyJiraConnectionFailure(instanceUrl, error) {
   return true;
 }
 
+// ═══════════════════════════════════════════════════════════════
+// Main Content Script
+// ═══════════════════════════════════════════════════════════════
+
 async function mainAsyncLocal() {
   const $ = require('jquery');
   const draggable = require('jquery-ui/ui/widgets/draggable');
+
+  // ── Initialization & State ──────────────────────────────────
 
   const config = await getConfig();
   const INSTANCE_URL = config.instanceUrl;
@@ -246,6 +264,8 @@ async function mainAsyncLocal() {
   let commentUploadSequence = 0;
 
 
+  // ── URL & Image Handling ───────────────────────────────────
+
   function toAbsoluteJiraUrl(url) {
     if (!url) {
       return url;
@@ -318,6 +338,8 @@ async function mainAsyncLocal() {
 
     await Promise.all(imageLoads);
   }
+
+  // ── Text & HTML Formatting ─────────────────────────────────
 
   function escapeHtml(input) {
     const node = document.createElement('div');
@@ -393,6 +415,8 @@ async function mainAsyncLocal() {
       timeStyle: 'short'
     }).format(createdAt);
   }
+
+  // ── HTML Sanitization ──────────────────────────────────────
 
   function sanitizeRichHtml(rawHtml) {
     const temp = document.createElement('div');
@@ -481,6 +505,8 @@ async function mainAsyncLocal() {
 
     return temp.innerHTML;
   }
+
+  // ── Comments ──────────────────────────────────────────────
 
   async function buildCommentsForDisplay(issueData) {
     const comments = [...(issueData.fields.comment?.comments || [])].sort((a, b) => {
@@ -1128,6 +1154,9 @@ async function mainAsyncLocal() {
     }
     await discardCommentComposerDraft();
   }
+
+  // ── Pull Requests & Dev Status ─────────────────────────────
+
   /***
    * Retrieve only the text that is directly owned by the node
    * @param node
@@ -1184,6 +1213,8 @@ async function mainAsyncLocal() {
     });
   }
 
+  // ── Caching ───────────────────────────────────────────────
+
   async function getCachedValue(cache, key, buildValue) {
     const existing = cache.get(key);
     if (existing && (Date.now() - existing.createdAt) < cacheTtlMs) {
@@ -1197,6 +1228,8 @@ async function mainAsyncLocal() {
     });
     return value;
   }
+
+  // ── Issue Data & Metadata ──────────────────────────────────
 
   async function getIssueMetaData(issueKey) {
     return getCachedValue(issueCache, issueKey, async () => {
@@ -1308,6 +1341,8 @@ async function mainAsyncLocal() {
         });
     });
   }
+
+  // ── Assignee Search ────────────────────────────────────────
 
   function normalizeAssignableUsers(users) {
     const uniqueById = new Map();
@@ -1467,6 +1502,8 @@ async function mainAsyncLocal() {
       };
     });
   }
+
+  // ── Issue Linkage & Hierarchy ──────────────────────────────
 
   function extractIssueKeyFromLinkageValue(value) {
     if (!value) {
@@ -1663,6 +1700,8 @@ async function mainAsyncLocal() {
     });
   }
 
+  // ── Labels ────────────────────────────────────────────────
+
   function stripSimpleHtml(value) {
     return String(value || '').replace(/<[^>]+>/g, '');
   }
@@ -1729,6 +1768,8 @@ async function mainAsyncLocal() {
     }
     return labelSuggestionSupportPromise;
   }
+
+  // ── Custom Fields ──────────────────────────────────────────
 
   function getCustomFieldPrimitive(entry) {
     if (entry === undefined || entry === null) {
@@ -2144,6 +2185,8 @@ async function mainAsyncLocal() {
     return chipsByRow;
   }
 
+  // ── Sprints & Versions ─────────────────────────────────────
+
   function getIssueSprintEntries(issueData) {
     const names = issueData.names || {};
     const fields = issueData.fields || {};
@@ -2273,6 +2316,8 @@ async function mainAsyncLocal() {
       .join(', ');
   }
 
+  // ── JQL & Display Utilities ────────────────────────────────
+
   function encodeJqlValue(value) {
     return `"${String(value || '').replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
   }
@@ -2362,6 +2407,8 @@ async function mainAsyncLocal() {
     return `project = ${encodeJqlValue(projectKey)} AND ${clause}`;
   }
 
+  // ── Chips & Activity Indicators ────────────────────────────
+
   function buildFilterChip(text, jql, extra = {}) {
     const linkUrl = jql ? buildJqlUrl(jql) : '';
     return {
@@ -2425,6 +2472,8 @@ async function mainAsyncLocal() {
     }));
   }
 
+  // ── Pull Request Display ───────────────────────────────────
+
   function formatPullRequestTitle(pr) {
     const id = pr?.id || pr?.number || pr?.key || '';
     const title = pr?.name || pr?.title || 'Untitled pull request';
@@ -2461,6 +2510,8 @@ async function mainAsyncLocal() {
   function buildQuickActionError(error) {
     return error?.message || error?.inner || 'Action failed';
   }
+
+  // ── User & Quick Actions ───────────────────────────────────
 
   function areSameJiraUser(left, right) {
     if (!left || !right) {
@@ -2523,6 +2574,8 @@ async function mainAsyncLocal() {
     return Array.isArray(response?.transitions) ? response.transitions : [];
   }
 
+  // ── Status Transitions ─────────────────────────────────────
+
   function isInProgressStatusCategory(statusCategory) {
     const key = String(statusCategory?.key || '').toLowerCase();
     const name = String(statusCategory?.name || '').toLowerCase();
@@ -2568,6 +2621,8 @@ async function mainAsyncLocal() {
   function buildEditFieldError(error) {
     return error?.message || error?.inner || 'Update failed';
   }
+
+  // ── Edit Options & Multi-Select ────────────────────────────
 
   function buildEditOption(id, label, extra = {}) {
     const normalizedLabel = String(label || '');
@@ -2659,6 +2714,8 @@ async function mainAsyncLocal() {
       hasChanges: !areSameOptionIds(selectedOptionIds, originalOptionIds)
     };
   }
+
+  // ── Field Option Retrieval ─────────────────────────────────
 
   async function getProjectVersionOptions(issueData, cacheKey) {
     const projectKey = String(issueData?.key || '').split('-')[0];
@@ -2842,6 +2899,8 @@ async function mainAsyncLocal() {
     }
     throw lastError || new Error('Could not update assignee');
   }
+
+  // ── Field Editor Definitions ───────────────────────────────
 
   async function getEditableFieldDefinition(fieldKey, issueData) {
     if (fieldKey === 'versions') {
@@ -3249,6 +3308,8 @@ async function mainAsyncLocal() {
     return null;
   }
 
+  // ── Edit UI Presentation ───────────────────────────────────
+
   function filterEditOptions(options, inputValue) {
     const normalizedInput = String(inputValue || '').trim().toLowerCase();
     const list = Array.isArray(options) ? options : [];
@@ -3357,6 +3418,8 @@ async function mainAsyncLocal() {
       editTitle: options.editTitle || `Edit ${baseChip.text}`
     };
   }
+
+  // ── Avatars & User Display ─────────────────────────────────
 
   function getUserInitials(displayName, fallbackInitials = 'NA') {
     const tokens = String(displayName || '')
@@ -3558,6 +3621,8 @@ async function mainAsyncLocal() {
     return populatedFieldId || sprintFieldIds?.[0] || '';
   }
 
+  // ── Quick Actions ──────────────────────────────────────────
+
   async function resolveQuickActions(issueData) {
 
     const actionResults = await Promise.allSettled([
@@ -3666,6 +3731,8 @@ async function mainAsyncLocal() {
       quickActions: actions
     };
   }
+
+  // ── Popup Data & Rendering ─────────────────────────────────
 
   async function buildPopupDisplayData(state) {
     const {key, issueData, pullRequests, actionLoadingKey, actionError, lastActionSuccess, actionsOpen, quickActions} = state;
@@ -3891,6 +3958,7 @@ async function mainAsyncLocal() {
     );
     return displayData;
   }
+  // ── Popup Positioning ──────────────────────────────────────
   function getRelativeHref(href) {
     const documentHref = document.location.href.split('#')[0];
     if (href.startsWith(documentHref)) {
@@ -3952,6 +4020,7 @@ async function mainAsyncLocal() {
     return clampContainerPosition(left, top);
   }
 
+  // ── Popup Rendering & State ────────────────────────────────
   const container = $('<div class="_JX_container">');
   const previewOverlay = $(`
     <div class="_JX_preview_overlay">
@@ -4063,6 +4132,7 @@ async function mainAsyncLocal() {
       snackBar(successMessage);
     }
   }
+  // ── Field Editing ─────────────────────────────────────────
   async function handleQuickAction(actionKey) {
     if (!popupState?.issueData || popupState.actionLoadingKey) {
       return;
@@ -4511,6 +4581,7 @@ async function mainAsyncLocal() {
     cancel: 'a, button, input, textarea, img, ._JX_description, ._JX_comments, ._JX_comment_body, ._JX_description_text, ._JX_related_pr'
   }, container);
   
+  // ── Clipboard & Copy ──────────────────────────────────────
   function buildPrettyLinkPayload(sourceElement) {
     const url = sourceElement?.getAttribute('data-url') || sourceElement?.getAttribute('href') || '';
     const ticket = sourceElement?.getAttribute('data-ticket') || '';
@@ -4572,6 +4643,7 @@ async function mainAsyncLocal() {
     }
   }
 
+  // ── Event Handlers ────────────────────────────────────────
   $(document.body).on('click', '._JX_copy_link', function (e) {
     e.preventDefault();
     copyPrettyLink(e.currentTarget).catch(() => snackBar('There was an error!'));
@@ -4790,6 +4862,7 @@ async function mainAsyncLocal() {
     handleCommentDiscard().catch(() => {});
   });
 
+  // ── Image Preview ─────────────────────────────────────────
   function closePreviewOverlay() {
     previewOverlay.removeClass('is-open');
     previewOverlay.find('img').attr('src', '');
@@ -4827,6 +4900,7 @@ async function mainAsyncLocal() {
     openPreviewOverlay(source).catch(() => {});
   });
 
+  // ── Container Lifecycle ────────────────────────────────────
   function hideContainer() {
     lastHoveredKey = '';
     popupState = null;
@@ -4856,6 +4930,7 @@ async function mainAsyncLocal() {
     }
   });
 
+  // ── Hover Detection & Script Bootstrap ─────────────────────
   let cancelToken = {};
 
   function passiveCancel(cooldown) {

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -240,6 +240,16 @@ async function mainAsyncLocal() {
   });
   let currentUserPromise;
   const projectSprintOptionsPromises = new Map();
+  const editMetaCache = new Map();
+  const transitionOptionsCache = new Map();
+  const assigneeSearchCache = new Map();
+  const assigneeLocalOptionsCache = new Map();
+  const issueSearchCache = new Map();
+  const issueSearchRecentCache = new Map();
+  const labelSuggestionCache = new Map();
+  let labelSuggestionSupportPromise = null;
+  let preferredAssigneeIdentifier = '';
+  let editSearchRequestCounter = 0;
   let popupState = null;
   let activeCommentContext = null;
   let commentMentionState = emptyCommentMentionState();
@@ -1228,6 +1238,154 @@ async function mainAsyncLocal() {
     });
   }
 
+  async function getIssueEditMeta(issueKey) {
+    if (!issueKey) {
+      return {fields: {}};
+    }
+    return getCachedValue(editMetaCache, issueKey, async () => {
+      const data = await get(`${INSTANCE_URL}rest/api/2/issue/${issueKey}/editmeta`);
+      return {
+        fields: data?.fields || {}
+      };
+    });
+  }
+
+  async function getEditableFieldCapability(issueData, fieldKey) {
+    if (!issueData?.key || !fieldKey) {
+      return {
+        editable: false,
+        operations: [],
+        allowedValues: []
+      };
+    }
+    const editMeta = await getIssueEditMeta(issueData.key);
+    const names = issueData.names || {};
+    let resolvedFieldKey = fieldKey;
+    if (fieldKey === 'sprint') {
+      const sprintFieldIds = await getSprintFieldIds(INSTANCE_URL);
+      resolvedFieldKey = pickSprintFieldId(issueData, sprintFieldIds);
+    }
+    const editMetaField = editMeta.fields?.[resolvedFieldKey];
+    const schemaCustom = String(editMetaField?.schema?.custom || '').toLowerCase();
+    const schemaType = String(editMetaField?.schema?.type || '').toLowerCase();
+    const displayName = String(names[resolvedFieldKey] || editMetaField?.name || '').toLowerCase();
+    const looksLikeSprint = fieldKey === 'sprint' ||
+      schemaCustom.includes('gh-sprint') ||
+      schemaType === 'sprint' ||
+      displayName.includes('sprint');
+    if (!editMetaField || (fieldKey === 'sprint' && !looksLikeSprint)) {
+      return {
+        editable: false,
+        fieldKey: resolvedFieldKey,
+        operations: [],
+        allowedValues: []
+      };
+    }
+    return {
+      editable: true,
+      fieldKey: resolvedFieldKey,
+      fieldMeta: editMetaField,
+      operations: Array.isArray(editMetaField.operations) ? editMetaField.operations : [],
+      allowedValues: Array.isArray(editMetaField.allowedValues) ? editMetaField.allowedValues : []
+    };
+  }
+
+  async function getTransitionOptions(issueKey) {
+    if (!issueKey) {
+      return [];
+    }
+    return getCachedValue(transitionOptionsCache, issueKey, async () => {
+      const response = await get(`${INSTANCE_URL}rest/api/2/issue/${issueKey}/transitions`);
+      const transitions = Array.isArray(response?.transitions) ? response.transitions : [];
+      return transitions
+        .filter(transition => transition?.id && transition?.to?.name)
+        .map(transition => {
+          const targetName = transition.to?.name || '';
+          const transitionName = transition.name && transition.name !== targetName
+            ? transition.name
+            : '';
+          const label = transitionName
+            ? `${transitionName} -> ${targetName}`
+            : targetName;
+          const metaText = transitionName || '';
+          return buildEditOption(transition.id, label, {
+            iconUrl: transition.to?.iconUrl || '',
+            metaText,
+            searchText: `${label} ${targetName} ${transitionName}`,
+            transitionName,
+            targetStatusName: targetName
+          });
+        });
+    });
+  }
+
+  function normalizeAssignableUsers(users) {
+    const uniqueById = new Map();
+    (Array.isArray(users) ? users : []).forEach(user => {
+      const option = buildEditOption(
+        user?.accountId || user?.name || user?.key,
+        user?.displayName || user?.name || user?.key || '',
+        {
+          avatarUrl: user?.avatarUrls?.['48x48'] || '',
+          metaText: user?.emailAddress || user?.name || user?.key || '',
+          searchText: `${user?.displayName || ''} ${user?.name || ''} ${user?.key || ''} ${user?.emailAddress || ''}`,
+          rawValue: {
+            accountId: user?.accountId || '',
+            name: user?.name || '',
+            key: user?.key || ''
+          }
+        }
+      );
+      if (option.id && option.label && !uniqueById.has(option.id)) {
+        uniqueById.set(option.id, option);
+      }
+    });
+    return [...uniqueById.values()];
+  }
+
+  async function fetchAssignableUsers(query, issueData) {
+    const issueKey = issueData?.key || '';
+    const projectKey = String(issueKey).split('-')[0];
+    const encodedQuery = encodeURIComponent(String(query || '').trim());
+    const encodedIssueKey = encodeURIComponent(issueKey);
+    const encodedProjectKey = encodeURIComponent(projectKey);
+    const urls = [
+      `${INSTANCE_URL}rest/api/2/user/assignable/search?issueKey=${encodedIssueKey}&maxResults=20&query=${encodedQuery}`,
+      `${INSTANCE_URL}rest/api/2/user/assignable/search?issueKey=${encodedIssueKey}&maxResults=20&username=${encodedQuery}`,
+      `${INSTANCE_URL}rest/api/2/user/assignable/search?project=${encodedProjectKey}&maxResults=20&query=${encodedQuery}`,
+      `${INSTANCE_URL}rest/api/2/user/assignable/search?project=${encodedProjectKey}&maxResults=20&username=${encodedQuery}`
+    ].filter(url => !url.includes('issueKey=&') && !url.includes('project=&'));
+
+    let lastError;
+    for (const url of urls) {
+      try {
+        const response = await get(url);
+        if (Array.isArray(response)) {
+          return response;
+        }
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    if (lastError) {
+      throw lastError;
+    }
+    return [];
+  }
+
+  async function searchAssignableUsers(query, issueData) {
+    const issueKey = issueData?.key || '';
+    if (!issueKey) {
+      return [];
+    }
+    const normalizedQuery = String(query || '').trim().toLowerCase();
+    const cacheKey = `${issueKey}__${normalizedQuery}`;
+    return getCachedValue(assigneeSearchCache, cacheKey, async () => {
+      const users = await fetchAssignableUsers(normalizedQuery, issueData);
+      return normalizeAssignableUsers(users);
+    });
+  }
+
   function getPullRequestDataCached(issueId, applicationType) {
     const cacheKey = `${issueId}__${applicationType}`;
     return getCachedValue(pullRequestCache, cacheKey, () => {
@@ -1768,12 +1926,22 @@ async function mainAsyncLocal() {
   }
 
   function buildEditOption(id, label, extra = {}) {
-    return {
+    const normalizedLabel = String(label || '');
+    const normalizedSearchText = [
+      normalizedLabel,
+      String(extra.searchText || ''),
+      String(extra.metaText || '')
+    ]
+      .join(' ')
+      .trim()
+      .toLowerCase();
+    const option = {
       id: id === '' ? '' : String(id || ''),
-      label: String(label || ''),
-      searchText: String(label || '').toLowerCase(),
+      label: normalizedLabel,
       ...extra
     };
+    option.searchText = normalizedSearchText;
+    return option;
   }
 
   function formatSprintOptionLabel(sprint) {
@@ -1969,11 +2137,78 @@ async function mainAsyncLocal() {
     });
   }
 
-  function getEditableFieldDefinition(fieldKey, issueData) {
+  function detectAssigneeIdentifier(issueData) {
+    if (preferredAssigneeIdentifier) {
+      return preferredAssigneeIdentifier;
+    }
+    const assignee = issueData?.fields?.assignee;
+    if (assignee?.accountId) {
+      return 'accountId';
+    }
+    if (assignee?.name) {
+      return 'name';
+    }
+    if (assignee?.key) {
+      return 'key';
+    }
+    return 'accountId';
+  }
+
+  function buildAssigneePayloadCandidates(selectedOption, issueData) {
+    const preferredIdentifier = detectAssigneeIdentifier(issueData);
+    const rawValue = selectedOption?.rawValue || {};
+    const isUnassigned = selectedOption?.id === '__unassigned__';
+    const payloadsByIdentifier = {
+      accountId: isUnassigned
+        ? {accountId: null}
+        : rawValue.accountId ? {accountId: rawValue.accountId} : null,
+      name: isUnassigned
+        ? {name: null}
+        : rawValue.name ? {name: rawValue.name} : null,
+      key: isUnassigned
+        ? {key: null}
+        : rawValue.key ? {key: rawValue.key} : null
+    };
+    const identifierOrder = [preferredIdentifier, 'accountId', 'name', 'key']
+      .filter((value, index, array) => value && array.indexOf(value) === index);
+    return identifierOrder
+      .map(identifier => ({identifier, payload: payloadsByIdentifier[identifier]}))
+      .filter(entry => entry.payload);
+  }
+
+  async function saveAssigneeSelection(issueData, selectedOptions) {
+    const selectedOption = selectedOptions[0];
+    if (!selectedOption) {
+      throw new Error('Pick an assignee before saving');
+    }
+    const payloadCandidates = buildAssigneePayloadCandidates(selectedOption, issueData);
+    if (!payloadCandidates.length) {
+      throw new Error('Could not build assignee payload');
+    }
+    const assigneeUrl = `${INSTANCE_URL}rest/api/2/issue/${issueData.key}/assignee`;
+    let lastError;
+    for (const candidate of payloadCandidates) {
+      try {
+        await requestJson('PUT', assigneeUrl, candidate.payload);
+        preferredAssigneeIdentifier = candidate.identifier;
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError || new Error('Could not update assignee');
+  }
+
+  async function getEditableFieldDefinition(fieldKey, issueData) {
     if (fieldKey === 'versions') {
+      const capability = await getEditableFieldCapability(issueData, fieldKey);
+      if (!capability.editable) {
+        return null;
+      }
       const currentVersions = issueData?.fields?.versions || [];
       return {
         fieldKey,
+        editorType: 'multi-select',
         label: 'Affects version',
         selectionMode: 'multi',
         currentText: formatVersionText(currentVersions),
@@ -1994,9 +2229,14 @@ async function mainAsyncLocal() {
     }
 
     if (fieldKey === 'fixVersions') {
+      const capability = await getEditableFieldCapability(issueData, fieldKey);
+      if (!capability.editable) {
+        return null;
+      }
       const currentFixVersions = issueData?.fields?.fixVersions || [];
       return {
         fieldKey,
+        editorType: 'multi-select',
         label: 'Fix version',
         selectionMode: 'multi',
         currentText: formatVersionText(currentFixVersions),
@@ -2017,9 +2257,14 @@ async function mainAsyncLocal() {
     }
 
     if (fieldKey === 'sprint') {
+      const capability = await getEditableFieldCapability(issueData, fieldKey);
+      if (!capability.editable) {
+        return null;
+      }
       const currentSprints = readSprintsFromIssue(issueData);
       return {
         fieldKey,
+        editorType: 'single-select',
         label: 'Sprint',
         selectionMode: 'single',
         currentText: formatSprintText(currentSprints),
@@ -2027,7 +2272,7 @@ async function mainAsyncLocal() {
         currentSelections: currentSprints.length === 1
           ? [buildEditOption(currentSprints[0]?.id, formatSprintOptionLabel(currentSprints[0]), {rawValue: currentSprints[0]})]
           : [],
-        initialInputValue: formatSprintText(currentSprints),
+        initialInputValue: '',
         loadOptions: () => getSprintOptions(issueData),
         save: async selectedOptions => {
           const option = selectedOptions[0] || buildEditOption('', 'No sprint');
@@ -2048,6 +2293,152 @@ async function mainAsyncLocal() {
       };
     }
 
+    if (fieldKey === 'priority') {
+      const capability = await getEditableFieldCapability(issueData, 'priority');
+      const allowedPriorities = capability.allowedValues || [];
+      if (!capability.editable || !allowedPriorities.length) {
+        return null;
+      }
+      const currentPriority = issueData?.fields?.priority;
+      return {
+        fieldKey,
+        editorType: 'single-select',
+        label: 'Priority',
+        selectionMode: 'single',
+        currentText: currentPriority?.name || '',
+        currentOptionId: currentPriority?.id ? String(currentPriority.id) : null,
+        currentSelections: currentPriority?.id && currentPriority?.name
+          ? [buildEditOption(currentPriority.id, currentPriority.name, {
+              iconUrl: currentPriority.iconUrl || ''
+            })]
+          : [],
+        initialInputValue: '',
+        loadOptions: async () => {
+          return allowedPriorities
+            .filter(priority => priority?.id && priority?.name)
+            .map(priority => buildEditOption(priority.id, priority.name, {
+              iconUrl: priority.iconUrl || ''
+            }));
+        },
+        save: selectedOptions => {
+          const selectedPriority = selectedOptions[0];
+          if (!selectedPriority?.id) {
+            throw new Error('Pick a priority before saving');
+          }
+          return requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
+            fields: {
+              priority: {id: selectedPriority.id}
+            }
+          });
+        },
+        successMessage: selectedOptions => {
+          const selectedPriority = selectedOptions[0];
+          return selectedPriority?.label
+            ? `Priority set to ${selectedPriority.label}`
+            : 'Priority updated';
+        }
+      };
+    }
+
+    if (fieldKey === 'status') {
+      const transitions = await getTransitionOptions(issueData?.key);
+      if (!transitions.length) {
+        return null;
+      }
+      return {
+        fieldKey,
+        editorType: 'transition-select',
+        label: 'Status transition',
+        selectionMode: 'single',
+        currentText: issueData?.fields?.status?.name || '',
+        currentOptionId: null,
+        currentSelections: [],
+        initialInputValue: '',
+        inputPlaceholder: 'Type to filter transitions',
+        loadOptions: () => transitions,
+        save: selectedOptions => {
+          const selectedTransition = selectedOptions[0];
+          if (!selectedTransition?.id) {
+            throw new Error('Pick a transition before saving');
+          }
+          return requestJson('POST', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}/transitions`, {
+            transition: {id: selectedTransition.id}
+          });
+        },
+        successMessage: selectedOptions => {
+          const selectedTransition = selectedOptions[0];
+          if (selectedTransition?.targetStatusName) {
+            return `Status moved to ${selectedTransition.targetStatusName}`;
+          }
+          return 'Status updated';
+        }
+      };
+    }
+
+    if (fieldKey === 'assignee') {
+      const capability = await getEditableFieldCapability(issueData, 'assignee');
+      if (!capability.editable) {
+        return null;
+      }
+      const currentAssignee = issueData?.fields?.assignee;
+      const currentOption = currentAssignee
+        ? buildEditOption(currentAssignee.accountId || currentAssignee.name || currentAssignee.key, currentAssignee.displayName || currentAssignee.name || currentAssignee.key, {
+            avatarUrl: currentAssignee.avatarUrls?.['48x48'] || '',
+            metaText: currentAssignee.name || currentAssignee.key || '',
+            rawValue: {
+              accountId: currentAssignee.accountId || '',
+              name: currentAssignee.name || '',
+              key: currentAssignee.key || ''
+            }
+          })
+        : null;
+      return {
+        fieldKey,
+        editorType: 'user-search',
+        label: 'Assignee',
+        selectionMode: 'single',
+        currentText: currentAssignee?.displayName || 'Unassigned',
+        currentOptionId: currentOption?.id || '__unassigned__',
+        currentSelections: currentOption ? [currentOption] : [buildEditOption('__unassigned__', 'Unassigned', {
+          metaText: 'No assignee'
+        })],
+        initialInputValue: '',
+        inputPlaceholder: 'Search assignable users',
+        loadOptions: async () => {
+          const searchedOptions = await searchAssignableUsers('', issueData);
+          const options = [buildEditOption('__unassigned__', 'Unassigned', {metaText: 'Clear assignee'})];
+          if (currentOption && !options.find(option => option.id === currentOption.id)) {
+            options.push(currentOption);
+          }
+          searchedOptions.forEach(option => {
+            if (!options.find(existing => existing.id === option.id)) {
+              options.push(option);
+            }
+          });
+          assigneeLocalOptionsCache.set(issueData.key, options.filter(option => option.id !== '__unassigned__'));
+          return options;
+        },
+        searchOptions: async query => {
+          const localBaselineOptions = assigneeLocalOptionsCache.get(issueData.key) || [];
+          const searchedOptions = await searchAssignableUsers(query, issueData);
+          const mergedOptions = [buildEditOption('__unassigned__', 'Unassigned', {metaText: 'Clear assignee'}), ...searchedOptions, ...localBaselineOptions]
+            .filter((option, index, options) => {
+              return option?.id && options.findIndex(candidate => candidate.id === option.id) === index;
+            });
+          assigneeLocalOptionsCache.set(issueData.key, mergedOptions.filter(option => option.id !== '__unassigned__'));
+          return mergedOptions;
+        },
+        save: selectedOptions => saveAssigneeSelection(issueData, selectedOptions),
+        successMessage: selectedOptions => {
+          const selectedOption = selectedOptions[0];
+          if (!selectedOption || selectedOption.id === '__unassigned__') {
+            return 'Assignee cleared';
+          }
+          return `Assignee set to ${selectedOption.label}`;
+        }
+      };
+    }
+
     return null;
   }
 
@@ -2060,60 +2451,159 @@ async function mainAsyncLocal() {
     return filtered;
   }
 
-  function buildEditableFieldChip(fieldKey, baseChip, state) {
+  function mergeEditOptions(primaryOptions, fallbackOptions) {
+    const mergedOptions = [];
+    const seen = new Set();
+    [...(Array.isArray(primaryOptions) ? primaryOptions : []), ...(Array.isArray(fallbackOptions) ? fallbackOptions : [])]
+      .forEach(option => {
+        const optionId = String(option?.id || '');
+        if (!optionId || seen.has(optionId)) {
+          return;
+        }
+        seen.add(optionId);
+        mergedOptions.push(option);
+      });
+    return mergedOptions;
+  }
+
+  function buildActiveEditPresentation(fieldKey, state, options = {}) {
     const editState = state?.editState;
-    if (editState?.fieldKey === fieldKey) {
-      const isMultiSelect = editState.selectionMode === 'multi';
-      const selectedOptionIds = new Set(isMultiSelect
-        ? normalizeMultiSelectOptionIds(editState.selectedOptionIds)
-        : (editState.selectedOptionId === null || typeof editState.selectedOptionId === 'undefined'
-            ? []
-            : [String(editState.selectedOptionId)]));
-      const options = filterEditOptions(editState.options, editState.inputValue).map(option => ({
-        ...option,
-        fieldKey,
-        isSelected: selectedOptionIds.has(option.id),
-        isMultiSelect,
-        title: option.label
-      }));
-      const selectedValues = isMultiSelect
-        ? (editState.selectedOptions || []).map(option => ({
-            ...option,
-            title: option.label
-          }))
-        : [];
+    if (editState?.fieldKey !== fieldKey) {
+      return null;
+    }
+
+    const isMultiSelect = editState.selectionMode === 'multi';
+    const selectedOptionIds = new Set(isMultiSelect
+      ? normalizeMultiSelectOptionIds(editState.selectedOptionIds)
+      : (editState.selectedOptionId === null || typeof editState.selectedOptionId === 'undefined'
+          ? []
+          : [String(editState.selectedOptionId)]));
+    const filteredOptions = filterEditOptions(editState.options, editState.inputValue).map(option => ({
+      ...option,
+      fieldKey,
+      isSelected: selectedOptionIds.has(option.id),
+      isMultiSelect,
+      title: option.label
+    }));
+    const selectedValues = isMultiSelect
+      ? (editState.selectedOptions || []).map(option => ({
+          ...option,
+          title: option.label
+        }))
+      : [];
+    const isSearchEditor = editState.editorType === 'user-search' || editState.editorType === 'issue-search';
+    const inputDisabled = !!(editState.saving || (editState.loadingOptions && !isSearchEditor));
+    const loadingText = editState.loadingOptions
+      ? (isSearchEditor ? `Searching ${editState.label.toLowerCase()}...` : `Loading ${editState.label.toLowerCase()} values...`)
+      : editState.saving
+        ? `Saving ${editState.label.toLowerCase()}...`
+        : '';
+
+    return {
+      fieldKey,
+      isEditing: true,
+      isRightAligned: options.isRightAligned || fieldKey === 'fixVersions' || fieldKey === 'versions',
+      editLabel: editState.label,
+      inputValue: editState.inputValue,
+      inputPlaceholder: editState.inputPlaceholder || `Type to filter ${editState.label.toLowerCase()} values`,
+      inputDisabled,
+      loadingText,
+      options: filteredOptions,
+      hasOptions: filteredOptions.length > 0,
+      editEmptyText: editState.loadingOptions ? 'Loading values...' : 'No matching values',
+      editError: editState.errorMessage || '',
+      isMultiSelect,
+      showActionButtons: isMultiSelect,
+      showSelectedValues: isMultiSelect && selectedValues.length > 0,
+      selectedValues,
+      saveDisabled: !!(editState.loadingOptions || editState.saving || !editState.hasChanges),
+      discardDisabled: !!editState.saving
+    };
+  }
+
+  function buildEditableFieldChip(fieldKey, baseChip, state, options = {}) {
+    if (options.canEdit === false) {
+      return baseChip;
+    }
+    const activeEdit = buildActiveEditPresentation(fieldKey, state, {
+      isRightAligned: options.isRightAligned
+    });
+    if (activeEdit) {
       return {
         ...baseChip,
+        ...activeEdit,
         isEditable: true,
-        isEditing: true,
-        isRightAligned: fieldKey === 'fixVersions' || fieldKey === 'versions',
-        fieldKey,
-        editLabel: editState.label,
-        inputValue: editState.inputValue,
-        inputPlaceholder: editState.inputPlaceholder || `Type to filter ${editState.label.toLowerCase()} values`,
-        inputDisabled: !!(editState.loadingOptions || editState.saving),
-        loadingText: editState.loadingOptions
-          ? `Loading ${editState.label.toLowerCase()} values...`
-          : editState.saving
-            ? `Saving ${editState.label.toLowerCase()}...`
-            : '',
-        options,
-        hasOptions: options.length > 0,
-        editEmptyText: editState.loadingOptions ? 'Loading values...' : 'No matching values',
-        editError: editState.errorMessage || '',
-        isMultiSelect,
-        showActionButtons: isMultiSelect,
-        showSelectedValues: isMultiSelect && selectedValues.length > 0,
-        selectedValues,
-        saveDisabled: !!(editState.loadingOptions || editState.saving || !editState.hasChanges),
-        discardDisabled: !!editState.saving
+        hideInlineEditButton: !!options.hideInlineEditButton
       };
     }
     return {
       ...baseChip,
       isEditable: true,
+      hideInlineEditButton: !!options.hideInlineEditButton,
       fieldKey,
-      editTitle: `Edit ${baseChip.text}`
+      editTitle: options.editTitle || `Edit ${baseChip.text}`
+    };
+  }
+
+  function getUserInitials(displayName, fallbackInitials = 'NA') {
+    const tokens = String(displayName || '')
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+    if (!tokens.length) {
+      return fallbackInitials;
+    }
+    if (tokens.length === 1) {
+      return tokens[0].slice(0, 2).toUpperCase();
+    }
+    return `${tokens[0][0] || ''}${tokens[tokens.length - 1][0] || ''}`.toUpperCase();
+  }
+
+  function isLikelyDefaultAvatar(user, avatarUrl) {
+    if (!avatarUrl) {
+      return true;
+    }
+    if (user?.isDefaultAvatar === true) {
+      return true;
+    }
+    const normalizedUrl = String(avatarUrl || '').toLowerCase();
+    return normalizedUrl.includes('defaultavatar') ||
+      normalizedUrl.includes('/avatar.png') ||
+      normalizedUrl.includes('avatar/default') ||
+      normalizedUrl.includes('initials=');
+  }
+
+  function buildUserAvatarView(user, titlePrefix, fallbackInitials = 'NA') {
+    const displayName = user?.displayName || '';
+    const avatarUrl = user?.avatarUrls?.['48x48'] || '';
+    const useInitials = isLikelyDefaultAvatar(user, avatarUrl);
+    return {
+      avatarUrl: useInitials ? '' : avatarUrl,
+      initials: getUserInitials(displayName, fallbackInitials),
+      displayName,
+      titleText: `${titlePrefix}: ${displayName || 'Unknown'}`
+    };
+  }
+
+  function buildAssigneeAvatarView(state, issueData, canEditAssignee) {
+    const assignee = issueData?.fields?.assignee;
+    const displayName = assignee?.displayName || 'Unassigned';
+    const baseAvatarView = assignee
+      ? buildUserAvatarView(assignee, 'Assignee', 'NA')
+      : {
+          avatarUrl: '',
+          initials: 'NA',
+          displayName,
+          titleText: 'Assignee: Unassigned'
+        };
+    const activeEdit = buildActiveEditPresentation('assignee', state);
+    return {
+      ...baseAvatarView,
+      displayName,
+      placeholderText: assignee ? '' : 'Unassigned',
+      isEditable: !!canEditAssignee,
+      editTitle: assignee ? 'Edit assignee' : 'Assign issue',
+      ...(activeEdit || {})
     };
   }
   function compareSprintState(left, right) {
@@ -2381,6 +2871,17 @@ async function mainAsyncLocal() {
     const statusName = issueData.fields.status?.name;
     const priorityName = issueData.fields.priority?.name;
     const projectKey = key.split('-')[0];
+    const [priorityCapability, assigneeCapability, transitionOptions, sprintCapability, affectsCapability, fixVersionsCapability] = await Promise.all([
+      displayFields.priority ? getEditableFieldCapability(issueData, 'priority') : Promise.resolve({editable: false}),
+      displayFields.assignee ? getEditableFieldCapability(issueData, 'assignee') : Promise.resolve({editable: false}),
+      displayFields.status ? getTransitionOptions(issueData.key).catch(() => []) : Promise.resolve([]),
+      displayFields.sprint ? getEditableFieldCapability(issueData, 'sprint') : Promise.resolve({editable: false}),
+      displayFields.affects ? getEditableFieldCapability(issueData, 'versions') : Promise.resolve({editable: false}),
+      displayFields.fixVersions ? getEditableFieldCapability(issueData, 'fixVersions') : Promise.resolve({editable: false})
+    ]);
+    const statusEditable = Array.isArray(transitionOptions) && transitionOptions.length > 0;
+    const priorityEditable = !!priorityCapability?.editable;
+    const assigneeEditable = !!assigneeCapability?.editable;
 
     const row1Chips = [
       displayFields.issueType ? buildFilterChip(
@@ -2388,16 +2889,22 @@ async function mainAsyncLocal() {
         issueTypeName ? `${scopeJqlToProject(projectKey, `issuetype = ${encodeJqlValue(issueTypeName)}`)}` : '',
         {iconUrl: issueData.fields.issuetype?.iconUrl || ''}
       ) : null,
-      displayFields.status ? buildFilterChip(
+      displayFields.status ? buildEditableFieldChip('status', buildFilterChip(
         statusName || 'No status',
         statusName ? `${scopeJqlToProject(projectKey, `status = ${encodeJqlValue(statusName)}`)}` : '',
         {iconUrl: issueData.fields.status?.iconUrl || ''}
-      ) : null,
-      displayFields.priority ? buildFilterChip(
+      ), state, {
+        canEdit: statusEditable,
+        editTitle: 'Change status via transition'
+      }) : null,
+      displayFields.priority ? buildEditableFieldChip('priority', buildFilterChip(
         priorityName || 'No priority',
         priorityName ? `${scopeJqlToProject(projectKey, `priority = ${encodeJqlValue(priorityName)}`)}` : '',
         {iconUrl: issueData.fields.priority?.iconUrl || ''}
-      ) : null,
+      ), state, {
+        canEdit: priorityEditable,
+        editTitle: 'Edit priority'
+      }) : null,
       displayFields.epicParent ? {
         text: epicOrParent
           ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
@@ -2414,15 +2921,23 @@ async function mainAsyncLocal() {
       displayFields.sprint ? buildEditableFieldChip('sprint', buildFilterChip(
         `Sprint: ${formatSprintText(sprints) || '--'}`,
         ''
-      ), state) : null,
+      ), state, {
+        canEdit: !!sprintCapability?.editable
+      }) : null,
       displayFields.affects ? buildEditableFieldChip('versions', buildFilterChip(
         `Affects: ${formatVersionText(affectsVersions) || '--'}`,
         singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
-      ), state) : null,
+      ), state, {
+        canEdit: !!affectsCapability?.editable,
+        isRightAligned: true
+      }) : null,
       displayFields.fixVersions ? buildEditableFieldChip('fixVersions', buildFilterChip(
         `Fix version: ${formatVersionText(fixVersions) || '--'}`,
         singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
-      ), state) : null,
+      ), state, {
+        canEdit: !!fixVersionsCapability?.editable,
+        isRightAligned: true
+      }) : null,
       ...customFieldChips[2]
     ].filter(Boolean);
 
@@ -2445,6 +2960,12 @@ async function mainAsyncLocal() {
     const visibleCommentsTotal = displayFields.comments ? commentsTotal : 0;
     const visibleAttachments = displayFields.attachments ? previewAttachments : [];
     const quickActionData = buildQuickActionViewData(actionsOpen, actionLoadingKey, quickActions);
+    const reporterView = displayFields.reporter && issueData.fields.reporter
+      ? buildUserAvatarView(issueData.fields.reporter, 'Reporter', 'NA')
+      : null;
+    const assigneeView = displayFields.assignee
+      ? buildAssigneeAvatarView(state, issueData, assigneeEditable)
+      : null;
     const displayData = {
       urlTitle: `[${key}] ${issueData.fields.summary}`,
       ticketKey: key,
@@ -2481,7 +3002,9 @@ async function mainAsyncLocal() {
       commentsTotal: visibleCommentsTotal,
       attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
       reporter: displayFields.reporter ? issueData.fields.reporter : null,
+      reporterView,
       assignee: displayFields.assignee ? issueData.fields.assignee : null,
+      assigneeView,
       commentUrl: issueUrl,
       hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
       activityIndicators: [],
@@ -2622,6 +3145,14 @@ async function mainAsyncLocal() {
       return;
     }
     issueCache.delete(popupState.key);
+    editMetaCache.delete(popupState.key);
+    transitionOptionsCache.delete(popupState.key);
+    assigneeLocalOptionsCache.delete(popupState.key);
+    [...assigneeSearchCache.keys()].forEach(cacheKey => {
+      if (String(cacheKey).startsWith(`${popupState.key}__`)) {
+        assigneeSearchCache.delete(cacheKey);
+      }
+    });
     if (popupState.issueData?.id) {
       const issueId = String(popupState.issueData.id);
       [...pullRequestCache.keys()].forEach(cacheKey => {
@@ -2709,6 +3240,47 @@ async function mainAsyncLocal() {
       await renderIssuePopup(popupState);
     }
   }
+  const triggerSearchOptionsForActiveEdit = debounce(async (fieldKey, queryText, requestId) => {
+    if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey) {
+      return;
+    }
+    try {
+      const definition = await getEditableFieldDefinition(fieldKey, popupState.issueData);
+      if (!definition?.searchOptions) {
+        return;
+      }
+      const options = await definition.searchOptions(queryText);
+      if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey || popupState.editState.searchRequestId !== requestId) {
+        return;
+      }
+      const mergedOptions = popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search'
+        ? mergeEditOptions(options, popupState.editState.options)
+        : options;
+      popupState = {
+        ...popupState,
+        editState: {
+          ...popupState.editState,
+          options: mergedOptions,
+          loadingOptions: false,
+          errorMessage: ''
+        }
+      };
+      await renderIssuePopup(popupState);
+    } catch (error) {
+      if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey || popupState.editState.searchRequestId !== requestId) {
+        return;
+      }
+      popupState = {
+        ...popupState,
+        editState: {
+          ...popupState.editState,
+          loadingOptions: false,
+          errorMessage: buildEditFieldError(error)
+        }
+      };
+      await renderIssuePopup(popupState);
+    }
+  }, 220);
   async function startFieldEdit(fieldKey) {
     if (!popupState?.issueData) {
       return;
@@ -2716,21 +3288,24 @@ async function mainAsyncLocal() {
     if (popupState.editState?.fieldKey === fieldKey) {
       return;
     }
-    const definition = getEditableFieldDefinition(fieldKey, popupState.issueData);
+    const definition = await getEditableFieldDefinition(fieldKey, popupState.issueData);
     if (!definition) {
       return;
     }
     const isMultiSelect = definition.selectionMode === 'multi';
-    const initialValue = definition.initialInputValue ?? definition.currentText ?? '';
+    const initialValue = isMultiSelect
+      ? (definition.initialInputValue ?? definition.currentText ?? '')
+      : (definition.initialInputValue ?? '');
     const currentSelections = Array.isArray(definition.currentSelections) ? definition.currentSelections : [];
     popupState = {
       ...popupState,
       editState: {
         fieldKey,
         label: definition.label,
+        editorType: definition.editorType || (isMultiSelect ? 'multi-select' : 'single-select'),
         selectionMode: definition.selectionMode || 'single',
         inputValue: initialValue,
-        inputPlaceholder: `Type to filter ${definition.label.toLowerCase()} values`,
+        inputPlaceholder: definition.inputPlaceholder || `Type to filter ${definition.label.toLowerCase()} values`,
         options: [],
         selectedOptionId: isMultiSelect ? null : definition.currentOptionId,
         selectedOptionIds: isMultiSelect ? normalizeMultiSelectOptionIds(currentSelections.map(option => option.id)) : [],
@@ -2740,6 +3315,7 @@ async function mainAsyncLocal() {
         loadingOptions: true,
         saving: false,
         errorMessage: '',
+        searchRequestId: 0,
         selectionStart: initialValue.length,
         selectionEnd: initialValue.length
       }
@@ -2760,8 +3336,7 @@ async function mainAsyncLocal() {
           })
         };
       } else {
-        const selectedOption = (Array.isArray(options) ? options : []).find(option => option.id === popupState.editState.selectedOptionId);
-        const nextInputValue = selectedOption ? selectedOption.label : popupState.editState.inputValue;
+        const nextInputValue = popupState.editState.inputValue || '';
         popupState = {
           ...popupState,
           editState: {
@@ -2775,6 +3350,20 @@ async function mainAsyncLocal() {
         };
       }
       await renderIssuePopup(popupState);
+
+      if (popupState?.editState?.fieldKey === fieldKey && popupState.editState.editorType === 'user-search') {
+        const searchRequestId = ++editSearchRequestCounter;
+        popupState = {
+          ...popupState,
+          editState: {
+            ...popupState.editState,
+            loadingOptions: true,
+            searchRequestId
+          }
+        };
+        await renderIssuePopup(popupState);
+        triggerSearchOptionsForActiveEdit(fieldKey, popupState.editState.inputValue, searchRequestId);
+      }
     } catch (error) {
       const errorMessage = buildEditFieldError(error);
       if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey) {
@@ -2830,18 +3419,58 @@ async function mainAsyncLocal() {
     const exactOption = (popupState.editState.options || []).find(option => {
       return option.label.toLowerCase() === normalizedValue.trim().toLowerCase();
     });
+    let nextInputValue = normalizedValue;
+    let nextSelectionStart = selectionStart;
+    let nextSelectionEnd = selectionEnd;
+    let nextSelectedOptionId = exactOption ? exactOption.id : null;
+
+    const canAutoComplete = popupState.editState.editorType !== 'user-search' &&
+      popupState.editState.editorType !== 'issue-search' &&
+      popupState.editState.editorType !== 'multi-select' &&
+      typeof selectionStart === 'number' &&
+      typeof selectionEnd === 'number' &&
+      selectionStart === selectionEnd &&
+      selectionEnd === normalizedValue.length &&
+      normalizedValue.length > 0;
+
+    if (canAutoComplete && !exactOption) {
+      const prefixOption = (popupState.editState.options || []).find(option => {
+        return option.label.toLowerCase().startsWith(normalizedValue.toLowerCase());
+      });
+      if (prefixOption) {
+        nextInputValue = prefixOption.label;
+        nextSelectedOptionId = prefixOption.id;
+        nextSelectionStart = normalizedValue.length;
+        nextSelectionEnd = prefixOption.label.length;
+      }
+    }
+
     popupState = {
       ...popupState,
       editState: {
         ...popupState.editState,
-        inputValue: normalizedValue,
-        selectedOptionId: exactOption ? exactOption.id : null,
+        inputValue: nextInputValue,
+        selectedOptionId: nextSelectedOptionId,
         errorMessage: '',
-        selectionStart,
-        selectionEnd
+        selectionStart: nextSelectionStart,
+        selectionEnd: nextSelectionEnd
       }
     };
     renderIssuePopup(popupState).catch(() => {});
+
+    if (popupState.editState.editorType === 'user-search') {
+      const searchRequestId = ++editSearchRequestCounter;
+      popupState = {
+        ...popupState,
+        editState: {
+          ...popupState.editState,
+          loadingOptions: true,
+          searchRequestId
+        }
+      };
+      renderIssuePopup(popupState).catch(() => {});
+      triggerSearchOptionsForActiveEdit(popupState.editState.fieldKey, normalizedValue, searchRequestId);
+    }
   }
 
   function selectFieldEditOption(optionId) {
@@ -2879,6 +3508,9 @@ async function mainAsyncLocal() {
       }
     };
     renderIssuePopup(popupState).catch(() => {});
+    if (popupState.editState.editorType === 'transition-select') {
+      submitFieldEdit(popupState.editState.fieldKey).catch(() => {});
+    }
   }
 
   function resolveSelectedEditOptions(editState) {
@@ -2921,7 +3553,7 @@ async function mainAsyncLocal() {
     if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey || popupState.editState.loadingOptions || popupState.editState.saving) {
       return;
     }
-    const definition = getEditableFieldDefinition(fieldKey, popupState.issueData);
+    const definition = await getEditableFieldDefinition(fieldKey, popupState.issueData);
     if (!definition) {
       return;
     }

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -41,6 +41,7 @@ async function getSprintFieldIds(instanceUrl) {
   return sprintFieldIdsPromise;
 }
 
+
 /**
  * Returns a function that will return an array of jira tickets for any given string
  * @param projectKeys project keys to match
@@ -168,7 +169,6 @@ async function mainAsyncLocal() {
     fixVersions: true,
     affects: true,
     labels: true,
-    account: true,
     epicParent: true,
     attachments: true,
     comments: true,
@@ -178,6 +178,7 @@ async function mainAsyncLocal() {
     pullRequests: true,
     ...(config.displayFields || {})
   };
+  const customFields = normalizeCustomFields(config.customFields);
   let jiraProjects = [];
   let getJiraKeys = buildFallbackJiraKeyMatcher();
   try {
@@ -190,9 +191,8 @@ async function mainAsyncLocal() {
     getJiraKeys = buildJiraKeyMatcher(jiraProjects.map(function (project) {
       return project.key;
     }));
-  } else {
-    console.log("Couldn't load Jira projects, using fallback issue-key matcher.");
   }
+
   const annotationTemplate = await fetch(chrome.runtime.getURL('resources/annotation.html')).then(response => response.text());
   const loaderGifUrl = chrome.runtime.getURL('resources/ajax-loader.gif');
   const imageProxyCache = {};
@@ -437,8 +437,47 @@ async function mainAsyncLocal() {
   }
 
   function getPullRequestData(issueId, applicationType) {
-    const appTypeQuery = applicationType ? `&applicationType=${encodeURIComponent(applicationType)}` : '';
-    return get(`${INSTANCE_URL}rest/dev-status/1.0/issue/details?issueId=${issueId}${appTypeQuery}&dataType=pullrequest`);
+    return get(INSTANCE_URL + 'rest/dev-status/1.0/issue/detail?issueId=' + issueId + '&applicationType=gitlabselfmanaged&dataType=pullrequest');
+  }
+
+  function getPullRequestSummaryData(issueId) {
+    return get(`${INSTANCE_URL}rest/dev-status/1.0/issue/summary?issueId=${issueId}`);
+  }
+
+  async function probeDevStatusEndpoints(issueId) {
+    const probes = [
+      {label: '1.0 summary', url: `${INSTANCE_URL}rest/dev-status/1.0/issue/summary?issueId=${issueId}`},
+      {label: 'latest summary', url: `${INSTANCE_URL}rest/dev-status/latest/issue/summary?issueId=${issueId}`},
+      {label: '1.0 details none', url: `${INSTANCE_URL}rest/dev-status/1.0/issue/detail?issueId=${issueId}&dataType=pullrequest`},
+      {label: 'latest details none', url: `${INSTANCE_URL}rest/dev-status/latest/issue/detail?issueId=${issueId}&dataType=pullrequest`},
+      {label: '1.0 details gitlabselfmanaged', url: `${INSTANCE_URL}rest/dev-status/1.0/issue/detail?issueId=${issueId}&applicationType=gitlabselfmanaged&dataType=pullrequest`},
+      {label: 'latest details gitlabselfmanaged', url: `${INSTANCE_URL}rest/dev-status/latest/issue/detail?issueId=${issueId}&applicationType=gitlabselfmanaged&dataType=pullrequest`}
+    ];
+
+    const results = [];
+    for (const probe of probes) {
+      try {
+        const response = await get(probe.url);
+        results.push({
+          label: probe.label,
+          url: probe.url,
+          ok: true,
+          topLevelKeys: Object.keys(response || {}),
+          hasSummary: Array.isArray(response?.summary),
+          hasDetail: Array.isArray(response?.detail),
+          summaryCount: Array.isArray(response?.summary) ? response.summary.length : null,
+          detailCount: Array.isArray(response?.detail) ? response.detail.length : null
+        });
+      } catch (ex) {
+        results.push({
+          label: probe.label,
+          url: probe.url,
+          ok: false,
+          error: ex?.message || String(ex)
+        });
+      }
+    }
+    return results;
   }
 
   async function getCachedValue(cache, key, buildValue) {
@@ -473,7 +512,8 @@ async function mainAsyncLocal() {
         'versions',
         'parent',
         'fixVersions',
-        ...sprintFieldIds
+        ...sprintFieldIds,
+        ...customFields.map(({fieldId}) => fieldId)
       ];
       return get(INSTANCE_URL + 'rest/api/2/issue/' + issueKey + '?fields=' + fields.join(',') + '&expand=renderedFields,names');
     });
@@ -484,6 +524,78 @@ async function mainAsyncLocal() {
     return getCachedValue(pullRequestCache, cacheKey, () => {
       return getPullRequestData(issueId, applicationType);
     });
+  }
+
+  function getPullRequestSummaryDataCached(issueId) {
+    return getCachedValue(pullRequestCache, `summary__${issueId}`, () => {
+      return getPullRequestSummaryData(issueId);
+    });
+  }
+
+  function normalizePullRequests(response) {
+    if (Array.isArray(response)) {
+      return response.filter(Boolean);
+    }
+
+    const detailEntries = Array.isArray(response?.detail)
+      ? response.detail
+      : Array.isArray(response?.details)
+        ? response.details
+        : response ? [response] : [];
+
+    return detailEntries
+      .flatMap(entry => {
+        if (Array.isArray(entry?.pullRequests)) {
+          return entry.pullRequests;
+        }
+        if (Array.isArray(entry?.pullrequests)) {
+          return entry.pullrequests;
+        }
+        if (Array.isArray(entry?.pullRequest)) {
+          return entry.pullRequest;
+        }
+        return [];
+      })
+      .filter(Boolean);
+  }
+
+  function summarizePullRequestDebugResponse(response) {
+    const detail = Array.isArray(response?.detail) ? response.detail : [];
+    return {
+      detailCount: detail.length,
+      details: detail.map(entry => ({
+        applicationType: entry?.applicationType || '',
+        objectName: entry?.objectName || '',
+        repoCount: Array.isArray(entry?.repositories) ? entry.repositories.length : 0,
+        pullRequestCount: Array.isArray(entry?.pullRequests) ? entry.pullRequests.length : 0,
+        pullRequests: (entry?.pullRequests || []).map(pr => ({
+          id: pr?.id,
+          name: pr?.name,
+          url: pr?.url,
+          status: pr?.status
+        }))
+      }))
+    };
+  }
+
+  function summarizePullRequestSummaryResponse(response) {
+    const summary = Array.isArray(response?.summary) ? response.summary : [];
+    return {
+      summaryCount: summary.length,
+      summary: summary.map(entry => ({
+        applicationType: entry?.applicationType || '',
+        dataType: entry?.dataType || '',
+        branchCount: entry?.branch?.overall?.count ?? entry?.branches?.overall?.count ?? null,
+        repositoryCount: entry?.repository?.overall?.count ?? entry?.repositories?.overall?.count ?? null,
+        commitCount: entry?.commit?.overall?.count ?? entry?.commits?.overall?.count ?? null,
+        pullRequestCount: entry?.pullrequest?.overall?.count ?? entry?.pullRequest?.overall?.count ?? entry?.pullrequests?.overall?.count ?? null,
+        reviewCount: entry?.review?.overall?.count ?? entry?.reviews?.overall?.count ?? null,
+        buildCount: entry?.build?.overall?.count ?? entry?.builds?.overall?.count ?? null,
+        deploymentCount: entry?.deployment?.overall?.count ?? entry?.deployments?.overall?.count ?? null,
+        overall: entry?.overall || null,
+        rawKeys: Object.keys(entry || {})
+      }))
+    };
   }
 
   async function getIssueSummary(issueKey) {
@@ -535,31 +647,70 @@ async function mainAsyncLocal() {
     }
   }
 
-  function readAccountValues(issueData) {
+  function normalizeCustomFields(customFields) {
+    if (!Array.isArray(customFields)) {
+      return [];
+    }
+    const seen = {};
+    return customFields
+      .map(field => {
+        const fieldId = String(field?.fieldId || '').trim();
+        const row = Math.min(3, Math.max(1, Number(field?.row) || 3));
+        return {fieldId, row};
+      })
+      .filter(field => {
+        if (!field.fieldId || seen[field.fieldId]) {
+          return false;
+        }
+        seen[field.fieldId] = true;
+        return true;
+      });
+  }
+
+  function formatCustomFieldChip(fieldName, entry) {
+    if (entry === undefined || entry === null) {
+      return null;
+    }
+    if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
+      const textValue = String(entry);
+      const looksLikeUrl = /^https?:\/\//i.test(textValue);
+      return {
+        text: looksLikeUrl ? (fieldName || textValue) : (fieldName ? `${fieldName}: ${textValue}` : textValue),
+        url: looksLikeUrl ? textValue : ''
+      };
+    }
+    const primaryText = entry.name || entry.value || entry.displayName || entry.id || entry.key;
+    const rawUrl = [entry.self, entry.url, entry.href].find(value => typeof value === 'string' && value.trim());
+    if (!primaryText && !rawUrl) {
+      return null;
+    }
+    const formattedValue = entry.key && (entry.name || entry.value)
+      ? `[${entry.key}] ${entry.name || entry.value}`
+      : primaryText ? String(primaryText) : rawUrl;
+    return {
+      text: fieldName ? `${fieldName}: ${formattedValue}` : formattedValue,
+      url: rawUrl ? toAbsoluteJiraUrl(rawUrl) : ''
+    };
+  }
+  function buildCustomFieldChips(issueData, customFields) {
     const names = issueData.names || {};
     const fields = issueData.fields || {};
-    const accountFieldIds = Object.keys(names).filter(fieldId => {
-      return String(names[fieldId] || '').toLowerCase().includes('account');
-    });
-    const values = [];
-    accountFieldIds.forEach(fieldId => {
-      const value = fields[fieldId];
-      if (!value) {
+    const chipsByRow = {1: [], 2: [], 3: []};
+    customFields.forEach(({fieldId, row}) => {
+      const rawValue = fields[fieldId];
+      if (rawValue === undefined || rawValue === null || rawValue === '') {
         return;
       }
-      const entries = Array.isArray(value) ? value : [value];
+      const fieldName = String(names[fieldId] || fieldId);
+      const entries = Array.isArray(rawValue) ? rawValue : [rawValue];
       entries.forEach(entry => {
-        if (!entry) {
-          return;
+        const chip = formatCustomFieldChip(fieldName, entry);
+        if (chip && chip.text) {
+          chipsByRow[row].push(chip);
         }
-        if (typeof entry === 'string') {
-          values.push(entry);
-          return;
-        }
-        values.push(entry.name || entry.value || entry.key || entry.id);
       });
     });
-    return [...new Set(values.filter(Boolean))];
+    return chipsByRow;
   }
 
   function readSprintsFromIssue(issueData) {
@@ -662,6 +813,40 @@ async function mainAsyncLocal() {
     if (totals.doc) chips.push({icon: '📝', count: totals.doc});
     if (totals.other) chips.push({icon: '📎', count: totals.other});
     return chips;
+  }
+
+
+  function buildActivityIndicators(attachments, commentsTotal, pullRequestsTotal) {
+    const attachmentCount = Array.isArray(attachments) ? attachments.length : 0;
+    const commentCount = Number(commentsTotal) || 0;
+    const pullRequestCount = Number(pullRequestsTotal) || 0;
+    return [
+      {icon: '📎', count: attachmentCount, label: 'Attachments'},
+      {icon: '💬', count: commentCount, label: 'Comments'},
+      {icon: '🔀', count: pullRequestCount, label: 'Pull requests'}
+    ].map(item => ({
+      ...item,
+      title: item.count + ' ' + item.label.toLowerCase()
+    }));
+  }
+
+  function formatPullRequestTitle(pr) {
+    const id = pr?.id || pr?.number || pr?.key || '';
+    const title = pr?.name || pr?.title || 'Untitled pull request';
+    return id ? '[' + id + '] ' + title : title;
+  }
+
+  function formatPullRequestAuthor(pr) {
+    return pr?.author?.name || pr?.author?.displayName || pr?.author?.username || pr?.author?.email || '--';
+  }
+
+  function formatPullRequestBranch(pr) {
+    const source = pr?.source?.branch || pr?.sourceBranch || pr?.fromRef?.displayId || pr?.fromRef?.id || pr?.source?.displayId || '';
+    const target = pr?.destination?.branch || pr?.targetBranch || pr?.toRef?.displayId || pr?.toRef?.id || pr?.destination?.displayId || '';
+    if (source && target) {
+      return source + ' --> ' + target;
+    }
+    return source || target || '--';
   }
 
   function buildPreviewAttachments(attachments) {
@@ -914,11 +1099,17 @@ async function mainAsyncLocal() {
           const issueData = await getIssueMetaData(key);
           await normalizeIssueImages(issueData);
           let pullRequests = [];
-          try {
-            const githubPrs = await getPullRequestDataCached(issueData.id, 'github');
-            pullRequests = githubPrs.detail?.[0]?.pullRequests || [];
-          } catch (ex) {
-            // probably no access
+          if (displayFields.pullRequests) {
+            try {
+              const pullRequestResponse = await getPullRequestDataCached(issueData.id);
+              pullRequests = normalizePullRequests(pullRequestResponse);
+            } catch (ex) {
+              console.log('[Jira HotLinker] Pull request fetch failed', {
+                issueKey: key,
+                issueId: issueData.id,
+                error: ex?.message || String(ex)
+              });
+            }
           }
 
           if (cancelToken.cancel) {
@@ -935,7 +1126,7 @@ async function mainAsyncLocal() {
           const attachments = issueData.fields.attachment || [];
           const previewAttachments = buildPreviewAttachments(attachments);
           const labels = issueData.fields.labels || [];
-          const accountValues = readAccountValues(issueData);
+          const customFieldChips = buildCustomFieldChips(issueData, customFields);
           const epicOrParent = await readEpicOrParent(issueData);
           const issueTypeName = issueData.fields.issuetype?.name;
           const statusName = issueData.fields.status?.name;
@@ -958,7 +1149,8 @@ async function mainAsyncLocal() {
               text: epicOrParent
                 ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
                 : 'Parent: --'
-            } : null
+            } : null,
+            ...customFieldChips[1]
           ].filter(Boolean);
 
           const row2Chips = [
@@ -966,12 +1158,13 @@ async function mainAsyncLocal() {
             displayFields.affects ? {
               text: `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`
             } : null,
-            displayFields.fixVersions ? {text: `Fix version: ${formatFixVersionText(fixVersions) || '--'}`} : null
+            displayFields.fixVersions ? {text: `Fix version: ${formatFixVersionText(fixVersions) || '--'}`} : null,
+            ...customFieldChips[2]
           ].filter(Boolean);
 
           const row3Chips = [
             displayFields.labels ? {text: `Labels: ${labels.filter(Boolean).join(', ') || '--'}`} : null,
-            displayFields.account ? {text: `Account: ${accountValues.filter(Boolean).join(', ') || '--'}`} : null
+            ...customFieldChips[3]
           ].filter(Boolean);
 
           const copyTicketMeta = (ticket) => ({
@@ -980,6 +1173,8 @@ async function mainAsyncLocal() {
             copyTitle: ticket.summary
           });
 
+          const visibleCommentsTotal = displayFields.comments ? commentsTotal : 0;
+          const visibleAttachments = displayFields.attachments ? previewAttachments : [];
           const displayData = {
             urlTitle: `[${key}] ${issueData.fields.summary}`,
             ticketKey: key,
@@ -993,11 +1188,11 @@ async function mainAsyncLocal() {
             prs: [],
             description: displayFields.description ? normalizedDescription : '',
             hasBodyContent: true,
-            emptyBodyText: (!normalizedDescription && previewAttachments.length === 0 && commentsForDisplay.length === 0)
+            emptyBodyText: (!normalizedDescription && visibleAttachments.length === 0 && visibleCommentsTotal === 0)
               ? 'No description, attachments or comments.'
               : '',
             attachments,
-            previewAttachments: displayFields.attachments ? previewAttachments : [],
+            previewAttachments: visibleAttachments,
             commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
             issuetype: issueData.fields.issuetype,
             status: issueData.fields.status,
@@ -1009,31 +1204,39 @@ async function mainAsyncLocal() {
             row1Chips,
             row2Chips,
             row3Chips,
-            hasComments: displayFields.comments && commentsTotal > 0,
-            commentsTotal: displayFields.comments ? commentsTotal : 0,
+            hasComments: visibleCommentsTotal > 0,
+            commentsTotal: visibleCommentsTotal,
             attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
             reporter: displayFields.reporter ? issueData.fields.reporter : null,
             assignee: displayFields.assignee ? issueData.fields.assignee : null,
             commentUrl: INSTANCE_URL + 'browse/' + key,
             hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
+            activityIndicators: [],
             loaderGifUrl,
           };
           if (issueData.fields.comment?.comments?.[0]?.id) {
             displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
           }
           if (displayFields.pullRequests && size(pullRequests)) {
-            displayData.prs = pullRequests.filter(function (pr) {
-              return pr.url !== location.href;
-            }).map(function (pr) {
+            const filteredPullRequests = pullRequests.filter(function (pr) {
+              return pr && pr.url !== location.href;
+            });
+            displayData.prs = filteredPullRequests.map(function (pr) {
               return {
                 id: pr.id,
                 url: pr.url,
-                name: pr.name,
+                title: formatPullRequestTitle(pr),
                 status: pr.status,
-                author: pr.author
+                authorName: formatPullRequestAuthor(pr),
+                branchText: formatPullRequestBranch(pr)
               };
             });
           }
+          displayData.activityIndicators = buildActivityIndicators(
+            displayFields.attachments ? attachments : [],
+            visibleCommentsTotal,
+            displayData.prs.length
+          );
           // TODO: fix scrolling in google docs
           container.html(Mustache.render(annotationTemplate, displayData));
           if (!containerPinned) {
@@ -1056,5 +1259,14 @@ if (!window.__JX__script_injected__) {
 }
 
 window.__JX__script_injected__ = true;
+
+
+
+
+
+
+
+
+
 
 

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -750,6 +750,7 @@ async function mainAsyncLocal() {
   $(document.body).append(previewOverlay);
   new draggable({
     handle: '._JX_title, ._JX_status',
+    cancel: 'a, button, input, textarea, img, ._JX_description, ._JX_comments, ._JX_comment_body, ._JX_description_text, ._JX_related_pr'
   }, container);
   
   function buildPrettyLinkPayload(sourceElement) {

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -206,6 +206,7 @@ function notifyJiraConnectionFailure(instanceUrl, error) {
 async function mainAsyncLocal() {
   const $ = require('jquery');
   const draggable = require('jquery-ui/ui/widgets/draggable');
+  const DEBUG_CUSTOM_FIELD_ID = 'customfield_11200';
 
   const config = await getConfig();
   const INSTANCE_URL = config.instanceUrl;
@@ -1309,13 +1310,21 @@ async function mainAsyncLocal() {
         allowedValues: []
       };
     }
-    return {
+    const result = {
       editable: true,
       fieldKey: resolvedFieldKey,
       fieldMeta: editMetaField,
       operations: Array.isArray(editMetaField.operations) ? editMetaField.operations : [],
       allowedValues: Array.isArray(editMetaField.allowedValues) ? editMetaField.allowedValues : []
     };
+    if (resolvedFieldKey === DEBUG_CUSTOM_FIELD_ID) {
+      console.log('[JiraHotLinker][customfield_11200] getEditableFieldCapability', {
+        issueKey: issueData.key,
+        resolvedFieldKey,
+        result
+      });
+    }
+    return result;
   }
 
   async function getTransitionOptions(issueKey) {
@@ -1903,12 +1912,34 @@ async function mainAsyncLocal() {
     const capability = await getEditableFieldCapability(issueData, fieldId);
     const fieldMeta = capability.fieldMeta;
     const fieldName = String(issueData?.names?.[fieldId] || fieldMeta?.name || fieldId);
+    if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
+      console.log('[JiraHotLinker][customfield_11200] precheck', {
+        issueKey: issueData?.key,
+        fieldId,
+        fieldName,
+        capability,
+        fieldMeta
+      });
+    }
     if (!capability.editable || !fieldMeta || !Array.isArray(capability.allowedValues) || !capability.allowedValues.length) {
+      if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
+        console.log('[JiraHotLinker][customfield_11200] rejected-before-support-descriptor', {
+          editable: capability.editable,
+          hasFieldMeta: !!fieldMeta,
+          hasAllowedValuesArray: Array.isArray(capability.allowedValues),
+          allowedValuesLength: Array.isArray(capability.allowedValues) ? capability.allowedValues.length : null
+        });
+      }
       return null;
     }
 
     const supportDescriptor = getCustomFieldSupportDescriptor(fieldMeta);
     if (!supportDescriptor) {
+      if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
+        console.log('[JiraHotLinker][customfield_11200] rejected-support-descriptor', {
+          schema: fieldMeta?.schema
+        });
+      }
       return null;
     }
 
@@ -1926,15 +1957,35 @@ async function mainAsyncLocal() {
       .map(entry => buildCustomFieldOption(fieldName, entry))
       .filter(Boolean);
     const allOptions = mergeEditOptions(currentSelections, allowedOptions);
+    if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
+      console.log('[JiraHotLinker][customfield_11200] normalized-options', {
+        supportDescriptor,
+        operations,
+        currentValue,
+        currentSelections,
+        allowedValues: capability.allowedValues,
+        allowedOptions,
+        allOptions
+      });
+    }
 
     if (!allOptions.length) {
+      if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
+        console.log('[JiraHotLinker][customfield_11200] rejected-empty-options');
+      }
       return null;
     }
 
     if (isMultiValue && !operations.includes('set')) {
+      if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
+        console.log('[JiraHotLinker][customfield_11200] rejected-no-set-operation', {operations});
+      }
       return null;
     }
     if (!isMultiValue && !operations.includes('set')) {
+      if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
+        console.log('[JiraHotLinker][customfield_11200] rejected-no-set-operation', {operations});
+      }
       return null;
     }
 

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -133,6 +133,15 @@ async function getImageDataUrl(url) {
     throw err;
   }
 }
+async function requestJson(method, url, body) {
+  const response = await sendMessage({action: 'requestJson', method, url, body});
+  if (Object.prototype.hasOwnProperty.call(response, 'result')) {
+    return response.result;
+  }
+  const err = new Error(response.error || 'Request failed');
+  err.inner = response.error;
+  throw err;
+}
 
 function isJiraConnectionFailure(error) {
   const message = String(error?.message || error?.inner || error || '');
@@ -199,6 +208,9 @@ async function mainAsyncLocal() {
   const cacheTtlMs = 60 * 1000;
   const issueCache = new Map();
   const pullRequestCache = new Map();
+  let currentUserPromise;
+  const projectSprintOptionsPromises = new Map();
+  let popupState = null;
 
   function toAbsoluteJiraUrl(url) {
     if (!url) {
@@ -723,16 +735,17 @@ async function mainAsyncLocal() {
     const seen = {};
     const sprints = [];
 
-    const pushSprint = (name, state) => {
+    const pushSprint = (id, name, state) => {
       if (!name) {
         return;
       }
-      const key = `${name}__${state || ''}`;
+      const sprintId = id ? String(id) : '';
+      const key = sprintId || `${name}__${state || ''}`;
       if (seen[key]) {
         return;
       }
       seen[key] = true;
-      sprints.push({name, state: state || ''});
+      sprints.push({id: sprintId, name, state: state || ''});
     };
 
     sprintValues.forEach(value => {
@@ -742,12 +755,17 @@ async function mainAsyncLocal() {
           return;
         }
         if (typeof entry === 'string') {
+          const idMatch = entry.match(/id=([^,\]]+)/i);
           const nameMatch = entry.match(/name=([^,\]]+)/i);
           const stateMatch = entry.match(/state=([^,\]]+)/i);
-          pushSprint(nameMatch && nameMatch[1] ? nameMatch[1] : entry, stateMatch && stateMatch[1]);
+          pushSprint(
+            idMatch && idMatch[1] ? idMatch[1] : '',
+            nameMatch && nameMatch[1] ? nameMatch[1] : entry,
+            stateMatch && stateMatch[1]
+          );
           return;
         }
-        pushSprint(entry.name || entry.goal || entry.id, entry.state);
+        pushSprint(entry.id || '', entry.name || entry.goal || entry.id, entry.state);
       });
     });
     return sprints;
@@ -871,6 +889,504 @@ async function mainAsyncLocal() {
     });
   }
 
+  function buildQuickActionError(error) {
+    return error?.message || error?.inner || 'Action failed';
+  }
+
+  function areSameJiraUser(left, right) {
+    if (!left || !right) {
+      return false;
+    }
+    const leftIds = [left.accountId, left.name, left.username, left.key].filter(Boolean);
+    const rightIds = [right.accountId, right.name, right.username, right.key].filter(Boolean);
+    return leftIds.some(value => rightIds.includes(value));
+  }
+
+  async function getCurrentUserInfo() {
+    if (currentUserPromise) {
+      return currentUserPromise;
+    }
+
+    currentUserPromise = (async () => {
+      try {
+        const myself = await get(INSTANCE_URL + 'rest/api/2/myself');
+        return {
+          accountId: myself?.accountId || '',
+          name: myself?.name || myself?.username || myself?.key || '',
+          username: myself?.username || myself?.name || '',
+          key: myself?.key || '',
+          displayName: myself?.displayName || myself?.name || myself?.username || 'You'
+        };
+      } catch (primaryError) {
+        const session = await get(INSTANCE_URL + 'rest/auth/1/session');
+        const user = session?.user || {};
+        return {
+          accountId: '',
+          name: user.name || user.username || user.key || '',
+          username: user.username || user.name || '',
+          key: user.key || '',
+          displayName: user.displayName || user.name || user.username || 'You'
+        };
+      }
+    })().catch(error => {
+      currentUserPromise = null;
+      throw error;
+    });
+
+    return currentUserPromise;
+  }
+
+  function buildAssignPayload(user) {
+    if (user?.accountId) {
+      return {accountId: user.accountId};
+    }
+    if (user?.name) {
+      return {name: user.name};
+    }
+    if (user?.key) {
+      return {key: user.key};
+    }
+    throw new Error('Could not resolve the current Jira user');
+  }
+
+  async function getAvailableTransitions(issueKey) {
+    const response = await get(`${INSTANCE_URL}rest/api/2/issue/${issueKey}/transitions`);
+    return Array.isArray(response?.transitions) ? response.transitions : [];
+  }
+
+  function isInProgressStatusCategory(statusCategory) {
+    const key = String(statusCategory?.key || '').toLowerCase();
+    const name = String(statusCategory?.name || '').toLowerCase();
+    return key === 'indeterminate' || name.includes('in progress');
+  }
+
+  function buildTransitionActionLabel(transition) {
+    const transitionName = String(transition?.name || '').trim();
+    const targetName = String(transition?.to?.name || '').trim();
+    const normalizedTransitionName = transitionName.toLowerCase();
+
+    if (
+      normalizedTransitionName.includes('start') ||
+      normalizedTransitionName.includes('progress') ||
+      normalizedTransitionName.includes('begin') ||
+      normalizedTransitionName.includes('resume')
+    ) {
+      return transitionName || 'Start progress';
+    }
+
+    if (targetName) {
+      return `Move to ${targetName}`;
+    }
+
+    return transitionName || 'Start progress';
+  }
+
+  function findStartProgressTransition(transitions) {
+    const candidates = Array.isArray(transitions) ? transitions.filter(Boolean) : [];
+    return candidates.find(transition => {
+      const transitionName = String(transition?.name || '').toLowerCase();
+      const targetName = String(transition?.to?.name || '').toLowerCase();
+      return isInProgressStatusCategory(transition?.to?.statusCategory) ||
+        targetName.includes('in progress') ||
+        transitionName.includes('start progress') ||
+        transitionName.includes('start work') ||
+        transitionName.includes('begin progress') ||
+        transitionName.includes('begin work') ||
+        transitionName.includes('resume progress');
+    }) || null;
+  }
+
+  function compareSprintState(left, right) {
+    const order = {
+      active: 0,
+      future: 1,
+      closed: 2
+    };
+    return (order[String(left || '').toLowerCase()] ?? 99) - (order[String(right || '').toLowerCase()] ?? 99);
+  }
+
+  function formatSprintActionLabel(sprint) {
+    const sprintName = String(sprint?.name || '').trim();
+    const sprintState = String(sprint?.state || '').toLowerCase();
+    const stateSuffix = sprintState === 'active'
+      ? ' (ACTIVE)'
+      : (sprintState === 'future' ? ' (NEXT)' : '');
+    return `Move to Sprint ${sprintName}${stateSuffix}`.trim();
+  }
+
+  async function getProjectSprintOptions(issueData) {
+    const projectKey = String(issueData?.key || '').split('-')[0];
+    if (!projectKey) {
+      return {
+        activeSprints: [],
+        upcomingSprint: null
+      };
+    }
+    if (projectSprintOptionsPromises.has(projectKey)) {
+      return projectSprintOptionsPromises.get(projectKey);
+    }
+
+    const sprintPromise = (async () => {
+      const sprintFieldIds = await getSprintFieldIds(INSTANCE_URL);
+      if (!sprintFieldIds.length) {
+        return {
+          activeSprints: [],
+          upcomingSprint: null
+        };
+      }
+
+      const boardResponse = await get(`${INSTANCE_URL}rest/agile/1.0/board?projectKeyOrId=${encodeURIComponent(projectKey)}&maxResults=50`);
+      const boards = Array.isArray(boardResponse?.values) ? boardResponse.values : [];
+      if (!boards.length) {
+        return {
+          activeSprints: [],
+          upcomingSprint: null
+        };
+      }
+
+      const sprintMap = new Map();
+      const sprintResponses = await Promise.allSettled(boards.map(board => {
+        return get(`${INSTANCE_URL}rest/agile/1.0/board/${board.id}/sprint?state=active,future&maxResults=50`)
+          .then(response => ({board, response}));
+      }));
+
+      sprintResponses.forEach(result => {
+        if (result.status !== 'fulfilled') {
+          return;
+        }
+        const board = result.value?.board || {};
+        const sprints = Array.isArray(result.value?.response?.values) ? result.value.response.values : [];
+        sprints.forEach(sprint => {
+          if (!sprint?.id || !sprint?.name) {
+            return;
+          }
+          const sprintId = String(sprint.id);
+          const existingSprint = sprintMap.get(sprintId);
+          const boardRefs = Array.isArray(existingSprint?.boardRefs) ? existingSprint.boardRefs.slice() : [];
+          const boardRefKey = String(board.id || '');
+          if (boardRefKey && !boardRefs.some(ref => String(ref.id) === boardRefKey)) {
+            boardRefs.push({
+              id: board.id,
+              name: board.name || '',
+              projectKey
+            });
+          }
+          sprintMap.set(sprintId, {
+            ...(existingSprint || {}),
+            ...sprint,
+            boardRefs
+          });
+        });
+      });
+
+      readSprintsFromIssue(issueData).forEach(sprint => {
+        if (!sprint?.id || !sprint?.name) {
+          return;
+        }
+        const sprintId = String(sprint.id);
+        if (sprintMap.has(sprintId)) {
+          return;
+        }
+        sprintMap.set(sprintId, {
+          ...sprint,
+          boardRefs: []
+        });
+      });
+
+      const sortedSprints = [...sprintMap.values()].sort((left, right) => {
+        const stateOrder = compareSprintState(left?.state, right?.state);
+        if (stateOrder !== 0) {
+          return stateOrder;
+        }
+        return String(left?.name || '').localeCompare(String(right?.name || ''));
+      });
+
+      const activeSprints = sortedSprints.filter(sprint => String(sprint?.state || '').toLowerCase() === 'active');
+      const upcomingSprint = sortedSprints.find(sprint => String(sprint?.state || '').toLowerCase() === 'future') || null;
+
+      return {
+        activeSprints,
+        upcomingSprint
+      };
+    })().catch(error => {
+      projectSprintOptionsPromises.delete(projectKey);
+      return {
+        activeSprints: [],
+        upcomingSprint: null
+      };
+    });
+
+    projectSprintOptionsPromises.set(projectKey, sprintPromise);
+    return sprintPromise;
+  }
+
+  function pickSprintFieldId(issueData, sprintFieldIds) {
+    const populatedFieldId = (sprintFieldIds || []).find(fieldId => {
+      const value = issueData?.fields?.[fieldId];
+      return Array.isArray(value) ? value.length > 0 : !!value;
+    });
+    return populatedFieldId || sprintFieldIds?.[0] || '';
+  }
+
+  async function resolveQuickActions(issueData) {
+
+    const actionResults = await Promise.allSettled([
+      getCurrentUserInfo(),
+      getAvailableTransitions(issueData.key),
+      getProjectSprintOptions(issueData),
+      getSprintFieldIds(INSTANCE_URL)
+    ]);
+
+    const currentUser = actionResults[0].status === 'fulfilled' ? actionResults[0].value : null;
+    const transitions = actionResults[1].status === 'fulfilled' ? actionResults[1].value : [];
+    const sprintOptions = actionResults[2].status === 'fulfilled' ? actionResults[2].value : {activeSprints: [], upcomingSprint: null};
+    const sprintFieldIds = actionResults[3].status === 'fulfilled' ? actionResults[3].value : [];
+    const actions = [];
+
+    if (currentUser && !areSameJiraUser(issueData.fields.assignee, currentUser)) {
+      actions.push({
+        key: 'assign-to-me',
+        label: 'Assign to me',
+        successMessage: 'Assigned to you',
+        payload: buildAssignPayload(currentUser)
+      });
+    }
+
+    const startProgressTransition = findStartProgressTransition(transitions);
+    if (startProgressTransition) {
+      actions.push({
+        key: 'start-progress',
+        label: buildTransitionActionLabel(startProgressTransition),
+        successMessage: `Moved to ${startProgressTransition.to?.name || startProgressTransition.name}`,
+        transitionId: startProgressTransition.id
+      });
+    }
+
+    const sprintFieldId = pickSprintFieldId(issueData, sprintFieldIds);
+    const existingSprints = readSprintsFromIssue(issueData)
+      .map(sprint => String(sprint.id || ''))
+      .filter(Boolean);
+    const sprintCandidates = [
+      ...(Array.isArray(sprintOptions.activeSprints) ? sprintOptions.activeSprints : []),
+      ...(sprintOptions.upcomingSprint ? [sprintOptions.upcomingSprint] : [])
+    ].filter(sprint => sprint?.id && !existingSprints.includes(String(sprint.id)));
+    const seenSprintIds = new Set();
+    sprintCandidates.forEach(sprint => {
+      const sprintId = String(sprint.id);
+      if (seenSprintIds.has(sprintId) || !sprintFieldId) {
+        return;
+      }
+      seenSprintIds.add(sprintId);
+      actions.push({
+        key: `move-to-sprint-${sprintId}`,
+        kind: 'move-to-sprint',
+        label: formatSprintActionLabel(sprint),
+        successMessage: `Moved to Sprint ${sprint.name}`,
+        sprintId,
+        sprintFieldId
+      });
+    });
+
+    return actions;
+  }
+
+  async function executeQuickAction(action, issueData) {
+    if (!action) {
+      throw new Error('Action is unavailable');
+    }
+
+    if (action.key === 'assign-to-me') {
+      await requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}/assignee`, action.payload);
+      return action.successMessage;
+    }
+
+    if (action.key === 'start-progress') {
+      await requestJson('POST', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}/transitions`, {
+        transition: {id: action.transitionId}
+      });
+      return action.successMessage;
+    }
+
+    if (action.kind === 'move-to-sprint') {
+      await requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
+        fields: {
+          [action.sprintFieldId]: action.sprintId
+        }
+      });
+      return action.successMessage;
+    }
+
+    throw new Error('Unknown action');
+  }
+
+  function buildQuickActionViewData(actionsOpen, actionLoadingKey, quickActions) {
+    const sourceActions = Array.isArray(quickActions) ? quickActions : [];
+    const firstSprintActionIndex = sourceActions.findIndex(action => action?.kind === 'move-to-sprint');
+    const actions = sourceActions.map((action, index) => ({
+      ...action,
+      showDividerBefore: firstSprintActionIndex > 0 && index === firstSprintActionIndex,
+      disabled: actionLoadingKey && actionLoadingKey !== action.key,
+      disabledAttr: actionLoadingKey && actionLoadingKey !== action.key ? 'disabled' : '',
+      isLoading: actionLoadingKey === action.key,
+      labelText: actionLoadingKey === action.key ? `${action.label}...` : action.label
+    }));
+    return {
+      hasQuickActions: actions.length > 0,
+      actionsOpen: actionsOpen && actions.length > 0,
+      quickActions: actions
+    };
+  }
+
+  async function buildPopupDisplayData(state) {
+    const {key, issueData, pullRequests, actionLoadingKey, actionError, lastActionSuccess, actionsOpen, quickActions} = state;
+    const normalizedDescription = await normalizeRichHtml(issueData.renderedFields.description, {
+      imageMaxHeight: 180
+    });
+    const commentsForDisplay = await buildCommentsForDisplay(issueData);
+    const fixVersions = issueData.fields.fixVersions || [];
+    const affectsVersions = issueData.fields.versions || [];
+    const sprints = readSprintsFromIssue(issueData);
+    const commentsTotal = commentsForDisplay.length;
+    const attachments = issueData.fields.attachment || [];
+    const previewAttachments = buildPreviewAttachments(attachments);
+    const labels = issueData.fields.labels || [];
+    const customFieldChips = buildCustomFieldChips(issueData, customFields);
+    const epicOrParent = await readEpicOrParent(issueData);
+    const issueTypeName = issueData.fields.issuetype?.name;
+    const statusName = issueData.fields.status?.name;
+    const priorityName = issueData.fields.priority?.name;
+    const projectKey = key.split('-')[0];
+
+    const row1Chips = [
+      displayFields.issueType ? buildFilterChip(
+        issueTypeName || 'No type',
+        issueTypeName ? `${scopeJqlToProject(projectKey, `issuetype = ${encodeJqlValue(issueTypeName)}`)}` : '',
+        {iconUrl: issueData.fields.issuetype?.iconUrl || ''}
+      ) : null,
+      displayFields.status ? buildFilterChip(
+        statusName || 'No status',
+        statusName ? `${scopeJqlToProject(projectKey, `status = ${encodeJqlValue(statusName)}`)}` : '',
+        {iconUrl: issueData.fields.status?.iconUrl || ''}
+      ) : null,
+      displayFields.priority ? buildFilterChip(
+        priorityName || 'No priority',
+        priorityName ? `${scopeJqlToProject(projectKey, `priority = ${encodeJqlValue(priorityName)}`)}` : '',
+        {iconUrl: issueData.fields.priority?.iconUrl || ''}
+      ) : null,
+      displayFields.epicParent ? {
+        text: epicOrParent
+          ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
+          : 'Parent: --',
+        linkUrl: epicOrParent?.url || ''
+      } : null,
+      ...customFieldChips[1]
+    ].filter(Boolean);
+
+    const singleAffectsVersion = affectsVersions.length === 1 ? affectsVersions[0]?.name : '';
+    const singleFixVersion = fixVersions.length === 1 ? fixVersions[0]?.name : '';
+    const row2Chips = [
+      displayFields.sprint ? buildFilterChip(
+        `Sprint: ${formatSprintText(sprints) || '--'}`,
+        ''
+      ) : null,
+      displayFields.affects ? buildFilterChip(
+        `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`,
+        singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
+      ) : null,
+      displayFields.fixVersions ? buildFilterChip(
+        `Fix version: ${formatFixVersionText(fixVersions) || '--'}`,
+        singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
+      ) : null,
+      ...customFieldChips[2]
+    ].filter(Boolean);
+
+    const singleLabel = labels.length === 1 ? labels[0] : '';
+    const row3Chips = [
+      displayFields.labels ? buildFilterChip(
+        `Labels: ${labels.filter(Boolean).join(', ') || '--'}`,
+        singleLabel ? `${scopeJqlToProject(projectKey, `labels = ${encodeJqlValue(singleLabel)}`)}` : ''
+      ) : null,
+      ...customFieldChips[3]
+    ].filter(Boolean);
+
+    const copyTicketMeta = ticket => ({
+      copyUrl: ticket.url,
+      copyTicket: ticket.key,
+      copyTitle: ticket.summary
+    });
+
+    const visibleCommentsTotal = displayFields.comments ? commentsTotal : 0;
+    const visibleAttachments = displayFields.attachments ? previewAttachments : [];
+    const quickActionData = buildQuickActionViewData(actionsOpen, actionLoadingKey, quickActions);
+    const displayData = {
+      urlTitle: `[${key}] ${issueData.fields.summary}`,
+      ticketKey: key,
+      ticketTitle: issueData.fields.summary,
+      url: INSTANCE_URL + 'browse/' + key,
+      ...copyTicketMeta({
+        key,
+        summary: issueData.fields.summary,
+        url: INSTANCE_URL + 'browse/' + key
+      }),
+      prs: [],
+      description: displayFields.description ? normalizedDescription : '',
+      hasBodyContent: true,
+      emptyBodyText: (!normalizedDescription && visibleAttachments.length === 0 && visibleCommentsTotal === 0)
+        ? 'No description, attachments or comments.'
+        : '',
+      attachments,
+      previewAttachments: visibleAttachments,
+      commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
+      issuetype: issueData.fields.issuetype,
+      status: issueData.fields.status,
+      priority: issueData.fields.priority,
+      issueTypeText: displayFields.issueType ? (issueTypeName || 'No type') : '',
+      statusText: displayFields.status ? (statusName || 'No status') : '',
+      sprintText: displayFields.sprint ? (formatSprintText(sprints) || 'No sprint') : '',
+      fixVersionText: displayFields.fixVersions ? (formatFixVersionText(fixVersions) || 'No fix version') : '',
+      row1Chips,
+      row2Chips,
+      row3Chips,
+      hasComments: visibleCommentsTotal > 0,
+      commentsTotal: visibleCommentsTotal,
+      attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
+      reporter: displayFields.reporter ? issueData.fields.reporter : null,
+      assignee: displayFields.assignee ? issueData.fields.assignee : null,
+      commentUrl: INSTANCE_URL + 'browse/' + key,
+      hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
+      activityIndicators: [],
+      loaderGifUrl,
+      actionNoticeText: actionError || lastActionSuccess,
+      actionNoticeClass: actionError ? '_JX_action_notice_error' : '_JX_action_notice_success',
+      hasActionNotice: !!(actionError || lastActionSuccess),
+      ...quickActionData
+    };
+    if (issueData.fields.comment?.comments?.[0]?.id) {
+      displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
+    }
+    if (displayFields.pullRequests && size(pullRequests)) {
+      const filteredPullRequests = pullRequests.filter(pr => {
+        return pr && pr.url !== location.href;
+      });
+      displayData.prs = filteredPullRequests.map(pr => {
+        return {
+          id: pr.id,
+          url: pr.url,
+          linkUrl: pr.url,
+          title: formatPullRequestTitle(pr),
+          status: pr.status,
+          authorName: formatPullRequestAuthor(pr),
+          branchText: formatPullRequestBranch(pr)
+        };
+      });
+    }
+    displayData.activityIndicators = buildActivityIndicators(
+      displayFields.attachments ? attachments : [],
+      visibleCommentsTotal,
+      displayData.prs.length
+    );
+    return displayData;
+  }
   function getRelativeHref(href) {
     const documentHref = document.location.href.split('#')[0];
     if (href.startsWith(documentHref)) {
@@ -918,6 +1434,100 @@ async function mainAsyncLocal() {
   `);
   $(document.body).append(container);
   $(document.body).append(previewOverlay);
+  async function renderIssuePopup(state) {
+    if (!state?.issueData) {
+      return;
+    }
+    const displayData = await buildPopupDisplayData(state);
+    container.html(Mustache.render(annotationTemplate, displayData));
+    if (!containerPinned) {
+      container.css(computeVisibleContainerPosition(state.pointerX, state.pointerY));
+    }
+  }
+
+  function invalidatePopupCaches() {
+    if (!popupState?.key) {
+      return;
+    }
+    issueCache.delete(popupState.key);
+    if (popupState.issueData?.id) {
+      const issueId = String(popupState.issueData.id);
+      [...pullRequestCache.keys()].forEach(cacheKey => {
+        if (String(cacheKey).includes(issueId)) {
+          pullRequestCache.delete(cacheKey);
+        }
+      });
+    }
+  }
+  async function refreshPopupIssueState(successMessage = '') {
+    if (!popupState?.key) {
+      return;
+    }
+    invalidatePopupCaches();
+    const refreshedIssueData = await getIssueMetaData(popupState.key);
+    await normalizeIssueImages(refreshedIssueData);
+
+    let refreshedPullRequests = [];
+    if (displayFields.pullRequests) {
+      try {
+        const pullRequestResponse = await getPullRequestDataCached(refreshedIssueData.id);
+        refreshedPullRequests = normalizePullRequests(pullRequestResponse);
+      } catch (ex) {
+        refreshedPullRequests = [];
+      }
+    }
+
+    let quickActions = [];
+    try {
+      quickActions = await resolveQuickActions(refreshedIssueData);
+    } catch (ex) {
+      quickActions = [];
+    }
+
+    popupState = {
+      ...popupState,
+      issueData: refreshedIssueData,
+      pullRequests: refreshedPullRequests,
+      quickActions,
+      actionLoadingKey: '',
+      actionError: '',
+      lastActionSuccess: successMessage,
+      actionsOpen: false
+    };
+    await renderIssuePopup(popupState);
+  }
+
+  async function handleQuickAction(actionKey) {
+    if (!popupState?.issueData || popupState.actionLoadingKey) {
+      return;
+    }
+    const action = (popupState.quickActions || []).find(candidate => candidate.key === actionKey);
+    if (!action) {
+      return;
+    }
+
+    popupState = {
+      ...popupState,
+      actionsOpen: false,
+      actionLoadingKey: action.key,
+      actionError: '',
+      lastActionSuccess: ''
+    };
+    await renderIssuePopup(popupState);
+
+    try {
+      const successMessage = await executeQuickAction(action, popupState.issueData);
+      await refreshPopupIssueState(successMessage);
+    } catch (error) {
+      popupState = {
+        ...popupState,
+        actionLoadingKey: '',
+        actionError: buildQuickActionError(error),
+        lastActionSuccess: ''
+      };
+      await renderIssuePopup(popupState);
+    }
+  }
   new draggable({
     handle: '._JX_title, ._JX_status',
     cancel: 'a, button, input, textarea, img, ._JX_description, ._JX_comments, ._JX_comment_body, ._JX_description_text, ._JX_related_pr'
@@ -989,6 +1599,39 @@ async function mainAsyncLocal() {
     copyPrettyLink(e.currentTarget).catch(() => snackBar('There was an error!'));
   });
 
+  $(document.body).on('click', '._JX_actions_toggle', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!popupState) {
+      return;
+    }
+    popupState = {
+      ...popupState,
+      actionsOpen: !popupState.actionsOpen
+    };
+    renderIssuePopup(popupState).catch(() => {});
+  });
+
+  $(document.body).on('click', '._JX_action_item', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const actionKey = e.currentTarget.getAttribute('data-action-key');
+    handleQuickAction(actionKey).catch(() => {});
+  });
+
+  $(document.body).on('click', function (e) {
+    if (!popupState?.actionsOpen) {
+      return;
+    }
+    if ($(e.target).closest('._JX_actions').length) {
+      return;
+    }
+    popupState = {
+      ...popupState,
+      actionsOpen: false
+    };
+    renderIssuePopup(popupState).catch(() => {});
+  });
   function closePreviewOverlay() {
     previewOverlay.removeClass('is-open');
     previewOverlay.find('img').attr('src', '');
@@ -1028,6 +1671,7 @@ async function mainAsyncLocal() {
 
   function hideContainer() {
     lastHoveredKey = '';
+    popupState = null;
     containerPinned = false;
     container.css({
       left: -5000,
@@ -1100,6 +1744,13 @@ async function mainAsyncLocal() {
         clearTimeout(hideTimeOut);
         const key = keys[0].replace(' ', '-');
         if (lastHoveredKey === key && container.html()) {
+          if (popupState) {
+            popupState = {
+              ...popupState,
+              pointerX: e.pageX,
+              pointerY: e.pageY
+            };
+          }
           if (!containerPinned) {
             container.css(computeVisibleContainerPosition(e.pageX, e.pageY));
           }
@@ -1128,152 +1779,26 @@ async function mainAsyncLocal() {
           if (cancelToken.cancel) {
             return;
           }
-          const normalizedDescription = await normalizeRichHtml(issueData.renderedFields.description, {
-            imageMaxHeight: 180
-          });
-          const commentsForDisplay = await buildCommentsForDisplay(issueData);
-          const fixVersions = issueData.fields.fixVersions || [];
-          const affectsVersions = issueData.fields.versions || [];
-          const sprints = readSprintsFromIssue(issueData);
-          const commentsTotal = commentsForDisplay.length;
-          const attachments = issueData.fields.attachment || [];
-          const previewAttachments = buildPreviewAttachments(attachments);
-          const labels = issueData.fields.labels || [];
-          const customFieldChips = buildCustomFieldChips(issueData, customFields);
-          const epicOrParent = await readEpicOrParent(issueData);
-          const issueTypeName = issueData.fields.issuetype?.name;
-          const statusName = issueData.fields.status?.name;
-          const priorityName = issueData.fields.priority?.name;
-          const projectKey = key.split('-')[0];
+          let quickActions = [];
+          try {
+            quickActions = await resolveQuickActions(issueData);
+          } catch (ex) {
+            quickActions = [];
+          }
 
-          const row1Chips = [
-            displayFields.issueType ? buildFilterChip(
-              issueTypeName || 'No type',
-              issueTypeName ? `${scopeJqlToProject(projectKey, `issuetype = ${encodeJqlValue(issueTypeName)}`)}` : '',
-              {iconUrl: issueData.fields.issuetype?.iconUrl || ''}
-            ) : null,
-            displayFields.status ? buildFilterChip(
-              statusName || 'No status',
-              statusName ? `${scopeJqlToProject(projectKey, `status = ${encodeJqlValue(statusName)}`)}` : '',
-              {iconUrl: issueData.fields.status?.iconUrl || ''}
-            ) : null,
-            displayFields.priority ? buildFilterChip(
-              priorityName || 'No priority',
-              priorityName ? `${scopeJqlToProject(projectKey, `priority = ${encodeJqlValue(priorityName)}`)}` : '',
-              {iconUrl: issueData.fields.priority?.iconUrl || ''}
-            ) : null,
-            displayFields.epicParent ? {
-              text: epicOrParent
-                ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
-                : 'Parent: --',
-              linkUrl: epicOrParent?.url || ''
-            } : null,
-            ...customFieldChips[1]
-          ].filter(Boolean);
-
-          const singleAffectsVersion = affectsVersions.length === 1 ? affectsVersions[0]?.name : '';
-          const singleFixVersion = fixVersions.length === 1 ? fixVersions[0]?.name : '';
-          const row2Chips = [
-            displayFields.sprint ? buildFilterChip(
-              `Sprint: ${formatSprintText(sprints) || '--'}`,
-              ''
-            ) : null,
-            displayFields.affects ? buildFilterChip(
-              `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`,
-              singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
-            ) : null,
-            displayFields.fixVersions ? buildFilterChip(
-              `Fix version: ${formatFixVersionText(fixVersions) || '--'}`,
-              singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
-            ) : null,
-            ...customFieldChips[2]
-          ].filter(Boolean);
-
-          const singleLabel = labels.length === 1 ? labels[0] : '';
-          const row3Chips = [
-            displayFields.labels ? buildFilterChip(
-              `Labels: ${labels.filter(Boolean).join(', ') || '--'}`,
-              singleLabel ? `${scopeJqlToProject(projectKey, `labels = ${encodeJqlValue(singleLabel)}`)}` : ''
-            ) : null,
-            ...customFieldChips[3]
-          ].filter(Boolean);
-
-          const copyTicketMeta = (ticket) => ({
-            copyUrl: ticket.url,
-            copyTicket: ticket.key,
-            copyTitle: ticket.summary
-          });
-
-          const visibleCommentsTotal = displayFields.comments ? commentsTotal : 0;
-          const visibleAttachments = displayFields.attachments ? previewAttachments : [];
-          const displayData = {
-            urlTitle: `[${key}] ${issueData.fields.summary}`,
-            ticketKey: key,
-            ticketTitle: issueData.fields.summary,
-            url: INSTANCE_URL + 'browse/' + key,
-            ...copyTicketMeta({
-              key,
-              summary: issueData.fields.summary,
-              url: INSTANCE_URL + 'browse/' + key
-            }),
-            prs: [],
-            description: displayFields.description ? normalizedDescription : '',
-            hasBodyContent: true,
-            emptyBodyText: (!normalizedDescription && visibleAttachments.length === 0 && visibleCommentsTotal === 0)
-              ? 'No description, attachments or comments.'
-              : '',
-            attachments,
-            previewAttachments: visibleAttachments,
-            commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
-            issuetype: issueData.fields.issuetype,
-            status: issueData.fields.status,
-            priority: issueData.fields.priority,
-            issueTypeText: displayFields.issueType ? (issueTypeName || 'No type') : '',
-            statusText: displayFields.status ? (statusName || 'No status') : '',
-            sprintText: displayFields.sprint ? (formatSprintText(sprints) || 'No sprint') : '',
-            fixVersionText: displayFields.fixVersions ? (formatFixVersionText(fixVersions) || 'No fix version') : '',
-            row1Chips,
-            row2Chips,
-            row3Chips,
-            hasComments: visibleCommentsTotal > 0,
-            commentsTotal: visibleCommentsTotal,
-            attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
-            reporter: displayFields.reporter ? issueData.fields.reporter : null,
-            assignee: displayFields.assignee ? issueData.fields.assignee : null,
-            commentUrl: INSTANCE_URL + 'browse/' + key,
-            hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
-            activityIndicators: [],
-            loaderGifUrl,
+          popupState = {
+            key,
+            issueData,
+            pullRequests,
+            pointerX,
+            pointerY,
+            quickActions,
+            actionsOpen: false,
+            actionLoadingKey: '',
+            actionError: '',
+            lastActionSuccess: ''
           };
-          if (issueData.fields.comment?.comments?.[0]?.id) {
-            displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
-          }
-          if (displayFields.pullRequests && size(pullRequests)) {
-            const filteredPullRequests = pullRequests.filter(function (pr) {
-              return pr && pr.url !== location.href;
-            });
-            displayData.prs = filteredPullRequests.map(function (pr) {
-              return {
-                id: pr.id,
-                url: pr.url,
-                linkUrl: pr.url,
-                title: formatPullRequestTitle(pr),
-                status: pr.status,
-                authorName: formatPullRequestAuthor(pr),
-                branchText: formatPullRequestBranch(pr)
-              };
-            });
-          }
-          displayData.activityIndicators = buildActivityIndicators(
-            displayFields.attachments ? attachments : [],
-            visibleCommentsTotal,
-            displayData.prs.length
-          );
-          // TODO: fix scrolling in google docs
-          container.html(Mustache.render(annotationTemplate, displayData));
-          if (!containerPinned) {
-            container.css(computeVisibleContainerPosition(pointerX, pointerY));
-          }
+          await renderIssuePopup(popupState);
         })(cancelToken).catch((error) => {
           notifyJiraConnectionFailure(INSTANCE_URL, error);
           lastHoveredKey = '';
@@ -1291,6 +1816,9 @@ if (!window.__JX__script_injected__) {
 }
 
 window.__JX__script_injected__ = true;
+
+
+
 
 
 

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -394,6 +394,11 @@ async function mainAsyncLocal() {
       }
       anchor.setAttribute('target', '_blank');
       anchor.setAttribute('rel', 'noopener noreferrer');
+      anchor.setAttribute('title', buildLinkHoverTitle(
+        'Open link',
+        anchor.textContent || absoluteHref || href,
+        absoluteHref || href
+      ));
     });
 
     return temp.innerHTML;
@@ -775,6 +780,13 @@ async function mainAsyncLocal() {
     return `${INSTANCE_URL}issues/?jql=${encodeURIComponent(jql)}`;
   }
 
+  function buildLinkHoverTitle(actionText, detailText, url) {
+    return [actionText, detailText, url]
+      .map(part => String(part || '').trim())
+      .filter(Boolean)
+      .join('\n');
+  }
+
   function scopeJqlToProject(projectKey, clause) {
     if (!projectKey || !clause) {
       return clause || '';
@@ -783,9 +795,11 @@ async function mainAsyncLocal() {
   }
 
   function buildFilterChip(text, jql, extra = {}) {
+    const linkUrl = jql ? buildJqlUrl(jql) : '';
     return {
       text,
-      linkUrl: jql ? buildJqlUrl(jql) : '',
+      linkUrl,
+      linkTitle: linkUrl ? buildLinkHoverTitle(extra.linkAction || 'Search Jira', text, linkUrl) : '',
       ...extra
     };
   }
@@ -863,12 +877,17 @@ async function mainAsyncLocal() {
   }
 
   function buildPreviewAttachments(attachments) {
-    return (attachments || []).filter(attachment => {
-      return !!attachment &&
-        typeof attachment.mimeType === 'string' &&
-        attachment.mimeType.toLowerCase().startsWith('image') &&
-        !!attachment.thumbnail;
-    });
+    return (attachments || [])
+      .filter(attachment => {
+        return !!attachment &&
+          typeof attachment.mimeType === 'string' &&
+          attachment.mimeType.toLowerCase().startsWith('image') &&
+          !!attachment.thumbnail;
+      })
+      .map(attachment => ({
+        ...attachment,
+        linkTitle: buildLinkHoverTitle('Open attachment', attachment.filename || 'Attachment', attachment.content)
+      }));
   }
 
   function getRelativeHref(href) {
@@ -1166,7 +1185,8 @@ async function mainAsyncLocal() {
               text: epicOrParent
                 ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
                 : 'Parent: --',
-              linkUrl: epicOrParent?.url || ''
+              linkUrl: epicOrParent?.url || '',
+              linkTitle: epicOrParent ? buildLinkHoverTitle('Open parent issue', epicOrParent.key, epicOrParent.url) : ''
             } : null,
             ...customFieldChips[1]
           ].filter(Boolean);
@@ -1203,6 +1223,7 @@ async function mainAsyncLocal() {
             copyTicket: ticket.key,
             copyTitle: ticket.summary
           });
+          const issueUrl = INSTANCE_URL + 'browse/' + key;
 
           const visibleCommentsTotal = displayFields.comments ? commentsTotal : 0;
           const visibleAttachments = displayFields.attachments ? previewAttachments : [];
@@ -1210,11 +1231,12 @@ async function mainAsyncLocal() {
             urlTitle: `[${key}] ${issueData.fields.summary}`,
             ticketKey: key,
             ticketTitle: issueData.fields.summary,
-            url: INSTANCE_URL + 'browse/' + key,
+            url: issueUrl,
+            urlHoverTitle: buildLinkHoverTitle('Open issue in Jira', `[${key}] ${issueData.fields.summary}`, issueUrl),
             ...copyTicketMeta({
               key,
               summary: issueData.fields.summary,
-              url: INSTANCE_URL + 'browse/' + key
+              url: issueUrl
             }),
             prs: [],
             description: displayFields.description ? normalizedDescription : '',
@@ -1240,7 +1262,7 @@ async function mainAsyncLocal() {
             attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
             reporter: displayFields.reporter ? issueData.fields.reporter : null,
             assignee: displayFields.assignee ? issueData.fields.assignee : null,
-            commentUrl: INSTANCE_URL + 'browse/' + key,
+            commentUrl: issueUrl,
             hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
             activityIndicators: [],
             loaderGifUrl,
@@ -1257,6 +1279,7 @@ async function mainAsyncLocal() {
                 id: pr.id,
                 url: pr.url,
                 linkUrl: pr.url,
+                linkTitle: buildLinkHoverTitle('Open pull request', formatPullRequestTitle(pr), pr.url),
                 title: formatPullRequestTitle(pr),
                 status: pr.status,
                 authorName: formatPullRequestAuthor(pr),
@@ -1291,6 +1314,10 @@ if (!window.__JX__script_injected__) {
 }
 
 window.__JX__script_injected__ = true;
+
+
+
+
 
 
 

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -183,7 +183,6 @@ async function mainAsyncLocal() {
     maybeNormalizeAvatar(issueData.fields.assignee);
     maybeNormalizeIcon(issueData.fields.issuetype);
     maybeNormalizeIcon(issueData.fields.status);
-    maybeNormalizeIcon(issueData.fields.priority);
 
     (issueData.fields.attachment || []).forEach(attachment => {
       attachment.content = toAbsoluteJiraUrl(attachment.content);
@@ -198,6 +197,35 @@ async function mainAsyncLocal() {
     });
 
     await Promise.all(imageLoads);
+  }
+
+  async function normalizeDescriptionHtml(descriptionHtml) {
+    if (!descriptionHtml) {
+      return descriptionHtml;
+    }
+    const temp = document.createElement('div');
+    temp.innerHTML = descriptionHtml;
+
+    const imageNodes = Array.from(temp.querySelectorAll('img[src]'));
+    await Promise.all(imageNodes.map(async img => {
+      const src = img.getAttribute('src');
+      const absoluteSrc = toAbsoluteJiraUrl(src);
+      const displaySrc = await getDisplayImageUrl(absoluteSrc);
+      if (displaySrc) {
+        img.setAttribute('src', displaySrc);
+      }
+    }));
+
+    const anchorNodes = Array.from(temp.querySelectorAll('a[href]'));
+    anchorNodes.forEach(anchor => {
+      const href = anchor.getAttribute('href');
+      const absoluteHref = toAbsoluteJiraUrl(href);
+      if (absoluteHref) {
+        anchor.setAttribute('href', absoluteHref);
+      }
+    });
+
+    return temp.innerHTML;
   }
 
   /***
@@ -228,7 +256,6 @@ async function mainAsyncLocal() {
       'comment',
       'issuetype',
       'status',
-      'priority',
       'fixVersions',
       ...sprintFieldIds
     ];
@@ -277,12 +304,104 @@ async function mainAsyncLocal() {
     return sprints;
   }
 
+  function formatFixVersionText(fixVersions) {
+    return (fixVersions || [])
+      .map(version => version.name)
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  function formatSprintText(sprints) {
+    return (sprints || [])
+      .map(sprint => sprint.state ? `${sprint.name} (${sprint.state})` : sprint.name)
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  function buildAttachmentChips(attachments) {
+    const totals = {
+      image: 0,
+      pdf: 0,
+      doc: 0,
+      other: 0
+    };
+
+    (attachments || []).forEach(attachment => {
+      const mimeType = (attachment.mimeType || '').toLowerCase();
+      if (mimeType.startsWith('image/')) {
+        totals.image += 1;
+      } else if (mimeType === 'application/pdf') {
+        totals.pdf += 1;
+      } else if (
+        mimeType.includes('word') ||
+        mimeType.includes('excel') ||
+        mimeType.includes('powerpoint') ||
+        mimeType.includes('officedocument') ||
+        mimeType.includes('msword') ||
+        mimeType.includes('opendocument') ||
+        mimeType.includes('rtf') ||
+        mimeType.startsWith('text/')
+      ) {
+        totals.doc += 1;
+      } else {
+        totals.other += 1;
+      }
+    });
+
+    const chips = [];
+    if (totals.image) chips.push({icon: '🖼️', count: totals.image});
+    if (totals.pdf) chips.push({icon: '📕', count: totals.pdf});
+    if (totals.doc) chips.push({icon: '📝', count: totals.doc});
+    if (totals.other) chips.push({icon: '📎', count: totals.other});
+    return chips;
+  }
+
+  function buildPreviewAttachments(attachments) {
+    return (attachments || []).filter(attachment => {
+      return !!attachment &&
+        typeof attachment.mimeType === 'string' &&
+        attachment.mimeType.toLowerCase().startsWith('image') &&
+        !!attachment.thumbnail;
+    });
+  }
+
   function getRelativeHref(href) {
     const documentHref = document.location.href.split('#')[0];
     if (href.startsWith(documentHref)) {
       return href.slice(documentHref.length);
     }
     return href;
+  }
+
+  function computeVisibleContainerPosition(pointerX, pointerY) {
+    const margin = 8;
+    const preferredLeft = pointerX + 20;
+    const preferredTop = pointerY + 25;
+    const width = container.outerWidth();
+    const height = container.outerHeight();
+    const viewportLeft = window.scrollX + margin;
+    const viewportTop = window.scrollY + margin;
+    const viewportRight = window.scrollX + window.innerWidth - margin;
+    const viewportBottom = window.scrollY + window.innerHeight - margin;
+
+    let left = preferredLeft;
+    let top = preferredTop;
+
+    if (left + width > viewportRight) {
+      left = pointerX - width - 15;
+    }
+    if (left < viewportLeft) {
+      left = viewportLeft;
+    }
+
+    if (top + height > viewportBottom) {
+      top = pointerY - height - 15;
+    }
+    if (top < viewportTop) {
+      top = viewportTop;
+    }
+
+    return {left, top};
   }
 
   const container = $('<div class="_JX_container">');
@@ -397,6 +516,8 @@ async function mainAsyncLocal() {
       if (size(keys)) {
         clearTimeout(hideTimeOut);
         const key = keys[0].replace(" ", "-");
+        const pointerX = e.pageX;
+        const pointerY = e.pageY;
         (async function (cancelToken) {
           const issueData = await getIssueMetaData(key);
           await normalizeIssueImages(issueData);
@@ -417,25 +538,39 @@ async function mainAsyncLocal() {
               comment => comment.author.displayName + ':\n' + comment.body
             ).join('\n\n');
           }
+          const normalizedDescription = await normalizeDescriptionHtml(issueData.renderedFields.description);
+          const fixVersions = issueData.fields.fixVersions || [];
+          const sprints = readSprintsFromIssue(issueData);
+          const commentsTotal = issueData.fields.comment?.total || 0;
+          const attachments = issueData.fields.attachment || [];
+          const previewAttachments = buildPreviewAttachments(attachments);
           const displayData = {
             urlTitle: key + ' ' + issueData.fields.summary,
             url: INSTANCE_URL + 'browse/' + key,
             prs: [],
-            description: issueData.renderedFields.description,
-            attachments: issueData.fields.attachment,
+            description: normalizedDescription,
+            hasBodyContent: !!normalizedDescription || previewAttachments.length > 0,
+            attachments,
+            previewAttachments,
             issuetype: issueData.fields.issuetype,
             status: issueData.fields.status,
-            priority: issueData.fields.priority,
-            fixVersions: issueData.fields.fixVersions || [],
-            sprints: readSprintsFromIssue(issueData),
+            issueTypeText: issueData.fields.issuetype?.name || 'No type',
+            statusText: issueData.fields.status?.name || 'No status',
+            hasComments: commentsTotal > 0,
+            commentsTotal,
+            fixVersionText: formatFixVersionText(fixVersions) || 'No fix version',
+            sprintText: formatSprintText(sprints) || 'No sprint',
+            attachmentChips: buildAttachmentChips(attachments),
             comment: issueData.fields.comment,
             reporter: issueData.fields.reporter,
             assignee: issueData.fields.assignee,
             comments,
-            commentUrl: '',
+            commentUrl: INSTANCE_URL + 'browse/' + key,
             loaderGifUrl,
           };
-          displayData.commentUrl = `${displayData.url}#comment-${displayData.comment?.comments?.[0]?.id || ''}`;
+          if (displayData.comment?.comments?.[0]?.id) {
+            displayData.commentUrl = `${displayData.url}#comment-${displayData.comment.comments[0].id}`;
+          }
           if (size(pullRequests)) {
             displayData.prs = pullRequests.filter(function (pr) {
               return pr.url !== location.href;
@@ -450,13 +585,9 @@ async function mainAsyncLocal() {
             });
           }
           // TODO: fix scrolling in google docs
-          const css = {
-            left: e.pageX + 20,
-            top: e.pageY + 25
-          };
           container.html(Mustache.render(annotationTemplate, displayData));
           if (!containerPinned) {
-            container.css(css);
+            container.css(computeVisibleContainerPosition(pointerX, pointerY));
           }
         })(cancelToken);
       } else if (!containerPinned) {

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -4646,6 +4646,12 @@ async function mainAsyncLocal() {
   }
 
   // ── Event Handlers ────────────────────────────────────────
+  $(document.body).on('click', '._JX_open_options', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    chrome.runtime.sendMessage({action: 'openOptionsPage'});
+  });
+
   $(document.body).on('click', '._JX_copy_link', function (e) {
     e.preventDefault();
     copyPrettyLink(e.currentTarget).catch(() => snackBar('There was an error!'));
@@ -5012,57 +5018,65 @@ async function mainAsyncLocal() {
     return true;
   }
 
-  function triggerPopupForKey(key, pointerX, pointerY) {
+  function fetchAndShowPopup(key, pointerX, pointerY) {
+    (async function (cancelToken) {
+      const issueData = await getIssueMetaData(key);
+      await normalizeIssueImages(issueData);
+      let pullRequests = [];
+      if (displayFields.pullRequests) {
+        try {
+          const pullRequestResponse = await getPullRequestDataCached(issueData.id);
+          pullRequests = normalizePullRequests(pullRequestResponse);
+        } catch (ex) {
+          console.log('[Jira HotLinker] Pull request fetch failed', {
+            issueKey: key,
+            issueId: issueData.id,
+            error: ex?.message || String(ex)
+          });
+        }
+      }
+
+      if (cancelToken.cancel) {
+        return;
+      }
+      let quickActions = [];
+      try {
+        quickActions = await resolveQuickActions(issueData);
+      } catch (ex) {
+        quickActions = [];
+      }
+
+      popupState = {
+        key,
+        issueData,
+        pullRequests,
+        pointerX,
+        pointerY,
+        quickActions,
+        actionsOpen: false,
+        actionLoadingKey: '',
+        actionError: '',
+        lastActionSuccess: '',
+        editState: null
+      };
+      await renderIssuePopup(popupState);
+    })(cancelToken).catch((error) => {
+      notifyJiraConnectionFailure(INSTANCE_URL, error);
+      lastHoveredKey = '';
+    });
+  }
+
+  function triggerPopupForKey(key, pointerX, pointerY, immediate) {
     clearTimeout(hoverDelayTimeout);
     lastHoveredKey = key;
     pendingHover = null;
-    hoverDelayTimeout = setTimeout(function () {
-      (async function (cancelToken) {
-        const issueData = await getIssueMetaData(key);
-        await normalizeIssueImages(issueData);
-        let pullRequests = [];
-        if (displayFields.pullRequests) {
-          try {
-            const pullRequestResponse = await getPullRequestDataCached(issueData.id);
-            pullRequests = normalizePullRequests(pullRequestResponse);
-          } catch (ex) {
-            console.log('[Jira HotLinker] Pull request fetch failed', {
-              issueKey: key,
-              issueId: issueData.id,
-              error: ex?.message || String(ex)
-            });
-          }
-        }
-
-        if (cancelToken.cancel) {
-          return;
-        }
-        let quickActions = [];
-        try {
-          quickActions = await resolveQuickActions(issueData);
-        } catch (ex) {
-          quickActions = [];
-        }
-
-        popupState = {
-          key,
-          issueData,
-          pullRequests,
-          pointerX,
-          pointerY,
-          quickActions,
-          actionsOpen: false,
-          actionLoadingKey: '',
-          actionError: '',
-          lastActionSuccess: '',
-          editState: null
-        };
-        await renderIssuePopup(popupState);
-      })(cancelToken).catch((error) => {
-        notifyJiraConnectionFailure(INSTANCE_URL, error);
-        lastHoveredKey = '';
-      });
-    }, 400);
+    if (immediate) {
+      fetchAndShowPopup(key, pointerX, pointerY);
+    } else {
+      hoverDelayTimeout = setTimeout(function () {
+        fetchAndShowPopup(key, pointerX, pointerY);
+      }, 400);
+    }
   }
 
   if (hoverModifierKey !== 'none') {
@@ -5071,7 +5085,7 @@ async function mainAsyncLocal() {
         return;
       }
       if (isModifierSatisfied(e)) {
-        triggerPopupForKey(pendingHover.key, pendingHover.pointerX, pendingHover.pointerY);
+        triggerPopupForKey(pendingHover.key, pendingHover.pointerX, pendingHover.pointerY, true);
       }
     });
   }
@@ -5081,9 +5095,17 @@ async function mainAsyncLocal() {
       return;
     }
     const element = document.elementFromPoint(e.clientX, e.clientY);
-    if (element === container[0] || $.contains(container[0], element)) {
+    const isOverContainer = element === container[0] || $.contains(container[0], element);
+    if (!isOverContainer && container.html()) {
+      const rect = container[0].getBoundingClientRect();
+      const margin = 40;
+      if (e.clientX >= rect.left - margin && e.clientX <= rect.right + margin &&
+          e.clientY >= rect.top - margin && e.clientY <= rect.bottom + margin) {
+        return;
+      }
+    }
+    if (isOverContainer) {
       showTip('tooltip_drag', 'Tip: You can pin the tooltip by dragging the title !');
-      // cancel when hovering over the container it self
       return;
     }
     if (element) {
@@ -5112,7 +5134,7 @@ async function mainAsyncLocal() {
           }
           return;
         }
-        triggerPopupForKey(key, e.pageX, e.pageY);
+        triggerPopupForKey(key, e.pageX, e.pageY, hoverModifierKey !== 'none');
       } else if (!containerPinned) {
         pendingHover = null;
         clearTimeout(hoverDelayTimeout);

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -14,6 +14,31 @@ const getInstanceUrl = async () => (await storageGet({
 })).instanceUrl;
 
 const getConfig = async () => (await storageGet(config));
+let sprintFieldIdsPromise;
+
+async function getSprintFieldIds(instanceUrl) {
+  if (sprintFieldIdsPromise) {
+    return sprintFieldIdsPromise;
+  }
+  sprintFieldIdsPromise = get(instanceUrl + 'rest/api/2/field')
+    .then(fields => {
+      if (!Array.isArray(fields)) {
+        return [];
+      }
+      return fields
+        .filter(field => {
+          const name = (field.name || '').toLowerCase();
+          const schemaCustom = ((field.schema && field.schema.custom) || '').toLowerCase();
+          const schemaType = ((field.schema && field.schema.type) || '').toLowerCase();
+          return name.includes('sprint') ||
+            schemaCustom.includes('gh-sprint') ||
+            schemaType === 'sprint';
+        })
+        .map(field => field.id);
+    })
+    .catch(() => []);
+  return sprintFieldIdsPromise;
+}
 
 /**
  * Returns a function that will return an array of jira tickets for any given string
@@ -71,6 +96,17 @@ async function get(url) {
   }
 }
 
+async function getImageDataUrl(url) {
+  const response = await sendMessage({action: 'getImageDataUrl', url});
+  if (response.result) {
+    return response.result;
+  } else if (response.error) {
+    const err = new Error(response.error);
+    err.inner = response.error;
+    throw err;
+  }
+}
+
 async function mainAsyncLocal() {
   const $ = require('jquery');
   const draggable = require('jquery-ui/ui/widgets/draggable');
@@ -89,6 +125,80 @@ async function mainAsyncLocal() {
   }));
   const annotationTemplate = await get(chrome.runtime.getURL('resources/annotation.html'));
   const loaderGifUrl = chrome.runtime.getURL('resources/ajax-loader.gif');
+  const imageProxyCache = {};
+
+  function toAbsoluteJiraUrl(url) {
+    if (!url) {
+      return url;
+    }
+    try {
+      return new URL(url, INSTANCE_URL).toString();
+    } catch (ex) {
+      return url;
+    }
+  }
+
+  async function getDisplayImageUrl(url) {
+    const absoluteUrl = toAbsoluteJiraUrl(url);
+    if (!absoluteUrl || !absoluteUrl.startsWith(INSTANCE_URL)) {
+      return absoluteUrl;
+    }
+    if (imageProxyCache[absoluteUrl]) {
+      return imageProxyCache[absoluteUrl];
+    }
+    try {
+      const dataUrl = await getImageDataUrl(absoluteUrl);
+      imageProxyCache[absoluteUrl] = dataUrl;
+      return dataUrl;
+    } catch (ex) {
+      return absoluteUrl;
+    }
+  }
+
+  async function normalizeIssueImages(issueData) {
+    const imageLoads = [];
+
+    const maybeNormalizeAvatar = field => {
+      const avatarUrl = field && field.avatarUrls && field.avatarUrls['48x48'];
+      if (avatarUrl) {
+        imageLoads.push(
+          getDisplayImageUrl(avatarUrl).then(src => {
+            field.avatarUrls['48x48'] = src;
+          })
+        );
+      }
+    };
+
+    const maybeNormalizeIcon = field => {
+      if (field && field.iconUrl) {
+        imageLoads.push(
+          getDisplayImageUrl(field.iconUrl).then(src => {
+            field.iconUrl = src;
+          })
+        );
+      }
+    };
+
+    maybeNormalizeAvatar(issueData.fields.reporter);
+    maybeNormalizeAvatar(issueData.fields.assignee);
+    maybeNormalizeIcon(issueData.fields.issuetype);
+    maybeNormalizeIcon(issueData.fields.status);
+    maybeNormalizeIcon(issueData.fields.priority);
+
+    (issueData.fields.attachment || []).forEach(attachment => {
+      attachment.content = toAbsoluteJiraUrl(attachment.content);
+      attachment.thumbnail = toAbsoluteJiraUrl(attachment.thumbnail) || attachment.content;
+      if (attachment.thumbnail) {
+        imageLoads.push(
+          getDisplayImageUrl(attachment.thumbnail).then(src => {
+            attachment.thumbnail = src;
+          })
+        );
+      }
+    });
+
+    await Promise.all(imageLoads);
+  }
 
   /***
    * Retrieve only the text that is directly owned by the node
@@ -106,8 +216,65 @@ async function mainAsyncLocal() {
     return get(INSTANCE_URL + 'rest/dev-status/1.0/issue/details?issueId=' + issueId + '&applicationType=' + applicationType + '&dataType=pullrequest');
   }
 
-  function getIssueMetaData(issueKey) {
-    return get(INSTANCE_URL + 'rest/api/2/issue/' + issueKey + '?fields=description,id,reporter,assignee,summary,attachment,comment,issuetype,status,priority&expand=renderedFields');
+  async function getIssueMetaData(issueKey) {
+    const sprintFieldIds = await getSprintFieldIds(INSTANCE_URL);
+    const fields = [
+      'description',
+      'id',
+      'reporter',
+      'assignee',
+      'summary',
+      'attachment',
+      'comment',
+      'issuetype',
+      'status',
+      'priority',
+      'fixVersions',
+      ...sprintFieldIds
+    ];
+    return get(INSTANCE_URL + 'rest/api/2/issue/' + issueKey + '?fields=' + fields.join(',') + '&expand=renderedFields,names');
+  }
+
+  function readSprintsFromIssue(issueData) {
+    const names = issueData.names || {};
+    const fields = issueData.fields || {};
+    const sprintFieldIds = Object.keys(names).filter(fieldId => {
+      return typeof names[fieldId] === 'string' && names[fieldId].toLowerCase().includes('sprint');
+    });
+    const sprintValues = sprintFieldIds
+      .map(fieldId => fields[fieldId])
+      .filter(value => value !== undefined && value !== null);
+    const seen = {};
+    const sprints = [];
+
+    const pushSprint = (name, state) => {
+      if (!name) {
+        return;
+      }
+      const key = `${name}__${state || ''}`;
+      if (seen[key]) {
+        return;
+      }
+      seen[key] = true;
+      sprints.push({name, state: state || ''});
+    };
+
+    sprintValues.forEach(value => {
+      const entries = Array.isArray(value) ? value : [value];
+      entries.forEach(entry => {
+        if (!entry) {
+          return;
+        }
+        if (typeof entry === 'string') {
+          const nameMatch = entry.match(/name=([^,\]]+)/i);
+          const stateMatch = entry.match(/state=([^,\]]+)/i);
+          pushSprint(nameMatch && nameMatch[1] ? nameMatch[1] : entry, stateMatch && stateMatch[1]);
+          return;
+        }
+        pushSprint(entry.name || entry.goal || entry.id, entry.state);
+      });
+    });
+    return sprints;
   }
 
   function getRelativeHref(href) {
@@ -232,6 +399,7 @@ async function mainAsyncLocal() {
         const key = keys[0].replace(" ", "-");
         (async function (cancelToken) {
           const issueData = await getIssueMetaData(key);
+          await normalizeIssueImages(issueData);
           let pullRequests = [];
           try {
             const githubPrs = await getPullRequestData(issueData.id, 'github');
@@ -258,6 +426,8 @@ async function mainAsyncLocal() {
             issuetype: issueData.fields.issuetype,
             status: issueData.fields.status,
             priority: issueData.fields.priority,
+            fixVersions: issueData.fields.fixVersions || [],
+            sprints: readSprintsFromIssue(issueData),
             comment: issueData.fields.comment,
             reporter: issueData.fields.reporter,
             assignee: issueData.fields.assignee,

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -2,7 +2,7 @@
 import size from 'lodash/size';
 import debounce from 'lodash/debounce';
 import Mustache from 'mustache';
-import {centerPopup, waitForDocument} from 'src/utils';
+import {waitForDocument} from 'src/utils';
 import {sendMessage, storageGet, storageSet} from 'src/chrome';
 import {snackBar} from 'src/snack';
 import config from 'options/config.js';
@@ -110,7 +110,6 @@ async function getImageDataUrl(url) {
 async function mainAsyncLocal() {
   const $ = require('jquery');
   const draggable = require('jquery-ui/ui/widgets/draggable');
-  const clipboard = require('clipboard/dist/clipboard');
 
   const config = await getConfig();
   const INSTANCE_URL = config.instanceUrl;
@@ -199,20 +198,70 @@ async function mainAsyncLocal() {
     await Promise.all(imageLoads);
   }
 
-  async function normalizeDescriptionHtml(descriptionHtml) {
-    if (!descriptionHtml) {
-      return descriptionHtml;
+  function escapeHtml(input) {
+    const node = document.createElement('div');
+    node.textContent = input || '';
+    return node.innerHTML;
+  }
+
+  function textToLinkedHtml(input) {
+    const escaped = escapeHtml(input || '');
+    const withLinks = escaped.replace(
+      /(https?:\/\/[^\s<]+)/g,
+      '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
+    );
+    return withLinks.replace(/\n/g, '<br/>');
+  }
+
+  function formatRelativeDate(created) {
+    const createdAt = new Date(created);
+    if (Number.isNaN(createdAt.getTime())) {
+      return '--';
     }
+    const diffMs = Date.now() - createdAt.getTime();
+    const twoDaysMs = 2 * 24 * 60 * 60 * 1000;
+    if (diffMs >= 0 && diffMs < twoDaysMs) {
+      const minuteMs = 60 * 1000;
+      const hourMs = 60 * minuteMs;
+      const dayMs = 24 * hourMs;
+      if (diffMs < hourMs) {
+        const minutes = Math.max(1, Math.floor(diffMs / minuteMs));
+        return `${minutes}m ago`;
+      }
+      if (diffMs < dayMs) {
+        const hours = Math.max(1, Math.floor(diffMs / hourMs));
+        return `${hours}h ago`;
+      }
+      const days = Math.max(1, Math.floor(diffMs / dayMs));
+      return `${days}d ago`;
+    }
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(createdAt);
+  }
+
+  async function normalizeRichHtml(html, options = {}) {
+    if (!html) {
+      return '';
+    }
+    const {imageMaxHeight} = options;
     const temp = document.createElement('div');
-    temp.innerHTML = descriptionHtml;
+    temp.innerHTML = html;
 
     const imageNodes = Array.from(temp.querySelectorAll('img[src]'));
     await Promise.all(imageNodes.map(async img => {
       const src = img.getAttribute('src');
       const absoluteSrc = toAbsoluteJiraUrl(src);
       const displaySrc = await getDisplayImageUrl(absoluteSrc);
-      if (displaySrc) {
-        img.setAttribute('src', displaySrc);
+      const resolvedSrc = displaySrc || absoluteSrc || src;
+      if (resolvedSrc) {
+        img.setAttribute('src', resolvedSrc);
+        img.setAttribute('data-jx-preview-src', resolvedSrc);
+        img.classList.add('_JX_previewable');
+      }
+      if (imageMaxHeight) {
+        img.style.maxHeight = `${imageMaxHeight}px`;
       }
     }));
 
@@ -223,9 +272,36 @@ async function mainAsyncLocal() {
       if (absoluteHref) {
         anchor.setAttribute('href', absoluteHref);
       }
+      anchor.setAttribute('target', '_blank');
+      anchor.setAttribute('rel', 'noopener noreferrer');
     });
 
     return temp.innerHTML;
+  }
+
+  async function buildCommentsForDisplay(issueData) {
+    const comments = [...(issueData.fields.comment?.comments || [])].sort((a, b) => {
+      return new Date(a.created).getTime() - new Date(b.created).getTime();
+    });
+    const renderedById = {};
+    ((issueData.renderedFields?.comment?.comments) || []).forEach(comment => {
+      if (comment && comment.id) {
+        renderedById[comment.id] = comment.body;
+      }
+    });
+
+    const result = [];
+    for (const comment of comments) {
+      const rendered = renderedById[comment.id];
+      const baseHtml = rendered || textToLinkedHtml(comment.body || '');
+      const bodyHtml = await normalizeRichHtml(baseHtml, {imageMaxHeight: 100});
+      result.push({
+        author: comment.author?.displayName || 'Unknown',
+        created: formatRelativeDate(comment.created),
+        bodyHtml
+      });
+    }
+    return result;
   }
 
   /***
@@ -405,48 +481,119 @@ async function mainAsyncLocal() {
   }
 
   const container = $('<div class="_JX_container">');
+  const previewOverlay = $(`
+    <div class="_JX_preview_overlay">
+      <img class="_JX_preview_image" />
+    </div>
+  `);
   $(document.body).append(container);
+  $(document.body).append(previewOverlay);
   new draggable({
     handle: '._JX_title, ._JX_status',
   }, container);
   
-  new clipboard('._JX_title_copy', {
-    text: function (trigger) {
-      return document.getElementById('_JX_title_link').text;
-    }
-  })
-  .on('success', e => { snackBar('Copied!');})
-  .on('error', e => { snackBar('There was an error!');});
+  function buildPrettyLinkPayload() {
+    const titleLink = document.getElementById('_JX_title_link');
+    const url = titleLink?.getAttribute('href') || '';
+    const ticket = titleLink?.getAttribute('data-ticket') || '';
+    const title = titleLink?.getAttribute('data-title') || '';
+    const label = `[${ticket}] ${title}`.trim();
+    const link = document.createElement('a');
+    link.href = url;
+    link.textContent = label;
+    return {
+      html: link.outerHTML,
+      text: url
+    };
+  }
 
-  $(document.body).on('click', '._JX_thumb', function previewThumb(e) {
-    const currentTarget = $(e.currentTarget);
-    if (currentTarget.data('_JX_loading')) {
+  function copyPrettyLinkFallback(html, text) {
+    return new Promise((resolve, reject) => {
+      const onCopy = event => {
+        event.preventDefault();
+        event.clipboardData.setData('text/html', html);
+        event.clipboardData.setData('text/plain', text);
+      };
+      document.addEventListener('copy', onCopy, {once: true});
+      const success = document.execCommand('copy');
+      if (!success) {
+        reject(new Error('Copy command failed'));
+        return;
+      }
+      resolve();
+    });
+  }
+
+  async function copyPrettyLink() {
+    const {html, text} = buildPrettyLinkPayload();
+    try {
+      if (navigator.clipboard && window.ClipboardItem && navigator.clipboard.write) {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'text/html': new Blob([html], {type: 'text/html'}),
+            'text/plain': new Blob([text], {type: 'text/plain'})
+          })
+        ]);
+        snackBar('Copied!');
+        return;
+      }
+    } catch (ex) {
+      // fall through to fallback copy path
+    }
+
+    try {
+      await copyPrettyLinkFallback(html, text);
+      snackBar('Copied!');
+    } catch (ex) {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(text);
+        snackBar('Copied as text');
+      } else {
+        snackBar('There was an error!');
+      }
+    }
+  }
+
+  $(document.body).on('click', '._JX_title_copy', function (e) {
+    e.preventDefault();
+    copyPrettyLink().catch(() => snackBar('There was an error!'));
+  });
+
+  function closePreviewOverlay() {
+    previewOverlay.removeClass('is-open');
+    previewOverlay.find('img').attr('src', '');
+  }
+
+  async function openPreviewOverlay(imageUrl) {
+    if (!imageUrl) {
       return;
     }
-    if (!currentTarget.data('mimeType').startsWith('image')) {
+    const displaySrc = await getDisplayImageUrl(imageUrl);
+    previewOverlay.find('img').attr('src', displaySrc || imageUrl);
+    previewOverlay.addClass('is-open');
+  }
+
+  previewOverlay.on('click', function (e) {
+    if (e.target === previewOverlay[0]) {
+      closePreviewOverlay();
+    }
+  });
+
+  $(document.body).on('click', '._JX_previewable', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const source = e.currentTarget.getAttribute('data-jx-preview-src') || e.currentTarget.getAttribute('src');
+    openPreviewOverlay(source).catch(() => {});
+  });
+
+  $(document.body).on('click', '._JX_thumb', function (e) {
+    if ($(e.target).closest('img._JX_previewable').length) {
       return;
     }
     e.preventDefault();
-    currentTarget.data('loading', true);
-    const opacityElements = currentTarget.children(':not(._JX_file_loader)');
-    opacityElements.css('opacity', 0.2);
-    currentTarget.find('._JX_file_loader').show();
-    const localCancelToken = cancelToken;
-    const img = new Image();
-    img.onload = function () {
-      currentTarget.data('_JX_loading', false);
-      currentTarget.find('._JX_file_loader').hide();
-      const name = currentTarget.find('._JX_thumb_filename').text();
-      opacityElements.css('opacity', 1);
-      if (localCancelToken.cancel) {
-        return;
-      }
-      centerPopup(chrome.runtime.getURL(`resources/preview.html?url=${currentTarget.data('url')}&title=${name}`), name, {
-        width: this.naturalWidth,
-        height: this.naturalHeight
-      }).focus();
-    };
-    img.src = currentTarget.data('url');
+    e.stopPropagation();
+    const source = e.currentTarget.getAttribute('data-preview-src') || e.currentTarget.getAttribute('data-url');
+    openPreviewOverlay(source).catch(() => {});
   });
 
   function hideContainer() {
@@ -464,6 +611,10 @@ async function mainAsyncLocal() {
     // TODO: escape not captured in google docs
     const ESCAPE_KEY_CODE = 27;
     if (e.keyCode === ESCAPE_KEY_CODE) {
+      if (previewOverlay.hasClass('is-open')) {
+        closePreviewOverlay();
+        return;
+      }
       hideContainer();
       passiveCancel(200);
     }
@@ -532,26 +683,26 @@ async function mainAsyncLocal() {
           if (cancelToken.cancel) {
             return;
           }
-          let comments = '';
-          if (issueData.fields.comment && issueData.fields.comment.total) {
-            comments = issueData.fields.comment.comments.map(
-              comment => comment.author.displayName + ':\n' + comment.body
-            ).join('\n\n');
-          }
-          const normalizedDescription = await normalizeDescriptionHtml(issueData.renderedFields.description);
+          const normalizedDescription = await normalizeRichHtml(issueData.renderedFields.description, {
+            imageMaxHeight: 180
+          });
+          const commentsForDisplay = await buildCommentsForDisplay(issueData);
           const fixVersions = issueData.fields.fixVersions || [];
           const sprints = readSprintsFromIssue(issueData);
-          const commentsTotal = issueData.fields.comment?.total || 0;
+          const commentsTotal = commentsForDisplay.length;
           const attachments = issueData.fields.attachment || [];
           const previewAttachments = buildPreviewAttachments(attachments);
           const displayData = {
-            urlTitle: key + ' ' + issueData.fields.summary,
+            urlTitle: `[${key}] ${issueData.fields.summary}`,
+            ticketKey: key,
+            ticketTitle: issueData.fields.summary,
             url: INSTANCE_URL + 'browse/' + key,
             prs: [],
             description: normalizedDescription,
-            hasBodyContent: !!normalizedDescription || previewAttachments.length > 0,
+            hasBodyContent: !!normalizedDescription || previewAttachments.length > 0 || commentsForDisplay.length > 0,
             attachments,
             previewAttachments,
+            commentsForDisplay,
             issuetype: issueData.fields.issuetype,
             status: issueData.fields.status,
             issueTypeText: issueData.fields.issuetype?.name || 'No type',
@@ -561,15 +712,13 @@ async function mainAsyncLocal() {
             fixVersionText: formatFixVersionText(fixVersions) || 'No fix version',
             sprintText: formatSprintText(sprints) || 'No sprint',
             attachmentChips: buildAttachmentChips(attachments),
-            comment: issueData.fields.comment,
             reporter: issueData.fields.reporter,
             assignee: issueData.fields.assignee,
-            comments,
             commentUrl: INSTANCE_URL + 'browse/' + key,
             loaderGifUrl,
           };
-          if (displayData.comment?.comments?.[0]?.id) {
-            displayData.commentUrl = `${displayData.url}#comment-${displayData.comment.comments[0].id}`;
+          if (issueData.fields.comment?.comments?.[0]?.id) {
+            displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
           }
           if (size(pullRequests)) {
             displayData.prs = pullRequests.filter(function (pr) {

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -3419,8 +3419,10 @@ async function mainAsyncLocal() {
     if (user?.isDefaultAvatar === true) {
       return true;
     }
+    const JIRA_DEFAULT_AVATAR_DATA_URI = 'data:image/svg+xml;base64,PHN2ZyBpZD0iV2Fyc3R3YV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgPHN0eWxlPgogICAgLnN0MHtmaWxsOiNjMWM3ZDB9CiAgPC9zdHlsZT4KICA8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMTIgMjRDNS40IDI0IDAgMTguNiAwIDEyUzUuNCAwIDEyIDBzMTIgNS40IDEyIDEyLTUuNCAxMi0xMiAxMnoiLz4KICA8cGF0aCBkPSJNMTkuNSAxMmMwLS45LS42LTEuNy0xLjUtMS45LS4yLTMuMS0yLjgtNS42LTYtNS42UzYuMiA3IDYgMTAuMWMtLjkuMi0xLjUgMS0xLjUgMS45IDAgMSAuNyAxLjggMS43IDIgLjYgMi44IDMgNS41IDUuOCA1LjVzNS4yLTIuNyA1LjgtNS41YzEtLjIgMS43LTEgMS43LTJ6IiBmaWxsPSIjZjRmNWY3Ii8+CiAgPHBhdGggY2xhc3M9InN0MCIgZD0iTTEyIDE2LjljLTEgMC0yLS43LTIuMy0xLjYtLjEtLjMgMC0uNS4zLS42LjMtLjEuNSAwIC42LjMuMi42LjggMSAxLjQgMSAuNiAwIDEuMi0uNCAxLjQtMSAuMS0uMy40LS40LjYtLjMuMy4xLjQuNC4zLjYtLjMuOS0xLjMgMS42LTIuMyAxLjZ6Ii8+Cjwvc3ZnPg==';
     const normalizedUrl = String(avatarUrl || '').toLowerCase();
-    return normalizedUrl.includes('defaultavatar') ||
+    return avatarUrl === JIRA_DEFAULT_AVATAR_DATA_URI ||
+      normalizedUrl.includes('defaultavatar') ||
       normalizedUrl.includes('/avatar.png') ||
       normalizedUrl.includes('avatar/default') ||
       normalizedUrl.includes('initials=');
@@ -4615,6 +4617,29 @@ async function mainAsyncLocal() {
     copyPrettyLink(e.currentTarget).catch(() => snackBar('There was an error!'));
   });
 
+  $(document.body).on('click', '._JX_close_button', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    hideContainer();
+    passiveCancel(200);
+  });
+
+  $(document.body).on('click', '._JX_pin_button', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!containerPinned) {
+      snackBar('Ticket Pinned! Hit esc to close !');
+      container.addClass('container-pinned');
+      const position = container.position();
+      container.css({
+        left: position.left - document.scrollingElement.scrollLeft,
+        top: position.top - document.scrollingElement.scrollTop,
+      });
+      containerPinned = true;
+      clearTimeout(hideTimeOut);
+    }
+  });
+
   $(document.body).on('click', '._JX_actions_toggle', function (e) {
     e.preventDefault();
     e.stopPropagation();
@@ -4849,7 +4874,7 @@ async function mainAsyncLocal() {
     activeCommentContext = null;
     resetCommentMentionState();
     containerPinned = false;
-    container.css({
+    container.html('').css({
       left: -5000,
       top: -5000,
       position: 'absolute',
@@ -4882,6 +4907,7 @@ async function mainAsyncLocal() {
   }
 
   let hideTimeOut;
+  let hoverDelayTimeout;
   let containerPinned = false;
   let lastHoveredKey = '';
   container.on('dragstop', () => {
@@ -4898,7 +4924,7 @@ async function mainAsyncLocal() {
     }
   });
   $(document.body).on('mousemove', debounce(function (e) {
-    if (cancelToken.cancel) {
+    if (e.buttons || cancelToken.cancel) {
       return;
     }
     const element = document.elementFromPoint(e.clientX, e.clientY);
@@ -4909,11 +4935,34 @@ async function mainAsyncLocal() {
     }
     if (element) {
       let keys = getJiraKeys(getShallowText(element));
+      if (!size(keys) && element.children.length < 10) {
+        const fullText = (element.textContent || '');
+        if (fullText.length < 200) {
+          keys = getJiraKeys(fullText);
+        }
+      }
       if (!size(keys) && element.href) {
         keys = getJiraKeys(getRelativeHref(element.href));
       }
       if (!size(keys) && element.parentElement && element.parentElement.href) {
         keys = getJiraKeys(getRelativeHref(element.parentElement.href));
+      }
+      if (!size(keys)) {
+        let ancestor = element.parentElement;
+        for (let i = 0; i < 5 && ancestor && !size(keys); i++) {
+          if (ancestor === document.body) break;
+          keys = getJiraKeys(getShallowText(ancestor));
+          if (!size(keys) && ancestor.children.length < 20) {
+            const ancestorText = (ancestor.textContent || '');
+            if (ancestorText.length < 300) {
+              keys = getJiraKeys(ancestorText);
+            }
+          }
+          if (!size(keys) && ancestor.href) {
+            keys = getJiraKeys(getRelativeHref(ancestor.href));
+          }
+          ancestor = ancestor.parentElement;
+        }
       }
 
       if (size(keys)) {
@@ -4932,55 +4981,59 @@ async function mainAsyncLocal() {
           }
           return;
         }
+        clearTimeout(hoverDelayTimeout);
         lastHoveredKey = key;
         const pointerX = e.pageX;
         const pointerY = e.pageY;
-        (async function (cancelToken) {
-          const issueData = await getIssueMetaData(key);
-          await normalizeIssueImages(issueData);
-          let pullRequests = [];
-          if (displayFields.pullRequests) {
-            try {
-              const pullRequestResponse = await getPullRequestDataCached(issueData.id);
-              pullRequests = normalizePullRequests(pullRequestResponse);
-            } catch (ex) {
-              console.log('[Jira HotLinker] Pull request fetch failed', {
-                issueKey: key,
-                issueId: issueData.id,
-                error: ex?.message || String(ex)
-              });
+        hoverDelayTimeout = setTimeout(function () {
+          (async function (cancelToken) {
+            const issueData = await getIssueMetaData(key);
+            await normalizeIssueImages(issueData);
+            let pullRequests = [];
+            if (displayFields.pullRequests) {
+              try {
+                const pullRequestResponse = await getPullRequestDataCached(issueData.id);
+                pullRequests = normalizePullRequests(pullRequestResponse);
+              } catch (ex) {
+                console.log('[Jira HotLinker] Pull request fetch failed', {
+                  issueKey: key,
+                  issueId: issueData.id,
+                  error: ex?.message || String(ex)
+                });
+              }
             }
-          }
 
-          if (cancelToken.cancel) {
-            return;
-          }
-          let quickActions = [];
-          try {
-            quickActions = await resolveQuickActions(issueData);
-          } catch (ex) {
-            quickActions = [];
-          }
+            if (cancelToken.cancel) {
+              return;
+            }
+            let quickActions = [];
+            try {
+              quickActions = await resolveQuickActions(issueData);
+            } catch (ex) {
+              quickActions = [];
+            }
 
-          popupState = {
-            key,
-            issueData,
-            pullRequests,
-            pointerX,
-            pointerY,
-            quickActions,
-            actionsOpen: false,
-            actionLoadingKey: '',
-            actionError: '',
-            lastActionSuccess: '',
-            editState: null
-          };
-          await renderIssuePopup(popupState);
-        })(cancelToken).catch((error) => {
-          notifyJiraConnectionFailure(INSTANCE_URL, error);
-          lastHoveredKey = '';
-        });
+            popupState = {
+              key,
+              issueData,
+              pullRequests,
+              pointerX,
+              pointerY,
+              quickActions,
+              actionsOpen: false,
+              actionLoadingKey: '',
+              actionError: '',
+              lastActionSuccess: '',
+              editState: null
+            };
+            await renderIssuePopup(popupState);
+          })(cancelToken).catch((error) => {
+            notifyJiraConnectionFailure(INSTANCE_URL, error);
+            lastHoveredKey = '';
+          });
+        }, 400);
       } else if (!containerPinned) {
+        clearTimeout(hoverDelayTimeout);
         lastHoveredKey = '';
         hideTimeOut = setTimeout(hideContainer, 250);
       }

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -16,6 +16,7 @@ const getInstanceUrl = async () => (await storageGet({
 
 const getConfig = async () => (await storageGet(config));
 let sprintFieldIdsPromise;
+let epicLinkFieldIdsPromise;
 
 async function getSprintFieldIds(instanceUrl) {
   if (sprintFieldIdsPromise) {
@@ -39,6 +40,27 @@ async function getSprintFieldIds(instanceUrl) {
     })
     .catch(() => []);
   return sprintFieldIdsPromise;
+}
+
+async function getEpicLinkFieldIds(instanceUrl) {
+  if (epicLinkFieldIdsPromise) {
+    return epicLinkFieldIdsPromise;
+  }
+  epicLinkFieldIdsPromise = get(instanceUrl + 'rest/api/2/field')
+    .then(fields => {
+      if (!Array.isArray(fields)) {
+        return [];
+      }
+      return fields
+        .filter(field => {
+          const name = (field.name || '').toLowerCase();
+          const schemaCustom = ((field.schema && field.schema.custom) || '').toLowerCase();
+          return name === 'epic link' || name === 'epic' || schemaCustom.includes('gh-epic-link');
+        })
+        .map(field => field.id);
+    })
+    .catch(() => []);
+  return epicLinkFieldIdsPromise;
 }
 
 
@@ -1215,7 +1237,10 @@ async function mainAsyncLocal() {
 
   async function getIssueMetaData(issueKey) {
     return getCachedValue(issueCache, issueKey, async () => {
-      const sprintFieldIds = await getSprintFieldIds(INSTANCE_URL);
+      const [sprintFieldIds, epicLinkFieldIds] = await Promise.all([
+        getSprintFieldIds(INSTANCE_URL),
+        getEpicLinkFieldIds(INSTANCE_URL)
+      ]);
       const fields = [
         'description',
         'id',
@@ -1232,6 +1257,7 @@ async function mainAsyncLocal() {
         'parent',
         'fixVersions',
         ...sprintFieldIds,
+        ...epicLinkFieldIds,
         ...customFields.map(({fieldId}) => fieldId)
       ];
       return get(INSTANCE_URL + 'rest/api/2/issue/' + issueKey + '?fields=' + fields.join(',') + '&expand=renderedFields,names');
@@ -1478,40 +1504,199 @@ async function mainAsyncLocal() {
     });
   }
 
-  async function readEpicOrParent(issueData) {
-    const parent = issueData.fields?.parent;
-    if (parent && parent.key) {
+  function extractIssueKeyFromLinkageValue(value) {
+    if (!value) {
+      return '';
+    }
+    if (typeof value === 'string') {
+      return value.trim();
+    }
+    if (typeof value === 'object') {
+      return String(value.key || value.value || value.id || '').trim();
+    }
+    return '';
+  }
+
+  function findEpicLinkFieldId(issueData, editMeta) {
+    const names = issueData?.names || {};
+    const editMetaFields = editMeta?.fields || {};
+    const fromNames = Object.keys(names).find(fieldId => {
+      const fieldName = String(names[fieldId] || '').toLowerCase();
+      return fieldName === 'epic link' || fieldName === 'epic';
+    });
+    if (fromNames) {
+      return fromNames;
+    }
+    return Object.keys(editMetaFields).find(fieldId => {
+      const fieldName = String(editMetaFields[fieldId]?.name || '').toLowerCase();
+      return fieldName === 'epic link' || fieldName === 'epic';
+    }) || '';
+  }
+
+  async function resolveIssueLinkage(issueData) {
+    if (!issueData?.key) {
       return {
-        key: parent.key,
-        summary: parent.fields?.summary || parent.key,
-        url: `${INSTANCE_URL}browse/${parent.key}`
+        mode: '',
+        label: 'Parent',
+        editable: false,
+        fieldKey: '',
+        currentLink: null
+      };
+    }
+    const editMeta = await getIssueEditMeta(issueData.key).catch(() => ({fields: {}}));
+    const parentValue = issueData?.fields?.parent;
+    const parentFieldMeta = editMeta.fields?.parent;
+    if (parentValue?.key || parentFieldMeta) {
+      const currentKey = parentValue?.key || '';
+      const currentSummary = parentValue?.fields?.summary || currentKey;
+      return {
+        mode: 'parent',
+        label: 'Parent',
+        editable: !!parentFieldMeta,
+        fieldKey: 'parent',
+        currentLink: currentKey
+          ? {
+              key: currentKey,
+              summary: currentSummary,
+              url: `${INSTANCE_URL}browse/${currentKey}`
+            }
+          : null
       };
     }
 
-    const names = issueData.names || {};
-    const fields = issueData.fields || {};
-    const epicFieldId = Object.keys(names).find(fieldId => {
-      const name = String(names[fieldId] || '').toLowerCase();
-      return name === 'epic link' || name === 'epic';
+    const epicFieldId = findEpicLinkFieldId(issueData, editMeta);
+    const epicKey = extractIssueKeyFromLinkageValue(issueData?.fields?.[epicFieldId]);
+    if (!epicFieldId && !epicKey) {
+      return {
+        mode: '',
+        label: 'Parent',
+        editable: false,
+        fieldKey: '',
+        currentLink: null
+      };
+    }
+    let epicSummary = epicKey;
+    if (epicKey) {
+      try {
+        const epicSummaryData = await getIssueSummary(epicKey);
+        epicSummary = epicSummaryData?.summary || epicKey;
+      } catch (error) {
+        epicSummary = epicKey;
+      }
+    }
+    return {
+      mode: 'epicLink',
+      label: 'Epic',
+      editable: !!editMeta.fields?.[epicFieldId],
+      fieldKey: epicFieldId,
+      currentLink: epicKey
+        ? {
+            key: epicKey,
+            summary: epicSummary,
+            url: `${INSTANCE_URL}browse/${epicKey}`
+          }
+        : null
+    };
+  }
+
+  function buildIssueSearchOption(issue, extra = {}) {
+    const issueKey = String(issue?.key || '').trim();
+    const issueSummary = String(issue?.fields?.summary || issue?.summary || issueKey).trim();
+    const statusName = issue?.fields?.status?.name || '';
+    return buildEditOption(issueKey, `[${issueKey}] ${issueSummary}`.trim(), {
+      id: issueKey,
+      iconUrl: issue?.fields?.issuetype?.iconUrl || issue?.issuetype?.iconUrl || '',
+      metaText: statusName,
+      rawValue: {
+        key: issueKey,
+        summary: issueSummary
+      },
+      searchText: `${issueKey} ${issueSummary} ${statusName}`,
+      ...extra
     });
-    const epicKey = epicFieldId ? fields[epicFieldId] : null;
-    if (!epicKey || typeof epicKey !== 'string') {
-      return null;
+  }
+
+  function buildIssueSearchCacheKey(query, issueData, mode) {
+    const projectKey = String(issueData?.key || '').split('-')[0];
+    return `${projectKey}__${mode}__${String(query || '').trim().toLowerCase()}`;
+  }
+
+  function getRecentIssueSearchOptions(issueData, mode) {
+    const projectKey = String(issueData?.key || '').split('-')[0];
+    return issueSearchRecentCache.get(`${projectKey}__${mode}`) || [];
+  }
+
+  function setRecentIssueSearchOptions(issueData, mode, options) {
+    const projectKey = String(issueData?.key || '').split('-')[0];
+    if (!projectKey || !mode) {
+      return;
     }
-    try {
-      const epic = await getIssueSummary(epicKey);
-      return {
-        key: epic.key,
-        summary: epic.summary || epic.key,
-        url: `${INSTANCE_URL}browse/${epic.key}`
-      };
-    } catch (ex) {
-      return {
-        key: epicKey,
-        summary: epicKey,
-        url: `${INSTANCE_URL}browse/${epicKey}`
-      };
+    issueSearchRecentCache.set(`${projectKey}__${mode}`, (Array.isArray(options) ? options : []).slice(0, 30));
+  }
+
+  function buildSafeIssueSearchClauses(query, projectKey) {
+    const normalizedQuery = String(query || '').trim();
+    if (!normalizedQuery) {
+      return [];
     }
+
+    const clauses = [];
+    const tokenClauses = normalizedQuery
+      .split(/[^A-Za-z0-9]+/)
+      .map(token => token.trim())
+      .filter(token => token.length >= 2)
+      .slice(0, 4)
+      .map(token => {
+        const escapedToken = token
+          .replace(/\\/g, '\\\\')
+          .replace(/"/g, '\\"');
+        return `summary ~ \"${escapedToken}*\"`;
+      });
+
+    if (tokenClauses.length === 1) {
+      clauses.push(tokenClauses[0]);
+    } else if (tokenClauses.length > 1) {
+      clauses.push(`(${tokenClauses.join(' AND ')})`);
+    }
+
+    if (/^\d+$/.test(normalizedQuery)) {
+      clauses.push(`key = ${encodeJqlValue(`${projectKey}-${normalizedQuery}`)}`);
+    } else if (/^[A-Z][A-Z0-9_]*-\d+$/i.test(normalizedQuery)) {
+      clauses.push(`key = ${encodeJqlValue(normalizedQuery.toUpperCase())}`);
+    }
+
+    return clauses;
+  }
+
+  async function searchParentCandidates(query, issueData, linkageMode) {
+    const issueKey = String(issueData?.key || '').trim();
+    const projectKey = issueKey.split('-')[0];
+    if (!issueKey || !projectKey) {
+      return [];
+    }
+    const normalizedQuery = String(query || '').trim();
+    const cacheKey = buildIssueSearchCacheKey(normalizedQuery, issueData, linkageMode || 'linkage');
+    return getCachedValue(issueSearchCache, cacheKey, async () => {
+      const escapedIssueKey = encodeJqlValue(issueKey);
+      const isEpicLinkMode = linkageMode === 'epicLink';
+      const jqlParts = [`key != ${escapedIssueKey}`];
+      if (!isEpicLinkMode) {
+        const escapedProjectKey = encodeJqlValue(projectKey);
+        jqlParts.unshift(`project = ${escapedProjectKey}`);
+      }
+      const searchClauses = buildSafeIssueSearchClauses(normalizedQuery, projectKey);
+      if (searchClauses.length) {
+        jqlParts.push(`(${searchClauses.join(' OR ')})`);
+      }
+      const jql = `${jqlParts.join(' AND ')} ORDER BY updated DESC`;
+      const response = await get(`${INSTANCE_URL}rest/api/2/search?maxResults=20&fields=summary,issuetype,status&jql=${encodeURIComponent(jql)}`);
+      const issues = Array.isArray(response?.issues) ? response.issues : [];
+      const options = issues
+        .map(issue => buildIssueSearchOption(issue))
+        .filter(option => option.id);
+      setRecentIssueSearchOptions(issueData, linkageMode || 'linkage', options);
+      return options;
+    });
   }
 
   function normalizeCustomFields(customFields) {
@@ -2439,6 +2624,71 @@ async function mainAsyncLocal() {
       };
     }
 
+    if (fieldKey === 'parentLink') {
+      const linkage = await resolveIssueLinkage(issueData);
+      if (!linkage?.editable || !linkage.mode) {
+        return null;
+      }
+      const currentLink = linkage.currentLink;
+      const currentOption = currentLink
+        ? buildEditOption(currentLink.key, `[${currentLink.key}] ${currentLink.summary || currentLink.key}`, {
+            rawValue: {
+              key: currentLink.key,
+              summary: currentLink.summary || currentLink.key
+            }
+          })
+        : null;
+      return {
+        fieldKey,
+        editorType: 'issue-search',
+        label: linkage.label,
+        selectionMode: 'single',
+        currentText: currentLink ? `[${currentLink.key}] ${currentLink.summary || currentLink.key}` : `${linkage.label}: none`,
+        currentOptionId: currentOption?.id || null,
+        currentSelections: currentOption ? [currentOption] : [],
+        initialInputValue: '',
+        inputPlaceholder: 'Search issues by key or summary',
+        loadOptions: async () => {
+          const recentOptions = getRecentIssueSearchOptions(issueData, linkage.mode);
+          const searchedOptions = await searchParentCandidates('', issueData, linkage.mode).catch(() => []);
+          return mergeEditOptions(
+            [currentOption].filter(Boolean),
+            mergeEditOptions(searchedOptions, recentOptions)
+          );
+        },
+        searchOptions: query => searchParentCandidates(query, issueData, linkage.mode),
+        save: selectedOptions => {
+          const selectedOption = selectedOptions[0];
+          const selectedIssueKey = selectedOption?.rawValue?.key || selectedOption?.id;
+          if (!selectedIssueKey) {
+            throw new Error(`Pick a ${linkage.label.toLowerCase()} issue before saving`);
+          }
+          if (linkage.mode === 'parent') {
+            return requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
+              fields: {
+                parent: {key: selectedIssueKey}
+              }
+            });
+          }
+          if (!linkage.fieldKey) {
+            throw new Error('Could not resolve Epic Link field');
+          }
+          return requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
+            fields: {
+              [linkage.fieldKey]: selectedIssueKey
+            }
+          });
+        },
+        successMessage: selectedOptions => {
+          const selectedOption = selectedOptions[0];
+          const selectedIssueKey = selectedOption?.rawValue?.key || selectedOption?.id || '';
+          return selectedIssueKey
+            ? `${linkage.label} set to ${selectedIssueKey}`
+            : `${linkage.label} updated`;
+        }
+      };
+    }
+
     return null;
   }
 
@@ -2866,7 +3116,7 @@ async function mainAsyncLocal() {
     const previewAttachments = buildPreviewAttachments(attachments);
     const labels = issueData.fields.labels || [];
     const customFieldChips = buildCustomFieldChips(issueData, customFields);
-    const epicOrParent = await readEpicOrParent(issueData);
+    const linkageData = await resolveIssueLinkage(issueData);
     const issueTypeName = issueData.fields.issuetype?.name;
     const statusName = issueData.fields.status?.name;
     const priorityName = issueData.fields.priority?.name;
@@ -2905,13 +3155,22 @@ async function mainAsyncLocal() {
         canEdit: priorityEditable,
         editTitle: 'Edit priority'
       }) : null,
-      displayFields.epicParent ? {
-        text: epicOrParent
-          ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
-          : 'Parent: --',
-        linkUrl: epicOrParent?.url || '',
-        linkTitle: epicOrParent ? buildLinkHoverTitle('Open parent issue', epicOrParent.key, epicOrParent.url) : ''
-      } : null,
+      displayFields.epicParent ? buildEditableFieldChip('parentLink', {
+        text: linkageData?.currentLink
+          ? `${linkageData.label}: [${linkageData.currentLink.key}] ${linkageData.currentLink.summary}`
+          : `${linkageData?.label || 'Parent'}: --`,
+        linkUrl: linkageData?.currentLink?.url || '',
+        linkTitle: linkageData?.currentLink
+          ? buildLinkHoverTitle(
+              `Open ${String(linkageData.label || 'linked').toLowerCase()} issue`,
+              linkageData.currentLink.key,
+              linkageData.currentLink.url
+            )
+          : ''
+      }, state, {
+        canEdit: !!linkageData?.editable,
+        editTitle: linkageData?.mode === 'epicLink' ? 'Edit epic link' : 'Edit parent'
+      }) : null,
       ...customFieldChips[1]
     ].filter(Boolean);
 
@@ -3148,6 +3407,7 @@ async function mainAsyncLocal() {
     editMetaCache.delete(popupState.key);
     transitionOptionsCache.delete(popupState.key);
     assigneeLocalOptionsCache.delete(popupState.key);
+    issueSearchCache.clear();
     [...assigneeSearchCache.keys()].forEach(cacheKey => {
       if (String(cacheKey).startsWith(`${popupState.key}__`)) {
         assigneeSearchCache.delete(cacheKey);
@@ -3351,7 +3611,7 @@ async function mainAsyncLocal() {
       }
       await renderIssuePopup(popupState);
 
-      if (popupState?.editState?.fieldKey === fieldKey && popupState.editState.editorType === 'user-search') {
+      if (popupState?.editState?.fieldKey === fieldKey && (popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search')) {
         const searchRequestId = ++editSearchRequestCounter;
         popupState = {
           ...popupState,
@@ -3458,7 +3718,7 @@ async function mainAsyncLocal() {
     };
     renderIssuePopup(popupState).catch(() => {});
 
-    if (popupState.editState.editorType === 'user-search') {
+    if (popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search') {
       const searchRequestId = ++editSearchRequestCounter;
       popupState = {
         ...popupState,

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -1699,6 +1699,182 @@ async function mainAsyncLocal() {
     });
   }
 
+  function stripSimpleHtml(value) {
+    return String(value || '').replace(/<[^>]+>/g, '');
+  }
+
+  function buildLabelOption(label, extra = {}) {
+    const normalizedLabel = String(label || '').trim();
+    return buildEditOption(normalizedLabel, normalizedLabel, {
+      rawValue: normalizedLabel,
+      ...extra
+    });
+  }
+
+  function normalizeLabelSuggestionPayload(payload) {
+    if (Array.isArray(payload?.results)) {
+      return payload.results
+        .map(entry => buildLabelOption(entry?.value || stripSimpleHtml(entry?.displayName || ''), {
+          metaText: stripSimpleHtml(entry?.displayName || '')
+        }))
+        .filter(option => option.id);
+    }
+    if (Array.isArray(payload?.suggestions)) {
+      return payload.suggestions
+        .map(entry => buildLabelOption(entry?.label || stripSimpleHtml(entry?.html || ''), {
+          metaText: stripSimpleHtml(entry?.html || '')
+        }))
+        .filter(option => option.id);
+    }
+    return [];
+  }
+
+  async function fetchLabelSuggestions(queryText) {
+    const normalizedQuery = String(queryText || '').trim();
+    const endpoints = [
+      `${INSTANCE_URL}rest/api/2/jql/autocompletedata/suggestions?fieldName=labels&fieldValue=${encodeURIComponent(normalizedQuery)}`,
+      `${INSTANCE_URL}rest/api/1.0/labels/suggest?query=${encodeURIComponent(normalizedQuery)}`
+    ];
+    let lastError;
+    for (const url of endpoints) {
+      try {
+        const response = await get(url);
+        return normalizeLabelSuggestionPayload(response);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError || new Error('Could not load label suggestions');
+  }
+
+  async function getLabelSuggestions(queryText = '') {
+    const normalizedQuery = String(queryText || '').trim().toLowerCase();
+    return getCachedValue(labelSuggestionCache, normalizedQuery, async () => {
+      return fetchLabelSuggestions(normalizedQuery);
+    });
+  }
+
+  async function hasLabelSuggestionSupport() {
+    if (!labelSuggestionSupportPromise) {
+      labelSuggestionSupportPromise = getLabelSuggestions('')
+        .then(() => true)
+        .catch(() => false);
+    }
+    return labelSuggestionSupportPromise;
+  }
+
+  function getCustomFieldPrimitive(entry) {
+    if (entry === undefined || entry === null) {
+      return '';
+    }
+    if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
+      return String(entry);
+    }
+    return String(entry.name || entry.value || entry.displayName || entry.key || entry.id || '');
+  }
+
+  function buildCustomFieldOption(fieldName, entry) {
+    const label = getCustomFieldPrimitive(entry);
+    if (!label) {
+      return null;
+    }
+    const optionId = String(entry?.id || entry?.value || entry?.name || entry?.key || label).trim();
+    if (!optionId) {
+      return null;
+    }
+    const metaText = entry?.description || entry?.child?.value || '';
+    return buildEditOption(optionId, label, {
+      iconUrl: entry?.iconUrl || '',
+      metaText,
+      rawValue: entry
+    });
+  }
+
+  function buildCustomFieldValueText(fieldName, value) {
+    if (Array.isArray(value)) {
+      const parts = value.map(entry => getCustomFieldPrimitive(entry)).filter(Boolean);
+      return `${fieldName}: ${parts.join(', ') || '--'}`;
+    }
+    const primitive = getCustomFieldPrimitive(value);
+    return `${fieldName}: ${primitive || '--'}`;
+  }
+
+  function buildCustomFieldSaveValue(rawValue) {
+    if (rawValue === undefined || rawValue === null) {
+      return rawValue;
+    }
+    if (typeof rawValue === 'string' || typeof rawValue === 'number' || typeof rawValue === 'boolean') {
+      return rawValue;
+    }
+    if (rawValue.id) {
+      return {id: String(rawValue.id)};
+    }
+    if (rawValue.value) {
+      return {value: rawValue.value};
+    }
+    if (rawValue.name) {
+      return {name: rawValue.name};
+    }
+    if (rawValue.key) {
+      return {key: rawValue.key};
+    }
+    return rawValue;
+  }
+
+  async function getSupportedCustomFieldDefinition(fieldId, issueData) {
+    const capability = await getEditableFieldCapability(issueData, fieldId);
+    const fieldMeta = capability.fieldMeta;
+    const fieldName = String(issueData?.names?.[fieldId] || fieldMeta?.name || fieldId);
+    if (!capability.editable || !fieldMeta || !Array.isArray(capability.allowedValues) || !capability.allowedValues.length) {
+      return null;
+    }
+
+    const schemaType = String(fieldMeta?.schema?.type || '').toLowerCase();
+    const operations = capability.operations || [];
+    const isMultiValue = schemaType === 'array';
+    const currentValue = issueData?.fields?.[fieldId];
+    const currentEntries = isMultiValue
+      ? (Array.isArray(currentValue) ? currentValue : [])
+      : (currentValue ? [currentValue] : []);
+    const currentSelections = currentEntries
+      .map(entry => buildCustomFieldOption(fieldName, entry))
+      .filter(Boolean);
+    const allowedOptions = capability.allowedValues
+      .map(entry => buildCustomFieldOption(fieldName, entry))
+      .filter(Boolean);
+    const allOptions = mergeEditOptions(currentSelections, allowedOptions);
+
+    if (isMultiValue && !operations.includes('set')) {
+      return null;
+    }
+    if (!isMultiValue && !operations.includes('set')) {
+      return null;
+    }
+
+    return {
+      fieldKey: fieldId,
+      editorType: isMultiValue ? 'multi-select' : 'single-select',
+      label: fieldName,
+      selectionMode: isMultiValue ? 'multi' : 'single',
+      currentText: buildCustomFieldValueText(fieldName, currentValue),
+      currentOptionId: !isMultiValue && currentSelections[0] ? currentSelections[0].id : null,
+      currentSelections,
+      initialInputValue: isMultiValue ? '' : '',
+      loadOptions: async () => allOptions,
+      save: selectedOptions => {
+        const fieldValue = isMultiValue
+          ? selectedOptions.map(option => buildCustomFieldSaveValue(option.rawValue))
+          : buildCustomFieldSaveValue(selectedOptions[0]?.rawValue);
+        return requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
+          fields: {
+            [fieldId]: isMultiValue ? fieldValue : (fieldValue ?? null)
+          }
+        });
+      },
+      successMessage: () => `${fieldName} updated`
+    };
+  }
+
   function normalizeCustomFields(customFields) {
     if (!Array.isArray(customFields)) {
       return [];
@@ -1742,16 +1918,27 @@ async function mainAsyncLocal() {
       linkUrl: ''
     };
   }
-  function buildCustomFieldChips(issueData, customFields) {
+  async function buildCustomFieldChips(issueData, customFields, state) {
     const names = issueData.names || {};
     const fields = issueData.fields || {};
     const chipsByRow = {1: [], 2: [], 3: []};
-    customFields.forEach(({fieldId, row}) => {
+    for (const {fieldId, row} of customFields) {
       const rawValue = fields[fieldId];
       if (rawValue === undefined || rawValue === null || rawValue === '') {
-        return;
+        continue;
       }
       const fieldName = String(names[fieldId] || fieldId);
+      const supportedDefinition = await getSupportedCustomFieldDefinition(fieldId, issueData).catch(() => null);
+      if (supportedDefinition) {
+        chipsByRow[row].push(buildEditableFieldChip(fieldId, {
+          text: buildCustomFieldValueText(fieldName, rawValue),
+          linkUrl: ''
+        }, state, {
+          canEdit: true,
+          editTitle: `Edit ${fieldName}`
+        }));
+        continue;
+      }
       const entries = Array.isArray(rawValue) ? rawValue : [rawValue];
       entries.forEach(entry => {
         const chip = formatCustomFieldChip(fieldName, entry);
@@ -1759,7 +1946,7 @@ async function mainAsyncLocal() {
           chipsByRow[row].push(chip);
         }
       });
-    });
+    }
     return chipsByRow;
   }
 
@@ -2689,6 +2876,51 @@ async function mainAsyncLocal() {
       };
     }
 
+    if (fieldKey === 'labels') {
+      const capability = await getEditableFieldCapability(issueData, 'labels');
+      const suggestionSupport = await hasLabelSuggestionSupport();
+      if (!capability.editable || !suggestionSupport) {
+        return null;
+      }
+      const currentLabels = (issueData?.fields?.labels || []).filter(Boolean);
+      const currentSelections = currentLabels.map(label => buildLabelOption(label));
+      return {
+        fieldKey,
+        editorType: 'label-search',
+        label: 'Labels',
+        selectionMode: 'multi',
+        currentText: `Labels: ${currentLabels.join(', ') || '--'}`,
+        currentOptionId: null,
+        currentSelections,
+        initialInputValue: '',
+        inputPlaceholder: 'Search existing labels',
+        loadOptions: async () => {
+          const baselineSuggestions = await getLabelSuggestions('').catch(() => []);
+          return mergeEditOptions(currentSelections, baselineSuggestions);
+        },
+        searchOptions: async query => {
+          const searchedOptions = await getLabelSuggestions(query);
+          return mergeEditOptions(currentSelections, mergeEditOptions(searchedOptions, popupState?.editState?.options || []));
+        },
+        save: selectedOptions => {
+          const nextLabels = selectedOptions.map(option => option.id).filter(Boolean);
+          return requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
+            fields: {
+              labels: nextLabels
+            }
+          });
+        },
+        successMessage: () => 'Labels updated'
+      };
+    }
+
+    if (String(fieldKey || '').startsWith('customfield_')) {
+      const customFieldDefinition = await getSupportedCustomFieldDefinition(fieldKey, issueData);
+      if (customFieldDefinition) {
+        return customFieldDefinition;
+      }
+    }
+
     return null;
   }
 
@@ -2741,7 +2973,7 @@ async function mainAsyncLocal() {
           title: option.label
         }))
       : [];
-    const isSearchEditor = editState.editorType === 'user-search' || editState.editorType === 'issue-search';
+    const isSearchEditor = editState.editorType === 'user-search' || editState.editorType === 'issue-search' || editState.editorType === 'label-search';
     const inputDisabled = !!(editState.saving || (editState.loadingOptions && !isSearchEditor));
     const loadingText = editState.loadingOptions
       ? (isSearchEditor ? `Searching ${editState.label.toLowerCase()}...` : `Loading ${editState.label.toLowerCase()} values...`)
@@ -3115,23 +3347,26 @@ async function mainAsyncLocal() {
     const attachments = issueData.fields.attachment || [];
     const previewAttachments = buildPreviewAttachments(attachments);
     const labels = issueData.fields.labels || [];
-    const customFieldChips = buildCustomFieldChips(issueData, customFields);
     const linkageData = await resolveIssueLinkage(issueData);
     const issueTypeName = issueData.fields.issuetype?.name;
     const statusName = issueData.fields.status?.name;
     const priorityName = issueData.fields.priority?.name;
     const projectKey = key.split('-')[0];
-    const [priorityCapability, assigneeCapability, transitionOptions, sprintCapability, affectsCapability, fixVersionsCapability] = await Promise.all([
+    const [priorityCapability, assigneeCapability, transitionOptions, sprintCapability, affectsCapability, fixVersionsCapability, labelsCapability, labelSuggestionSupport, customFieldChips] = await Promise.all([
       displayFields.priority ? getEditableFieldCapability(issueData, 'priority') : Promise.resolve({editable: false}),
       displayFields.assignee ? getEditableFieldCapability(issueData, 'assignee') : Promise.resolve({editable: false}),
       displayFields.status ? getTransitionOptions(issueData.key).catch(() => []) : Promise.resolve([]),
       displayFields.sprint ? getEditableFieldCapability(issueData, 'sprint') : Promise.resolve({editable: false}),
       displayFields.affects ? getEditableFieldCapability(issueData, 'versions') : Promise.resolve({editable: false}),
-      displayFields.fixVersions ? getEditableFieldCapability(issueData, 'fixVersions') : Promise.resolve({editable: false})
+      displayFields.fixVersions ? getEditableFieldCapability(issueData, 'fixVersions') : Promise.resolve({editable: false}),
+      displayFields.labels ? getEditableFieldCapability(issueData, 'labels') : Promise.resolve({editable: false}),
+      displayFields.labels ? hasLabelSuggestionSupport() : Promise.resolve(false),
+      buildCustomFieldChips(issueData, customFields, state)
     ]);
     const statusEditable = Array.isArray(transitionOptions) && transitionOptions.length > 0;
     const priorityEditable = !!priorityCapability?.editable;
     const assigneeEditable = !!assigneeCapability?.editable;
+    const labelsEditable = !!labelsCapability?.editable && !!labelSuggestionSupport;
 
     const row1Chips = [
       displayFields.issueType ? buildFilterChip(
@@ -3202,10 +3437,13 @@ async function mainAsyncLocal() {
 
     const singleLabel = labels.length === 1 ? labels[0] : '';
     const row3Chips = [
-      displayFields.labels ? buildFilterChip(
+      displayFields.labels ? buildEditableFieldChip('labels', buildFilterChip(
         `Labels: ${labels.filter(Boolean).join(', ') || '--'}`,
         singleLabel ? `${scopeJqlToProject(projectKey, `labels = ${encodeJqlValue(singleLabel)}`)}` : ''
-      ) : null,
+      ), state, {
+        canEdit: labelsEditable,
+        editTitle: 'Edit labels'
+      }) : null,
       ...customFieldChips[3]
     ].filter(Boolean);
 
@@ -3513,7 +3751,7 @@ async function mainAsyncLocal() {
       if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey || popupState.editState.searchRequestId !== requestId) {
         return;
       }
-      const mergedOptions = popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search'
+      const mergedOptions = popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search' || popupState.editState.editorType === 'label-search'
         ? mergeEditOptions(options, popupState.editState.options)
         : options;
       popupState = {
@@ -3611,7 +3849,7 @@ async function mainAsyncLocal() {
       }
       await renderIssuePopup(popupState);
 
-      if (popupState?.editState?.fieldKey === fieldKey && (popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search')) {
+      if (popupState?.editState?.fieldKey === fieldKey && (popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search' || popupState.editState.editorType === 'label-search')) {
         const searchRequestId = ++editSearchRequestCounter;
         popupState = {
           ...popupState,
@@ -3686,6 +3924,7 @@ async function mainAsyncLocal() {
 
     const canAutoComplete = popupState.editState.editorType !== 'user-search' &&
       popupState.editState.editorType !== 'issue-search' &&
+      popupState.editState.editorType !== 'label-search' &&
       popupState.editState.editorType !== 'multi-select' &&
       typeof selectionStart === 'number' &&
       typeof selectionEnd === 'number' &&
@@ -3718,7 +3957,7 @@ async function mainAsyncLocal() {
     };
     renderIssuePopup(popupState).catch(() => {});
 
-    if (popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search') {
+    if (popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search' || popupState.editState.editorType === 'label-search') {
       const searchRequestId = ++editSearchRequestCounter;
       popupState = {
         ...popupState,

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -1420,15 +1420,29 @@ async function mainAsyncLocal() {
     return chipsByRow;
   }
 
-  function readSprintsFromIssue(issueData) {
+  function getIssueSprintEntries(issueData) {
     const names = issueData.names || {};
     const fields = issueData.fields || {};
     const sprintFieldIds = Object.keys(names).filter(fieldId => {
       return typeof names[fieldId] === 'string' && names[fieldId].toLowerCase().includes('sprint');
     });
-    const sprintValues = sprintFieldIds
-      .map(fieldId => fields[fieldId])
-      .filter(value => value !== undefined && value !== null);
+    const sprintEntries = [];
+    sprintFieldIds.forEach(fieldId => {
+      const value = fields[fieldId];
+      if (value === undefined || value === null) {
+        return;
+      }
+      if (Array.isArray(value)) {
+        sprintEntries.push(...value.filter(Boolean));
+        return;
+      }
+      sprintEntries.push(value);
+    });
+    return sprintEntries;
+  }
+
+  function readSprintsFromIssue(issueData) {
+    const sprintEntries = getIssueSprintEntries(issueData);
     const seen = {};
     const sprints = [];
 
@@ -1445,27 +1459,65 @@ async function mainAsyncLocal() {
       sprints.push({id: sprintId, name, state: state || ''});
     };
 
-    sprintValues.forEach(value => {
-      const entries = Array.isArray(value) ? value : [value];
-      entries.forEach(entry => {
-        if (!entry) {
-          return;
-        }
-        if (typeof entry === 'string') {
-          const idMatch = entry.match(/id=([^,\]]+)/i);
-          const nameMatch = entry.match(/name=([^,\]]+)/i);
-          const stateMatch = entry.match(/state=([^,\]]+)/i);
-          pushSprint(
-            idMatch && idMatch[1] ? idMatch[1] : '',
-            nameMatch && nameMatch[1] ? nameMatch[1] : entry,
-            stateMatch && stateMatch[1]
-          );
-          return;
-        }
-        pushSprint(entry.id || '', entry.name || entry.goal || entry.id, entry.state);
-      });
+    sprintEntries.forEach(entry => {
+      if (!entry) {
+        return;
+      }
+      if (typeof entry === 'string') {
+        const idMatch = entry.match(/id=([^,\]]+)/i);
+        const nameMatch = entry.match(/name=([^,\]]+)/i);
+        const stateMatch = entry.match(/state=([^,\]]+)/i);
+        pushSprint(
+          idMatch && idMatch[1] ? idMatch[1] : '',
+          nameMatch && nameMatch[1] ? nameMatch[1] : entry,
+          stateMatch && stateMatch[1]
+        );
+        return;
+      }
+      pushSprint(entry.id || '', entry.name || entry.goal || entry.id, entry.state);
     });
     return sprints;
+  }
+
+  function readSprintBoardRefsFromIssue(issueData) {
+    const projectKey = String(issueData?.key || '').split('-')[0];
+    const seen = new Set();
+    const boardRefs = [];
+
+    getIssueSprintEntries(issueData).forEach(entry => {
+      const candidateBoardIds = [];
+      if (typeof entry === 'string') {
+        ['rapidViewId', 'boardId', 'originBoardId'].forEach(fieldName => {
+          const match = entry.match(new RegExp(`${fieldName}=([^,\\]]+)`, 'i'));
+          if (match && match[1]) {
+            candidateBoardIds.push(match[1]);
+          }
+        });
+      } else {
+        candidateBoardIds.push(
+          entry.rapidViewId,
+          entry.boardId,
+          entry.originBoardId,
+          entry.board?.id,
+          entry.rapidView?.id
+        );
+      }
+
+      candidateBoardIds.forEach(candidateId => {
+        const boardId = String(candidateId || '').trim();
+        if (!boardId || seen.has(boardId)) {
+          return;
+        }
+        seen.add(boardId);
+        boardRefs.push({
+          id: boardId,
+          name: String(entry?.board?.name || entry?.rapidView?.name || ''),
+          projectKey
+        });
+      });
+    });
+
+    return boardRefs;
   }
 
   function formatFixVersionText(fixVersions) {
@@ -1765,6 +1817,34 @@ async function mainAsyncLocal() {
     return getProjectVersionOptions(issueData, 'versions', 'No affects version');
   }
 
+  async function getCandidateSprintBoards(issueData) {
+    const projectKey = String(issueData?.key || '').split('-')[0];
+    const boardsById = new Map();
+    const addBoard = board => {
+      const boardId = String(board?.id || '').trim();
+      if (!boardId) {
+        return;
+      }
+      const existingBoard = boardsById.get(boardId) || {};
+      boardsById.set(boardId, {
+        ...existingBoard,
+        ...board,
+        id: boardId,
+        name: String(board?.name || existingBoard.name || ''),
+        projectKey: String(board?.projectKey || existingBoard.projectKey || projectKey)
+      });
+    };
+
+    if (projectKey) {
+      const boardResponse = await get(`${INSTANCE_URL}rest/agile/1.0/board?projectKeyOrId=${encodeURIComponent(projectKey)}&maxResults=50`).catch(() => null);
+      const projectBoards = Array.isArray(boardResponse?.values) ? boardResponse.values : [];
+      projectBoards.forEach(addBoard);
+    }
+
+    readSprintBoardRefsFromIssue(issueData).forEach(addBoard);
+    return [...boardsById.values()];
+  }
+
   async function getSprintOptions(issueData) {
     const projectKey = String(issueData?.key || '').split('-')[0];
     if (!projectKey) {
@@ -1774,23 +1854,45 @@ async function mainAsyncLocal() {
     if (!sprintFieldIds.length) {
       return [];
     }
-    return getCachedValue(fieldOptionsCache, `sprint__${projectKey}`, async () => {
-      const boardResponse = await get(`${INSTANCE_URL}rest/agile/1.0/board?projectKeyOrId=${encodeURIComponent(projectKey)}&maxResults=50`);
-      const boards = Array.isArray(boardResponse?.values) ? boardResponse.values : [];
+    const issueBoardIdsKey = readSprintBoardRefsFromIssue(issueData)
+      .map(board => String(board.id || ''))
+      .filter(Boolean)
+      .sort()
+      .join(',');
+    return getCachedValue(fieldOptionsCache, `sprint__${projectKey}__${issueBoardIdsKey}`, async () => {
+      const boards = await getCandidateSprintBoards(issueData);
       const sprintMap = new Map();
       const sprintResponses = await Promise.allSettled(boards.map(board => {
-        return get(`${INSTANCE_URL}rest/agile/1.0/board/${board.id}/sprint?state=active,future&maxResults=50`);
+        return get(`${INSTANCE_URL}rest/agile/1.0/board/${board.id}/sprint?state=active,future&maxResults=50`)
+          .then(response => ({board, response}));
       }));
 
       sprintResponses.forEach(result => {
         if (result.status !== 'fulfilled') {
           return;
         }
-        const sprints = Array.isArray(result.value?.values) ? result.value.values : [];
+        const sprints = Array.isArray(result.value?.response?.values) ? result.value.response.values : [];
         sprints.forEach(sprint => {
-          if (sprint?.id && sprint?.name) {
-            sprintMap.set(String(sprint.id), sprint);
+          if (!sprint?.id || !sprint?.name) {
+            return;
           }
+          const sprintId = String(sprint.id);
+          const existingSprint = sprintMap.get(sprintId);
+          const boardRefs = Array.isArray(existingSprint?.boardRefs) ? existingSprint.boardRefs.slice() : [];
+          const board = result.value?.board || {};
+          const boardRefKey = String(board.id || '');
+          if (boardRefKey && !boardRefs.some(ref => String(ref.id) === boardRefKey)) {
+            boardRefs.push({
+              id: board.id,
+              name: board.name || '',
+              projectKey: board.projectKey || projectKey
+            });
+          }
+          sprintMap.set(sprintId, {
+            ...(existingSprint || {}),
+            ...sprint,
+            boardRefs
+          });
         });
       });
 
@@ -1951,8 +2053,14 @@ async function mainAsyncLocal() {
         upcomingSprint: null
       };
     }
-    if (projectSprintOptionsPromises.has(projectKey)) {
-      return projectSprintOptionsPromises.get(projectKey);
+    const issueBoardIdsKey = readSprintBoardRefsFromIssue(issueData)
+      .map(board => String(board.id || ''))
+      .filter(Boolean)
+      .sort()
+      .join(',');
+    const cacheKey = `${projectKey}__${issueBoardIdsKey}`;
+    if (projectSprintOptionsPromises.has(cacheKey)) {
+      return projectSprintOptionsPromises.get(cacheKey);
     }
 
     const sprintPromise = (async () => {
@@ -1964,8 +2072,7 @@ async function mainAsyncLocal() {
         };
       }
 
-      const boardResponse = await get(`${INSTANCE_URL}rest/agile/1.0/board?projectKeyOrId=${encodeURIComponent(projectKey)}&maxResults=50`);
-      const boards = Array.isArray(boardResponse?.values) ? boardResponse.values : [];
+      const boards = await getCandidateSprintBoards(issueData);
       if (!boards.length) {
         return {
           activeSprints: [],
@@ -1997,7 +2104,7 @@ async function mainAsyncLocal() {
             boardRefs.push({
               id: board.id,
               name: board.name || '',
-              projectKey
+              projectKey: board.projectKey || projectKey
             });
           }
           sprintMap.set(sprintId, {
@@ -2038,14 +2145,14 @@ async function mainAsyncLocal() {
         upcomingSprint
       };
     })().catch(error => {
-      projectSprintOptionsPromises.delete(projectKey);
+      projectSprintOptionsPromises.delete(cacheKey);
       return {
         activeSprints: [],
         upcomingSprint: null
       };
     });
 
-    projectSprintOptionsPromises.set(projectKey, sprintPromise);
+    projectSprintOptionsPromises.set(cacheKey, sprintPromise);
     return sprintPromise;
   }
 
@@ -2540,7 +2647,7 @@ async function mainAsyncLocal() {
     if (!definition) {
       return;
     }
-    const initialValue = definition.currentText || '';
+    const initialValue = '';
     popupState = {
       ...popupState,
       editState: {
@@ -2564,7 +2671,7 @@ async function mainAsyncLocal() {
         return;
       }
       const selectedOption = (Array.isArray(options) ? options : []).find(option => option.id === popupState.editState.selectedOptionId);
-      const nextInputValue = selectedOption ? selectedOption.label : popupState.editState.inputValue;
+      const nextInputValue = '';
       popupState = {
         ...popupState,
         editState: {
@@ -3149,3 +3256,4 @@ if (!window.__JX__script_injected__) {
 }
 
 window.__JX__script_injected__ = true;
+

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -143,6 +143,23 @@ async function requestJson(method, url, body) {
   throw err;
 }
 
+async function uploadAttachment(url, file) {
+  const bytes = Array.from(new Uint8Array(await file.arrayBuffer()));
+  const response = await sendMessage({
+    action: 'uploadAttachment',
+    bytes,
+    contentType: file.type,
+    fileName: file.name,
+    url
+  });
+  if (Object.prototype.hasOwnProperty.call(response, 'result')) {
+    return response.result;
+  }
+  const err = new Error(response.error || 'Attachment upload failed');
+  err.inner = response.error;
+  throw err;
+}
+
 function isJiraConnectionFailure(error) {
   const message = String(error?.message || error?.inner || error || '');
   return CONNECTION_ERROR_PATTERN.test(message);
@@ -217,10 +234,16 @@ async function mainAsyncLocal() {
     suggestions: [],
     visible: false
   });
+  const emptyCommentUploadState = () => ({
+    items: []
+  });
   let currentUserPromise;
   let activeCommentContext = null;
   let commentMentionState = emptyCommentMentionState();
   let commentMentionRequestId = 0;
+  let commentUploadState = emptyCommentUploadState();
+  let commentUploadSessionId = 0;
+  let commentUploadSequence = 0;
 
   function toAbsoluteJiraUrl(url) {
     if (!url) {
@@ -308,19 +331,34 @@ async function mainAsyncLocal() {
     return normalized ? `@${normalized}` : '@mention';
   }
 
-  function textToLinkedHtml(input) {
+  function textToLinkedHtml(input, options = {}) {
+    const {attachmentImagesByName = {}} = options;
     const mentionHtml = [];
     const inputWithMentions = String(input || '').replace(/\[~([^[\]\r\n]+?)\]/g, function (match, mentionValue) {
       const placeholderIndex = mentionHtml.length;
       mentionHtml.push(`<span class="_JX_mention">${escapeHtml(getMentionDisplayText(mentionValue))}</span>`);
       return `__JX_COMMENT_MENTION_${placeholderIndex}__`;
     });
-    const escaped = escapeHtml(inputWithMentions);
+    const imageHtml = [];
+    const inputWithImages = inputWithMentions.replace(/!([^!\r\n]+)!/g, function (match, imageName) {
+      const normalizedName = String(imageName || '').trim();
+      const imageMarkup = attachmentImagesByName[normalizedName];
+      if (!imageMarkup) {
+        return match;
+      }
+      const placeholderIndex = imageHtml.length;
+      imageHtml.push(imageMarkup);
+      return `__JX_COMMENT_IMAGE_${placeholderIndex}__`;
+    });
+    const escaped = escapeHtml(inputWithImages);
     const withLinks = escaped.replace(
       /(https?:\/\/[^\s<]+)/g,
       '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
     );
     return withLinks
+      .replace(/__JX_COMMENT_IMAGE_(\d+)__/g, function (match, index) {
+        return imageHtml[Number(index)] || '';
+      })
       .replace(/__JX_COMMENT_MENTION_(\d+)__/g, function (match, index) {
         return mentionHtml[Number(index)] || '';
       })
@@ -534,10 +572,270 @@ async function mainAsyncLocal() {
       root: container.find('._JX_comment_compose'),
       input: container.find('._JX_comment_input'),
       mentions: container.find('._JX_comment_mentions'),
+      uploads: container.find('._JX_comment_uploads'),
       save: container.find('._JX_comment_save'),
       discard: container.find('._JX_comment_discard'),
       error: container.find('._JX_comment_error')
     };
+  }
+
+  function hasCommentUploadInFlight() {
+    return commentUploadState.items.some(item => item.status === 'uploading');
+  }
+
+  function getUploadedCommentAttachments() {
+    return commentUploadState.items.filter(item => item.status === 'uploaded' && item.attachmentId);
+  }
+
+  function renderCommentUploads() {
+    const {uploads} = getCommentComposerElements();
+    if (!uploads.length) {
+      return;
+    }
+
+    if (!commentUploadState.items.length) {
+      uploads.attr('hidden', 'hidden').empty();
+      keepContainerVisible();
+      return;
+    }
+
+    uploads.removeAttr('hidden').html(commentUploadState.items.map(item => {
+      const stateClass = item.status === 'error' ? ' is-error' : '';
+      const statusText = item.status === 'uploading'
+        ? 'Uploading to Jira...'
+        : (item.status === 'uploaded' ? 'Attached to issue' : (item.errorMessage || 'Upload failed'));
+      const previewHtml = item.previewUrl
+        ? `<img class="_JX_comment_upload_preview" src="${escapeHtml(item.previewUrl)}" alt="${escapeHtml(item.fileName)}" />`
+        : '<span class="_JX_comment_upload_preview"></span>';
+      return `
+        <div class="_JX_comment_upload${stateClass}">
+          ${previewHtml}
+          <span>
+            <span class="_JX_comment_upload_name">${escapeHtml(item.fileName)}</span>
+            <span class="_JX_comment_upload_status">${escapeHtml(statusText)}</span>
+          </span>
+        </div>
+      `;
+    }).join(''));
+    keepContainerVisible();
+  }
+
+  function updateCommentUploadItem(localId, updater) {
+    const nextItems = commentUploadState.items.map(item => {
+      if (item.localId !== localId) {
+        return item;
+      }
+      return typeof updater === 'function' ? updater(item) : {...item, ...updater};
+    });
+    commentUploadState = {items: nextItems};
+    renderCommentUploads();
+    syncCommentComposerState();
+  }
+
+  function buildPastedImageFileName(file) {
+    const mimeType = String(file?.type || '').toLowerCase();
+    const extensionByMimeType = {
+      'image/bmp': 'bmp',
+      'image/gif': 'gif',
+      'image/jpeg': 'jpg',
+      'image/jpg': 'jpg',
+      'image/png': 'png',
+      'image/webp': 'webp'
+    };
+    const extension = extensionByMimeType[mimeType] || 'png';
+    commentUploadSequence += 1;
+    const timestamp = new Date().toISOString().replace(/[^\d]/g, '').slice(0, 14);
+    return `pasted-image-${timestamp}-${commentUploadSequence}.${extension}`;
+  }
+
+  function buildCommentImageMarkup(fileName) {
+    return `!${fileName}!`;
+  }
+
+  function replaceCommentInputText(searchValue, replaceValue = '') {
+    const {input} = getCommentComposerElements();
+    const inputElement = input.get(0);
+    if (!inputElement || !searchValue) {
+      return false;
+    }
+    const currentValue = inputElement.value || '';
+    const nextValue = currentValue.replace(searchValue, replaceValue).replace(/\n{3,}/g, '\n\n');
+    if (nextValue === currentValue) {
+      return false;
+    }
+    input.val(nextValue);
+    const caretPosition = Math.min(nextValue.length, (typeof inputElement.selectionStart === 'number' ? inputElement.selectionStart : nextValue.length));
+    inputElement.setSelectionRange(caretPosition, caretPosition);
+    return true;
+  }
+
+  function insertCommentInputText(text) {
+    const {input} = getCommentComposerElements();
+    const inputElement = input.get(0);
+    if (!inputElement) {
+      return false;
+    }
+    const value = inputElement.value || '';
+    const selectionStart = typeof inputElement.selectionStart === 'number' ? inputElement.selectionStart : value.length;
+    const selectionEnd = typeof inputElement.selectionEnd === 'number' ? inputElement.selectionEnd : selectionStart;
+    const prefix = selectionStart > 0 && value.charAt(selectionStart - 1) !== '\n' ? '\n' : '';
+    const suffix = selectionEnd < value.length
+      ? (value.charAt(selectionEnd) !== '\n' ? '\n' : '')
+      : '\n';
+    const insertedText = `${prefix}${text}${suffix}`;
+    const nextValue = value.slice(0, selectionStart) + insertedText + value.slice(selectionEnd);
+    input.val(nextValue);
+    inputElement.focus();
+    const caretPosition = selectionStart + insertedText.length;
+    inputElement.setSelectionRange(caretPosition, caretPosition);
+    return true;
+  }
+
+  function revokeCommentUploadPreview(item) {
+    if (item?.previewUrl && item.previewUrl.startsWith('blob:')) {
+      URL.revokeObjectURL(item.previewUrl);
+    }
+  }
+
+  async function deleteCommentDraftAttachment(attachmentId) {
+    if (!attachmentId) {
+      return;
+    }
+    try {
+      await requestJson('DELETE', `${INSTANCE_URL}rest/api/2/attachment/${attachmentId}`);
+    } catch (error) {
+      console.warn('[Jira HotLinker] Could not delete draft attachment', {
+        attachmentId,
+        error: error?.message || String(error)
+      });
+    }
+  }
+
+  async function clearCommentUploads(options = {}) {
+    const {deleteUploaded = false} = options;
+    const previousItems = commentUploadState.items;
+    commentUploadSessionId += 1;
+    commentUploadState = emptyCommentUploadState();
+    renderCommentUploads();
+    syncCommentComposerState();
+    previousItems.forEach(revokeCommentUploadPreview);
+    if (deleteUploaded) {
+      await Promise.all(previousItems.map(item => deleteCommentDraftAttachment(item.attachmentId)));
+    }
+  }
+
+  async function discardCommentComposerDraft(options = {}) {
+    const {deleteUploaded = true} = options;
+    resetCommentMentionState();
+    const {input} = getCommentComposerElements();
+    if (input.length) {
+      input.val('');
+    }
+    setCommentComposerError('');
+    await clearCommentUploads({deleteUploaded});
+    syncCommentComposerState();
+  }
+
+  async function buildOptimisticCommentBodyHtml(commentText, uploadedAttachments = []) {
+    const attachmentImagesByName = {};
+    for (const attachment of uploadedAttachments) {
+      if (!attachment?.fileName) {
+        continue;
+      }
+      const imageUrl = attachment.thumbnailUrl || attachment.contentUrl;
+      if (!imageUrl) {
+        continue;
+      }
+      const displaySrc = await getDisplayImageUrl(imageUrl).catch(() => imageUrl);
+      const previewSrc = attachment.contentUrl || imageUrl;
+      attachmentImagesByName[attachment.fileName] = `<img class="_JX_previewable" src="${escapeHtml(displaySrc || imageUrl)}" data-jx-preview-src="${escapeHtml(previewSrc)}" alt="${escapeHtml(attachment.fileName)}" style="max-height: 100px;" />`;
+    }
+    return textToLinkedHtml(commentText || '', {attachmentImagesByName});
+  }
+
+  async function uploadPastedImage(file) {
+    if (!activeCommentContext?.issueKey) {
+      return;
+    }
+
+    const issueKey = activeCommentContext.issueKey;
+    const fileName = buildPastedImageFileName(file);
+    const markup = buildCommentImageMarkup(fileName);
+    const localId = `upload-${Date.now()}-${commentUploadSequence}`;
+    const previewUrl = URL.createObjectURL(file);
+    const sessionId = commentUploadSessionId;
+    commentUploadState = {
+      items: [...commentUploadState.items, {
+        attachmentId: '',
+        contentUrl: '',
+        errorMessage: '',
+        fileName,
+        localId,
+        markup,
+        previewUrl,
+        status: 'uploading',
+        thumbnailUrl: ''
+      }]
+    };
+    renderCommentUploads();
+    insertCommentInputText(markup);
+    setCommentComposerError('');
+    syncCommentComposerState();
+
+    try {
+      const uploadResult = await uploadAttachment(`${INSTANCE_URL}rest/api/2/issue/${issueKey}/attachments`, new File([file], fileName, {type: file.type || 'image/png'}));
+      const uploadedAttachment = (Array.isArray(uploadResult) ? uploadResult : [uploadResult]).find(item => item && item.id);
+      if (!uploadedAttachment) {
+        throw new Error('Attachment upload failed');
+      }
+
+      if (sessionId !== commentUploadSessionId || activeCommentContext?.issueKey !== issueKey) {
+        await deleteCommentDraftAttachment(uploadedAttachment.id);
+        return;
+      }
+
+      const nextFileName = uploadedAttachment.filename || fileName;
+      const nextMarkup = buildCommentImageMarkup(nextFileName);
+      if (nextMarkup !== markup) {
+        replaceCommentInputText(markup, nextMarkup);
+      }
+      updateCommentUploadItem(localId, {
+        attachmentId: uploadedAttachment.id,
+        contentUrl: toAbsoluteJiraUrl(uploadedAttachment.content),
+        errorMessage: '',
+        fileName: nextFileName,
+        markup: nextMarkup,
+        status: 'uploaded',
+        thumbnailUrl: toAbsoluteJiraUrl(uploadedAttachment.thumbnail || uploadedAttachment.content)
+      });
+    } catch (error) {
+      if (sessionId !== commentUploadSessionId) {
+        return;
+      }
+      replaceCommentInputText(markup, '');
+      updateCommentUploadItem(localId, {
+        errorMessage: error?.message || error?.inner || 'Upload failed',
+        status: 'error'
+      });
+      setCommentComposerError(error?.message || error?.inner || 'Could not upload pasted image');
+    }
+  }
+
+  function getClipboardImageFiles(event) {
+    const clipboardData = event?.originalEvent?.clipboardData || event?.clipboardData;
+    if (!clipboardData) {
+      return [];
+    }
+
+    const items = Array.from(clipboardData.items || []);
+    const itemFiles = items
+      .filter(item => item && item.kind === 'file' && String(item.type || '').toLowerCase().startsWith('image/'))
+      .map(item => item.getAsFile())
+      .filter(Boolean);
+    if (itemFiles.length) {
+      return itemFiles;
+    }
+    return Array.from(clipboardData.files || []).filter(file => String(file?.type || '').toLowerCase().startsWith('image/'));
   }
 
   function renderCommentMentionSuggestions() {
@@ -548,21 +846,25 @@ async function mainAsyncLocal() {
 
     if (!commentMentionState.visible) {
       mentions.attr('hidden', 'hidden').empty();
+      keepContainerVisible();
       return;
     }
 
     if (commentMentionState.loading) {
       mentions.removeAttr('hidden').html('<div class="_JX_comment_mentions_status">Searching people...</div>');
+      keepContainerVisible();
       return;
     }
 
     if (commentMentionState.error) {
       mentions.removeAttr('hidden').html(`<div class="_JX_comment_mentions_status">${escapeHtml(commentMentionState.error)}</div>`);
+      keepContainerVisible();
       return;
     }
 
     if (!commentMentionState.suggestions.length) {
       mentions.removeAttr('hidden').html('<div class="_JX_comment_mentions_status">No people found.</div>');
+      keepContainerVisible();
       return;
     }
 
@@ -580,6 +882,7 @@ async function mainAsyncLocal() {
         </button>
       `;
     }).join(''));
+    keepContainerVisible();
   }
 
   function resetCommentMentionState() {
@@ -718,10 +1021,12 @@ async function mainAsyncLocal() {
       return;
     }
     const isSaving = elements.root.attr('data-saving') === 'true';
+    const hasUploadsInFlight = hasCommentUploadInFlight();
     const hasText = !!elements.input.val().trim();
+    const hasDraftUploads = commentUploadState.items.length > 0;
     elements.input.prop('disabled', isSaving);
-    elements.save.prop('disabled', !hasText || isSaving).text(isSaving ? 'Saving...' : 'Save');
-    elements.discard.prop('disabled', !hasText || isSaving);
+    elements.save.prop('disabled', !hasText || isSaving || hasUploadsInFlight).text(isSaving ? 'Saving...' : (hasUploadsInFlight ? 'Uploading...' : 'Save'));
+    elements.discard.prop('disabled', (!hasText && !hasDraftUploads) || isSaving);
   }
 
   function setCommentComposerError(message) {
@@ -744,7 +1049,7 @@ async function mainAsyncLocal() {
     activityItem.attr('title', `${nextCount} comments`);
   }
 
-  async function appendCommentToPopup(commentText) {
+  async function appendCommentToPopup(commentText, uploadedAttachments = []) {
     const commentsRoot = container.find('._JX_comments');
     if (!commentsRoot.length) {
       return;
@@ -753,7 +1058,7 @@ async function mainAsyncLocal() {
     commentsRoot.find('._JX_comments_empty').remove();
     container.find('._JX_empty_body').remove();
     const currentUser = await getCurrentUserInfo().catch(() => ({displayName: 'You'}));
-    const bodyHtml = textToLinkedHtml(commentText || '');
+    const bodyHtml = await buildOptimisticCommentBodyHtml(commentText || '', uploadedAttachments);
     const commentHtml = `
       <div class="_JX_comment">
         <div class="_JX_comment_meta">
@@ -784,17 +1089,24 @@ async function mainAsyncLocal() {
       syncCommentComposerState();
       return;
     }
+    if (hasCommentUploadInFlight()) {
+      setCommentComposerError('Wait for image uploads to finish.');
+      syncCommentComposerState();
+      return;
+    }
 
     elements.root.attr('data-saving', 'true');
     setCommentComposerError('');
     syncCommentComposerState();
 
     try {
+      const uploadedAttachments = getUploadedCommentAttachments();
       await requestJson('POST', `${INSTANCE_URL}rest/api/2/issue/${activeCommentContext.issueKey}/comment`, {
         body: commentText
       });
-      await appendCommentToPopup(commentText);
+      await appendCommentToPopup(commentText, uploadedAttachments);
       elements.input.val('');
+      await clearCommentUploads({deleteUploaded: false});
       elements.root.attr('data-saving', 'false');
       setCommentComposerError('');
       syncCommentComposerState();
@@ -805,15 +1117,12 @@ async function mainAsyncLocal() {
     }
   }
 
-  function handleCommentDiscard() {
+  async function handleCommentDiscard() {
     const elements = getCommentComposerElements();
     if (!elements.root.length || elements.root.attr('data-saving') === 'true') {
       return;
     }
-    resetCommentMentionState();
-    elements.input.val('');
-    setCommentComposerError('');
-    syncCommentComposerState();
+    await discardCommentComposerDraft();
   }
   /***
    * Retrieve only the text that is directly owned by the node
@@ -1270,16 +1579,44 @@ async function mainAsyncLocal() {
     return href;
   }
 
-  function computeVisibleContainerPosition(pointerX, pointerY) {
+  function clampContainerPosition(left, top) {
     const margin = 8;
-    const preferredLeft = pointerX + 20;
-    const preferredTop = pointerY + 25;
-    const width = container.outerWidth();
-    const height = container.outerHeight();
+    const width = container.outerWidth() || 0;
+    const height = container.outerHeight() || 0;
     const viewportLeft = window.scrollX + margin;
     const viewportTop = window.scrollY + margin;
     const viewportRight = window.scrollX + window.innerWidth - margin;
     const viewportBottom = window.scrollY + window.innerHeight - margin;
+    const maxLeft = Math.max(viewportLeft, viewportRight - width);
+    const maxTop = Math.max(viewportTop, viewportBottom - height);
+
+    return {
+      left: Math.min(Math.max(left, viewportLeft), maxLeft),
+      top: Math.min(Math.max(top, viewportTop), maxTop)
+    };
+  }
+
+  function keepContainerVisible() {
+    if (containerPinned || !container.html()) {
+      return;
+    }
+    const currentLeft = Number.parseFloat(container.css('left'));
+    const currentTop = Number.parseFloat(container.css('top'));
+    const fallbackLeft = window.scrollX + 8;
+    const fallbackTop = window.scrollY + 8;
+    container.css(clampContainerPosition(
+      Number.isFinite(currentLeft) ? currentLeft : fallbackLeft,
+      Number.isFinite(currentTop) ? currentTop : fallbackTop
+    ));
+  }
+
+  function computeVisibleContainerPosition(pointerX, pointerY) {
+    const preferredLeft = pointerX + 20;
+    const preferredTop = pointerY + 25;
+    const width = container.outerWidth() || 0;
+    const height = container.outerHeight() || 0;
+    const viewportRight = window.scrollX + window.innerWidth - 8;
+    const viewportBottom = window.scrollY + window.innerHeight - 8;
 
     let left = preferredLeft;
     let top = preferredTop;
@@ -1287,18 +1624,12 @@ async function mainAsyncLocal() {
     if (left + width > viewportRight) {
       left = pointerX - width - 15;
     }
-    if (left < viewportLeft) {
-      left = viewportLeft;
-    }
 
     if (top + height > viewportBottom) {
       top = pointerY - height - 15;
     }
-    if (top < viewportTop) {
-      top = viewportTop;
-    }
 
-    return {left, top};
+    return clampContainerPosition(left, top);
   }
 
   const container = $('<div class="_JX_container">');
@@ -1385,6 +1716,17 @@ async function mainAsyncLocal() {
     syncCommentMentionSuggestions(this);
   });
 
+  $(document.body).on('paste', '._JX_comment_input', function (e) {
+    const imageFiles = getClipboardImageFiles(e);
+    if (!imageFiles.length || !activeCommentContext?.issueKey) {
+      return;
+    }
+    e.preventDefault();
+    imageFiles.forEach(file => {
+      uploadPastedImage(file).catch(() => {});
+    });
+  });
+
   $(document.body).on('click', '._JX_comment_input', function () {
     syncCommentMentionSuggestions(this);
   });
@@ -1448,7 +1790,7 @@ async function mainAsyncLocal() {
 
   $(document.body).on('click', '._JX_comment_discard', function (e) {
     e.preventDefault();
-    handleCommentDiscard();
+    handleCommentDiscard().catch(() => {});
   });
   function closePreviewOverlay() {
     previewOverlay.removeClass('is-open');
@@ -1489,6 +1831,7 @@ async function mainAsyncLocal() {
 
   function hideContainer() {
     lastHoveredKey = '';
+    discardCommentComposerDraft().catch(() => {});
     activeCommentContext = null;
     resetCommentMentionState();
     containerPinned = false;
@@ -1682,9 +2025,6 @@ async function mainAsyncLocal() {
             prs: [],
             description: displayFields.description ? normalizedDescription : '',
             hasBodyContent: true,
-            emptyBodyText: (!normalizedDescription && visibleAttachments.length === 0 && visibleCommentsTotal === 0)
-              ? 'No description, attachments or comments.'
-              : '',
             attachments,
             previewAttachments: visibleAttachments,
             commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
@@ -1735,6 +2075,9 @@ async function mainAsyncLocal() {
             displayData.prs.length
           );
           // TODO: fix scrolling in google docs
+          if (activeCommentContext?.issueKey && activeCommentContext.issueKey !== key) {
+            discardCommentComposerDraft().catch(() => {});
+          }
           container.html(Mustache.render(annotationTemplate, displayData));
           activeCommentContext = displayFields.comments ? { issueKey: key, issueId: issueData.id } : null;
           syncCommentComposerState();

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -1804,8 +1804,64 @@ async function mainAsyncLocal() {
     return `${fieldName}: ${primitive || '--'}`;
   }
 
-  function buildCustomFieldSaveValue(rawValue) {
+  function getCustomFieldSupportDescriptor(fieldMeta) {
+    const schemaType = String(fieldMeta?.schema?.type || '').toLowerCase();
+    const itemType = String(fieldMeta?.schema?.items || '').toLowerCase();
+    const schemaCustom = String(fieldMeta?.schema?.custom || '').toLowerCase();
+
+    if (schemaCustom.includes('cascadingselect')) {
+      return null;
+    }
+
+    if (schemaType === 'option') {
+      return {
+        selectionMode: 'single',
+        valueKind: 'option'
+      };
+    }
+
+    if (schemaType === 'string') {
+      return {
+        selectionMode: 'single',
+        valueKind: 'primitive'
+      };
+    }
+
+    if (schemaType === 'array' && itemType === 'option') {
+      return {
+        selectionMode: 'multi',
+        valueKind: 'option'
+      };
+    }
+
+    if (schemaType === 'array' && itemType === 'string') {
+      return {
+        selectionMode: 'multi',
+        valueKind: 'primitive'
+      };
+    }
+
+    return null;
+  }
+
+  function isSupportedCustomFieldAllowedValue(entry, supportDescriptor) {
+    if (!supportDescriptor) {
+      return false;
+    }
+    if (supportDescriptor.valueKind === 'primitive') {
+      return typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean';
+    }
+    if (!entry || typeof entry !== 'object') {
+      return false;
+    }
+    return !!(entry.id || entry.value || entry.name);
+  }
+
+  function buildCustomFieldSaveValue(rawValue, supportDescriptor) {
     if (rawValue === undefined || rawValue === null) {
+      return rawValue;
+    }
+    if (supportDescriptor?.valueKind === 'primitive') {
       return rawValue;
     }
     if (typeof rawValue === 'string' || typeof rawValue === 'number' || typeof rawValue === 'boolean') {
@@ -1851,9 +1907,13 @@ async function mainAsyncLocal() {
       return null;
     }
 
-    const schemaType = String(fieldMeta?.schema?.type || '').toLowerCase();
+    const supportDescriptor = getCustomFieldSupportDescriptor(fieldMeta);
+    if (!supportDescriptor) {
+      return null;
+    }
+
     const operations = capability.operations || [];
-    const isMultiValue = schemaType === 'array';
+    const isMultiValue = supportDescriptor.selectionMode === 'multi';
     const currentValue = issueData?.fields?.[fieldId];
     const currentEntries = isMultiValue
       ? (Array.isArray(currentValue) ? currentValue : [])
@@ -1862,9 +1922,14 @@ async function mainAsyncLocal() {
       .map(entry => buildCustomFieldOption(fieldName, entry))
       .filter(Boolean);
     const allowedOptions = capability.allowedValues
+      .filter(entry => isSupportedCustomFieldAllowedValue(entry, supportDescriptor))
       .map(entry => buildCustomFieldOption(fieldName, entry))
       .filter(Boolean);
     const allOptions = mergeEditOptions(currentSelections, allowedOptions);
+
+    if (!allOptions.length) {
+      return null;
+    }
 
     if (isMultiValue && !operations.includes('set')) {
       return null;
@@ -1885,8 +1950,8 @@ async function mainAsyncLocal() {
       loadOptions: async () => allOptions,
       save: selectedOptions => {
         const fieldValue = isMultiValue
-          ? selectedOptions.map(option => buildCustomFieldSaveValue(option.rawValue))
-          : buildCustomFieldSaveValue(selectedOptions[0]?.rawValue);
+          ? selectedOptions.map(option => buildCustomFieldSaveValue(option.rawValue, supportDescriptor))
+          : buildCustomFieldSaveValue(selectedOptions[0]?.rawValue, supportDescriptor);
         return requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
           fields: {
             [fieldId]: isMultiValue ? fieldValue : (fieldValue ?? null)

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -779,8 +779,8 @@ async function mainAsyncLocal() {
     return sprints;
   }
 
-  function formatFixVersionText(fixVersions) {
-    return (fixVersions || [])
+  function formatVersionText(versions) {
+    return (versions || [])
       .map(version => version.name)
       .filter(Boolean)
       .join(', ');
@@ -950,19 +950,27 @@ async function mainAsyncLocal() {
     });
   }
 
-  async function getFixVersionOptions(issueData) {
+  async function getProjectVersionOptions(issueData, cacheKey, emptyLabel) {
     const projectKey = String(issueData?.key || '').split('-')[0];
     if (!projectKey) {
       return [];
     }
-    return getCachedValue(fieldOptionsCache, `fixVersions__${projectKey}`, async () => {
+    return getCachedValue(fieldOptionsCache, `${cacheKey}__${projectKey}`, async () => {
       const versions = await get(`${INSTANCE_URL}rest/api/2/project/${encodeURIComponent(projectKey)}/versions`);
       const options = (Array.isArray(versions) ? versions : [])
         .filter(version => version?.name && !version?.archived)
         .sort(compareFixVersionOptions)
         .map(version => buildEditOption(version.id, version.name, {rawValue: version}));
-      return [buildEditOption('', 'No fix version'), ...options];
+      return [buildEditOption('', emptyLabel), ...options];
     });
+  }
+
+  async function getFixVersionOptions(issueData) {
+    return getProjectVersionOptions(issueData, 'fixVersions', 'No fix version');
+  }
+
+  async function getAffectsVersionOptions(issueData) {
+    return getProjectVersionOptions(issueData, 'versions', 'No affects version');
   }
 
   function compareSprintState(left, right) {
@@ -1024,12 +1032,31 @@ async function mainAsyncLocal() {
   }
 
   function getEditableFieldDefinition(fieldKey, issueData) {
+    if (fieldKey === 'versions') {
+      const currentVersions = issueData?.fields?.versions || [];
+      return {
+        fieldKey,
+        label: 'Affects version',
+        currentText: formatVersionText(currentVersions),
+        currentOptionId: currentVersions.length === 1 ? String(currentVersions[0]?.id || '') : null,
+        loadOptions: () => getAffectsVersionOptions(issueData),
+        save: option => {
+          return requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
+            fields: {
+              versions: option.id ? [{id: option.id}] : []
+            }
+          });
+        },
+        successMessage: option => option.id ? `Affects version set to ${option.label}` : 'Affects version cleared'
+      };
+    }
+
     if (fieldKey === 'fixVersions') {
       const currentFixVersions = issueData?.fields?.fixVersions || [];
       return {
         fieldKey,
         label: 'Fix version',
-        currentText: formatFixVersionText(currentFixVersions),
+        currentText: formatVersionText(currentFixVersions),
         currentOptionId: currentFixVersions.length === 1 ? String(currentFixVersions[0]?.id || '') : null,
         loadOptions: () => getFixVersionOptions(issueData),
         save: option => {
@@ -1091,7 +1118,7 @@ async function mainAsyncLocal() {
         ...baseChip,
         isEditable: true,
         isEditing: true,
-        isRightAligned: fieldKey === 'fixVersions',
+        isRightAligned: fieldKey === 'fixVersions' || fieldKey === 'versions',
         fieldKey,
         editLabel: editState.label,
         inputValue: editState.inputValue,
@@ -1229,19 +1256,35 @@ async function mainAsyncLocal() {
 
     const singleAffectsVersion = affectsVersions.length === 1 ? affectsVersions[0]?.name : '';
     const singleFixVersion = fixVersions.length === 1 ? fixVersions[0]?.name : '';
+    const canEditAffectsVersions = affectsVersions.length <= 1;
+    const canEditFixVersions = fixVersions.length <= 1;
     const row2Chips = [
       displayFields.sprint ? buildEditableFieldChip('sprint', buildFilterChip(
         `Sprint: ${formatSprintText(sprints) || '--'}`,
         ''
       ), state) : null,
-      displayFields.affects ? buildFilterChip(
-        `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`,
-        singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
+      displayFields.affects ? (
+        canEditAffectsVersions
+          ? buildEditableFieldChip('versions', buildFilterChip(
+            `Affects: ${formatVersionText(affectsVersions) || '--'}`,
+            singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
+          ), state)
+          : buildFilterChip(
+            `Affects: ${formatVersionText(affectsVersions) || '--'}`,
+            ''
+          )
       ) : null,
-      displayFields.fixVersions ? buildEditableFieldChip('fixVersions', buildFilterChip(
-        `Fix version: ${formatFixVersionText(fixVersions) || '--'}`,
-        singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
-      ), state) : null,
+      displayFields.fixVersions ? (
+        canEditFixVersions
+          ? buildEditableFieldChip('fixVersions', buildFilterChip(
+            `Fix version: ${formatVersionText(fixVersions) || '--'}`,
+            singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
+          ), state)
+          : buildFilterChip(
+            `Fix version: ${formatVersionText(fixVersions) || '--'}`,
+            ''
+          )
+      ) : null,
       ...customFieldChips[2]
     ].filter(Boolean);
 
@@ -1289,7 +1332,7 @@ async function mainAsyncLocal() {
       issueTypeText: displayFields.issueType ? (issueTypeName || 'No type') : '',
       statusText: displayFields.status ? (statusName || 'No status') : '',
       sprintText: displayFields.sprint ? (formatSprintText(sprints) || 'No sprint') : '',
-      fixVersionText: displayFields.fixVersions ? (formatFixVersionText(fixVersions) || 'No fix version') : '',
+      fixVersionText: displayFields.fixVersions ? (formatVersionText(fixVersions) || 'No fix version') : '',
       row1Chips,
       row2Chips,
       row3Chips,

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -269,9 +269,11 @@ async function mainAsyncLocal() {
   const issueSearchCache = new Map();
   const issueSearchRecentCache = new Map();
   const labelSuggestionCache = new Map();
+  const labelLocalOptionsCache = new Map();
   let labelSuggestionSupportPromise = null;
   let preferredAssigneeIdentifier = '';
   let editSearchRequestCounter = 0;
+  let labelSearchTimeoutId = null;
   let popupState = null;
   let activeCommentContext = null;
   let commentMentionState = emptyCommentMentionState();
@@ -1705,13 +1707,27 @@ async function mainAsyncLocal() {
 
   function buildLabelOption(label, extra = {}) {
     const normalizedLabel = String(label || '').trim();
+    const normalizedMetaText = String(extra.metaText || '').trim();
     return buildEditOption(normalizedLabel, normalizedLabel, {
+      ...extra,
+      metaText: normalizedMetaText && normalizedMetaText !== normalizedLabel ? normalizedMetaText : '',
       rawValue: normalizedLabel,
-      ...extra
     });
   }
 
   function normalizeLabelSuggestionPayload(payload) {
+    if (Array.isArray(payload)) {
+      return payload
+        .map(entry => {
+          if (typeof entry === 'string') {
+            return buildLabelOption(entry);
+          }
+          return buildLabelOption(entry?.label || entry?.value || entry?.name || stripSimpleHtml(entry?.html || entry?.displayName || ''), {
+            metaText: stripSimpleHtml(entry?.html || entry?.displayName || '')
+          });
+        })
+        .filter(option => option.id);
+    }
     if (Array.isArray(payload?.results)) {
       return payload.results
         .map(entry => buildLabelOption(entry?.value || stripSimpleHtml(entry?.displayName || ''), {
@@ -1731,26 +1747,15 @@ async function mainAsyncLocal() {
 
   async function fetchLabelSuggestions(queryText) {
     const normalizedQuery = String(queryText || '').trim();
-    const endpoints = [
-      `${INSTANCE_URL}rest/api/2/jql/autocompletedata/suggestions?fieldName=labels&fieldValue=${encodeURIComponent(normalizedQuery)}`,
-      `${INSTANCE_URL}rest/api/1.0/labels/suggest?query=${encodeURIComponent(normalizedQuery)}`
-    ];
-    let lastError;
-    for (const url of endpoints) {
-      try {
-        const response = await get(url);
-        return normalizeLabelSuggestionPayload(response);
-      } catch (error) {
-        lastError = error;
-      }
-    }
-    throw lastError || new Error('Could not load label suggestions');
+    const response = await get(`${INSTANCE_URL}rest/api/2/jql/autocompletedata/suggestions?fieldName=labels&fieldValue=${encodeURIComponent(normalizedQuery)}`);
+    return normalizeLabelSuggestionPayload(response);
   }
 
   async function getLabelSuggestions(queryText = '') {
-    const normalizedQuery = String(queryText || '').trim().toLowerCase();
-    return getCachedValue(labelSuggestionCache, normalizedQuery, async () => {
-      return fetchLabelSuggestions(normalizedQuery);
+    const rawQuery = String(queryText || '').trim();
+    const cacheKey = rawQuery.toLowerCase();
+    return getCachedValue(labelSuggestionCache, cacheKey, async () => {
+      return fetchLabelSuggestions(rawQuery);
     });
   }
 
@@ -1819,6 +1824,23 @@ async function mainAsyncLocal() {
       return {key: rawValue.key};
     }
     return rawValue;
+  }
+
+  function normalizeIssueTypeOptions(allowedIssueTypes, currentIssueType) {
+    const currentIsSubtask = currentIssueType?.subtask === true;
+    return (Array.isArray(allowedIssueTypes) ? allowedIssueTypes : [])
+      .filter(issueType => issueType?.id && issueType?.name)
+      .filter(issueType => {
+        if (typeof issueType?.subtask !== 'boolean' || typeof currentIssueType?.subtask !== 'boolean') {
+          return true;
+        }
+        return issueType.subtask === currentIsSubtask;
+      })
+      .map(issueType => buildEditOption(issueType.id, issueType.name, {
+        iconUrl: issueType.iconUrl || '',
+        metaText: issueType.description || '',
+        rawValue: issueType
+      }));
   }
 
   async function getSupportedCustomFieldDefinition(fieldId, issueData) {
@@ -2712,6 +2734,51 @@ async function mainAsyncLocal() {
       };
     }
 
+    if (fieldKey === 'issuetype') {
+      const capability = await getEditableFieldCapability(issueData, 'issuetype');
+      const currentIssueType = issueData?.fields?.issuetype;
+      const issueTypeOptions = normalizeIssueTypeOptions(capability.allowedValues || [], currentIssueType);
+      const currentOption = currentIssueType?.id && currentIssueType?.name
+        ? buildEditOption(currentIssueType.id, currentIssueType.name, {
+            iconUrl: currentIssueType.iconUrl || '',
+            metaText: currentIssueType.description || '',
+            rawValue: currentIssueType
+          })
+        : null;
+      const allOptions = mergeEditOptions(currentOption ? [currentOption] : [], issueTypeOptions);
+      if (!capability.editable || allOptions.length < 2) {
+        return null;
+      }
+      return {
+        fieldKey,
+        editorType: 'single-select',
+        label: 'Issue type',
+        selectionMode: 'single',
+        currentText: currentIssueType?.name || '',
+        currentOptionId: currentOption?.id || null,
+        currentSelections: currentOption ? [currentOption] : [],
+        initialInputValue: '',
+        loadOptions: async () => allOptions,
+        save: selectedOptions => {
+          const selectedIssueType = selectedOptions[0];
+          if (!selectedIssueType?.id) {
+            throw new Error('Pick an issue type before saving');
+          }
+          return requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
+            fields: {
+              issuetype: {id: selectedIssueType.id}
+            }
+          });
+        },
+        successMessage: selectedOptions => {
+          const selectedIssueType = selectedOptions[0];
+          return selectedIssueType?.label
+            ? `Issue type set to ${selectedIssueType.label}`
+            : 'Issue type updated';
+        }
+      };
+    }
+
     if (fieldKey === 'status') {
       const transitions = await getTransitionOptions(issueData?.key);
       if (!transitions.length) {
@@ -2896,11 +2963,19 @@ async function mainAsyncLocal() {
         inputPlaceholder: 'Search existing labels',
         loadOptions: async () => {
           const baselineSuggestions = await getLabelSuggestions('').catch(() => []);
-          return mergeEditOptions(currentSelections, baselineSuggestions);
+          const mergedOptions = mergeEditOptions(currentSelections, baselineSuggestions);
+          labelLocalOptionsCache.set(issueData.key, mergedOptions);
+          return mergedOptions;
         },
         searchOptions: async query => {
-          const searchedOptions = await getLabelSuggestions(query);
-          return mergeEditOptions(currentSelections, mergeEditOptions(searchedOptions, popupState?.editState?.options || []));
+          const normalizedQuery = String(query || '').trim();
+          const localBaselineOptions = labelLocalOptionsCache.get(issueData.key) || [];
+          const searchedOptions = await getLabelSuggestions(normalizedQuery);
+          const mergedOptions = normalizedQuery
+            ? searchedOptions
+            : mergeEditOptions(currentSelections, mergeEditOptions(searchedOptions, mergeEditOptions(localBaselineOptions, popupState?.editState?.options || [])));
+          labelLocalOptionsCache.set(issueData.key, mergedOptions);
+          return mergedOptions;
         },
         save: selectedOptions => {
           const nextLabels = selectedOptions.map(option => option.id).filter(Boolean);
@@ -3352,7 +3427,8 @@ async function mainAsyncLocal() {
     const statusName = issueData.fields.status?.name;
     const priorityName = issueData.fields.priority?.name;
     const projectKey = key.split('-')[0];
-    const [priorityCapability, assigneeCapability, transitionOptions, sprintCapability, affectsCapability, fixVersionsCapability, labelsCapability, labelSuggestionSupport, customFieldChips] = await Promise.all([
+    const [issueTypeCapability, priorityCapability, assigneeCapability, transitionOptions, sprintCapability, affectsCapability, fixVersionsCapability, labelsCapability, labelSuggestionSupport, customFieldChips] = await Promise.all([
+      displayFields.issueType ? getEditableFieldCapability(issueData, 'issuetype') : Promise.resolve({editable: false, allowedValues: []}),
       displayFields.priority ? getEditableFieldCapability(issueData, 'priority') : Promise.resolve({editable: false}),
       displayFields.assignee ? getEditableFieldCapability(issueData, 'assignee') : Promise.resolve({editable: false}),
       displayFields.status ? getTransitionOptions(issueData.key).catch(() => []) : Promise.resolve([]),
@@ -3364,16 +3440,20 @@ async function mainAsyncLocal() {
       buildCustomFieldChips(issueData, customFields, state)
     ]);
     const statusEditable = Array.isArray(transitionOptions) && transitionOptions.length > 0;
+    const issueTypeEditable = !!issueTypeCapability?.editable && normalizeIssueTypeOptions(issueTypeCapability.allowedValues || [], issueData.fields.issuetype).length > 1;
     const priorityEditable = !!priorityCapability?.editable;
     const assigneeEditable = !!assigneeCapability?.editable;
     const labelsEditable = !!labelsCapability?.editable && !!labelSuggestionSupport;
 
     const row1Chips = [
-      displayFields.issueType ? buildFilterChip(
+      displayFields.issueType ? buildEditableFieldChip('issuetype', buildFilterChip(
         issueTypeName || 'No type',
         issueTypeName ? `${scopeJqlToProject(projectKey, `issuetype = ${encodeJqlValue(issueTypeName)}`)}` : '',
         {iconUrl: issueData.fields.issuetype?.iconUrl || ''}
-      ) : null,
+      ), state, {
+        canEdit: issueTypeEditable,
+        editTitle: 'Edit issue type'
+      }) : null,
       displayFields.status ? buildEditableFieldChip('status', buildFilterChip(
         statusName || 'No status',
         statusName ? `${scopeJqlToProject(projectKey, `status = ${encodeJqlValue(statusName)}`)}` : '',
@@ -3645,6 +3725,7 @@ async function mainAsyncLocal() {
     editMetaCache.delete(popupState.key);
     transitionOptionsCache.delete(popupState.key);
     assigneeLocalOptionsCache.delete(popupState.key);
+    labelLocalOptionsCache.delete(popupState.key);
     issueSearchCache.clear();
     [...assigneeSearchCache.keys()].forEach(cacheKey => {
       if (String(cacheKey).startsWith(`${popupState.key}__`)) {
@@ -3738,7 +3819,7 @@ async function mainAsyncLocal() {
       await renderIssuePopup(popupState);
     }
   }
-  const triggerSearchOptionsForActiveEdit = debounce(async (fieldKey, queryText, requestId) => {
+  async function runSearchOptionsForActiveEdit(fieldKey, queryText, requestId) {
     if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey) {
       return;
     }
@@ -3751,7 +3832,7 @@ async function mainAsyncLocal() {
       if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey || popupState.editState.searchRequestId !== requestId) {
         return;
       }
-      const mergedOptions = popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search' || popupState.editState.editorType === 'label-search'
+      const mergedOptions = popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search'
         ? mergeEditOptions(options, popupState.editState.options)
         : options;
       popupState = {
@@ -3778,7 +3859,21 @@ async function mainAsyncLocal() {
       };
       await renderIssuePopup(popupState);
     }
+  }
+
+  const triggerSearchOptionsForActiveEdit = debounce((fieldKey, queryText, requestId) => {
+    runSearchOptionsForActiveEdit(fieldKey, queryText, requestId).catch(() => {});
   }, 220);
+
+  function scheduleLabelSearchOptionsForActiveEdit(fieldKey, queryText, requestId) {
+    if (labelSearchTimeoutId) {
+      clearTimeout(labelSearchTimeoutId);
+    }
+    labelSearchTimeoutId = setTimeout(() => {
+      labelSearchTimeoutId = null;
+      runSearchOptionsForActiveEdit(fieldKey, queryText, requestId).catch(() => {});
+    }, 180);
+  }
   async function startFieldEdit(fieldKey) {
     if (!popupState?.issueData) {
       return;
@@ -3912,6 +4007,20 @@ async function mainAsyncLocal() {
         })
       };
       renderIssuePopup(popupState).catch(() => {});
+
+      if (popupState.editState.editorType === 'label-search') {
+        const searchRequestId = ++editSearchRequestCounter;
+        popupState = {
+          ...popupState,
+          editState: {
+            ...popupState.editState,
+            loadingOptions: true,
+            searchRequestId
+          }
+        };
+        renderIssuePopup(popupState).catch(() => {});
+        scheduleLabelSearchOptionsForActiveEdit(popupState.editState.fieldKey, normalizedValue, searchRequestId);
+      }
       return;
     }
     const exactOption = (popupState.editState.options || []).find(option => {
@@ -3968,7 +4077,11 @@ async function mainAsyncLocal() {
         }
       };
       renderIssuePopup(popupState).catch(() => {});
-      triggerSearchOptionsForActiveEdit(popupState.editState.fieldKey, normalizedValue, searchRequestId);
+      if (popupState.editState.editorType === 'label-search') {
+        scheduleLabelSearchOptionsForActiveEdit(popupState.editState.fieldKey, normalizedValue, searchRequestId);
+      } else {
+        triggerSearchOptionsForActiveEdit(popupState.editState.fieldKey, normalizedValue, searchRequestId);
+      }
     }
   }
 

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -673,23 +673,21 @@ async function mainAsyncLocal() {
     }
     if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
       const textValue = String(entry);
-      const looksLikeUrl = /^https?:\/\//i.test(textValue);
       return {
-        text: looksLikeUrl ? (fieldName || textValue) : (fieldName ? `${fieldName}: ${textValue}` : textValue),
-        url: looksLikeUrl ? textValue : ''
+        text: fieldName ? `${fieldName}: ${textValue}` : textValue,
+        linkUrl: ''
       };
     }
     const primaryText = entry.name || entry.value || entry.displayName || entry.id || entry.key;
-    const rawUrl = [entry.self, entry.url, entry.href].find(value => typeof value === 'string' && value.trim());
-    if (!primaryText && !rawUrl) {
+    if (!primaryText) {
       return null;
     }
     const formattedValue = entry.key && (entry.name || entry.value)
       ? `[${entry.key}] ${entry.name || entry.value}`
-      : primaryText ? String(primaryText) : rawUrl;
+      : String(primaryText);
     return {
       text: fieldName ? `${fieldName}: ${formattedValue}` : formattedValue,
-      url: rawUrl ? toAbsoluteJiraUrl(rawUrl) : ''
+      linkUrl: ''
     };
   }
   function buildCustomFieldChips(issueData, customFields) {
@@ -775,6 +773,21 @@ async function mainAsyncLocal() {
 
   function buildJqlUrl(jql) {
     return `${INSTANCE_URL}issues/?jql=${encodeURIComponent(jql)}`;
+  }
+
+  function scopeJqlToProject(projectKey, clause) {
+    if (!projectKey || !clause) {
+      return clause || '';
+    }
+    return `project = ${encodeJqlValue(projectKey)} AND ${clause}`;
+  }
+
+  function buildFilterChip(text, jql, extra = {}) {
+    return {
+      text,
+      linkUrl: jql ? buildJqlUrl(jql) : '',
+      ...extra
+    };
   }
 
   function buildAttachmentChips(attachments) {
@@ -1131,39 +1144,57 @@ async function mainAsyncLocal() {
           const issueTypeName = issueData.fields.issuetype?.name;
           const statusName = issueData.fields.status?.name;
           const priorityName = issueData.fields.priority?.name;
+          const projectKey = key.split('-')[0];
 
           const row1Chips = [
-            displayFields.issueType ? {
-              text: issueTypeName || 'No type',
-              iconUrl: issueData.fields.issuetype?.iconUrl || ''
-            } : null,
-            displayFields.status ? {
-              text: statusName || 'No status',
-              iconUrl: issueData.fields.status?.iconUrl || ''
-            } : null,
-            displayFields.priority ? {
-              text: priorityName || 'No priority',
-              iconUrl: issueData.fields.priority?.iconUrl || ''
-            } : null,
+            displayFields.issueType ? buildFilterChip(
+              issueTypeName || 'No type',
+              issueTypeName ? `${scopeJqlToProject(projectKey, `issuetype = ${encodeJqlValue(issueTypeName)}`)}` : '',
+              {iconUrl: issueData.fields.issuetype?.iconUrl || ''}
+            ) : null,
+            displayFields.status ? buildFilterChip(
+              statusName || 'No status',
+              statusName ? `${scopeJqlToProject(projectKey, `status = ${encodeJqlValue(statusName)}`)}` : '',
+              {iconUrl: issueData.fields.status?.iconUrl || ''}
+            ) : null,
+            displayFields.priority ? buildFilterChip(
+              priorityName || 'No priority',
+              priorityName ? `${scopeJqlToProject(projectKey, `priority = ${encodeJqlValue(priorityName)}`)}` : '',
+              {iconUrl: issueData.fields.priority?.iconUrl || ''}
+            ) : null,
             displayFields.epicParent ? {
               text: epicOrParent
                 ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
-                : 'Parent: --'
+                : 'Parent: --',
+              linkUrl: epicOrParent?.url || ''
             } : null,
             ...customFieldChips[1]
           ].filter(Boolean);
 
+          const singleAffectsVersion = affectsVersions.length === 1 ? affectsVersions[0]?.name : '';
+          const singleFixVersion = fixVersions.length === 1 ? fixVersions[0]?.name : '';
           const row2Chips = [
-            displayFields.sprint ? {text: `Sprint: ${formatSprintText(sprints) || '--'}`} : null,
-            displayFields.affects ? {
-              text: `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`
-            } : null,
-            displayFields.fixVersions ? {text: `Fix version: ${formatFixVersionText(fixVersions) || '--'}`} : null,
+            displayFields.sprint ? buildFilterChip(
+              `Sprint: ${formatSprintText(sprints) || '--'}`,
+              ''
+            ) : null,
+            displayFields.affects ? buildFilterChip(
+              `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`,
+              singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
+            ) : null,
+            displayFields.fixVersions ? buildFilterChip(
+              `Fix version: ${formatFixVersionText(fixVersions) || '--'}`,
+              singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
+            ) : null,
             ...customFieldChips[2]
           ].filter(Boolean);
 
+          const singleLabel = labels.length === 1 ? labels[0] : '';
           const row3Chips = [
-            displayFields.labels ? {text: `Labels: ${labels.filter(Boolean).join(', ') || '--'}`} : null,
+            displayFields.labels ? buildFilterChip(
+              `Labels: ${labels.filter(Boolean).join(', ') || '--'}`,
+              singleLabel ? `${scopeJqlToProject(projectKey, `labels = ${encodeJqlValue(singleLabel)}`)}` : ''
+            ) : null,
             ...customFieldChips[3]
           ].filter(Boolean);
 
@@ -1225,6 +1256,7 @@ async function mainAsyncLocal() {
               return {
                 id: pr.id,
                 url: pr.url,
+                linkUrl: pr.url,
                 title: formatPullRequestTitle(pr),
                 status: pr.status,
                 authorName: formatPullRequestAuthor(pr),

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -208,8 +208,19 @@ async function mainAsyncLocal() {
   const cacheTtlMs = 60 * 1000;
   const issueCache = new Map();
   const pullRequestCache = new Map();
+  const emptyCommentMentionState = () => ({
+    error: '',
+    loading: false,
+    query: '',
+    range: null,
+    selectedIndex: 0,
+    suggestions: [],
+    visible: false
+  });
   let currentUserPromise;
   let activeCommentContext = null;
+  let commentMentionState = emptyCommentMentionState();
+  let commentMentionRequestId = 0;
 
   function toAbsoluteJiraUrl(url) {
     if (!url) {
@@ -290,13 +301,30 @@ async function mainAsyncLocal() {
     return node.innerHTML;
   }
 
+  function getMentionDisplayText(rawValue) {
+    const normalized = String(rawValue || '')
+      .trim()
+      .replace(/^accountid:/i, '');
+    return normalized ? `@${normalized}` : '@mention';
+  }
+
   function textToLinkedHtml(input) {
-    const escaped = escapeHtml(input || '');
+    const mentionHtml = [];
+    const inputWithMentions = String(input || '').replace(/\[~([^[\]\r\n]+?)\]/g, function (match, mentionValue) {
+      const placeholderIndex = mentionHtml.length;
+      mentionHtml.push(`<span class="_JX_mention">${escapeHtml(getMentionDisplayText(mentionValue))}</span>`);
+      return `__JX_COMMENT_MENTION_${placeholderIndex}__`;
+    });
+    const escaped = escapeHtml(inputWithMentions);
     const withLinks = escaped.replace(
       /(https?:\/\/[^\s<]+)/g,
       '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
     );
-    return withLinks.replace(/\n/g, '<br/>');
+    return withLinks
+      .replace(/__JX_COMMENT_MENTION_(\d+)__/g, function (match, index) {
+        return mentionHtml[Number(index)] || '';
+      })
+      .replace(/\n/g, '<br/>');
   }
 
   function formatRelativeDate(created) {
@@ -461,14 +489,227 @@ async function mainAsyncLocal() {
     return currentUserPromise;
   }
 
+  function getCommentMentionMarkup(candidate) {
+    const username = candidate?.name || candidate?.username || '';
+    if (username) {
+      return `[~${username}]`;
+    }
+    const accountId = candidate?.accountId || '';
+    if (accountId) {
+      return `[~accountid:${accountId}]`;
+    }
+    return '';
+  }
+
+  async function searchCommentMentionCandidates(query) {
+    const response = await get(`${INSTANCE_URL}rest/api/2/user/picker?query=${encodeURIComponent(query)}`);
+    const rawCandidates = Array.isArray(response)
+      ? response
+      : response?.users || response?.items || [];
+    const seen = new Set();
+    return rawCandidates
+      .map(candidate => {
+        const mentionMarkup = getCommentMentionMarkup(candidate);
+        if (!mentionMarkup || seen.has(mentionMarkup)) {
+          return null;
+        }
+        seen.add(mentionMarkup);
+        const displayName = candidate?.displayName || candidate?.name || candidate?.username || candidate?.emailAddress || 'Unknown user';
+        const username = candidate?.name || candidate?.username || '';
+        const secondaryText = (username && username !== displayName)
+          ? `@${username}`
+          : ((candidate?.emailAddress && candidate.emailAddress !== displayName) ? candidate.emailAddress : '');
+        return {
+          displayName,
+          mentionMarkup,
+          secondaryText
+        };
+      })
+      .filter(Boolean)
+      .slice(0, 6);
+  }
+
   function getCommentComposerElements() {
     return {
       root: container.find('._JX_comment_compose'),
       input: container.find('._JX_comment_input'),
+      mentions: container.find('._JX_comment_mentions'),
       save: container.find('._JX_comment_save'),
       discard: container.find('._JX_comment_discard'),
       error: container.find('._JX_comment_error')
     };
+  }
+
+  function renderCommentMentionSuggestions() {
+    const {mentions} = getCommentComposerElements();
+    if (!mentions.length) {
+      return;
+    }
+
+    if (!commentMentionState.visible) {
+      mentions.attr('hidden', 'hidden').empty();
+      return;
+    }
+
+    if (commentMentionState.loading) {
+      mentions.removeAttr('hidden').html('<div class="_JX_comment_mentions_status">Searching people...</div>');
+      return;
+    }
+
+    if (commentMentionState.error) {
+      mentions.removeAttr('hidden').html(`<div class="_JX_comment_mentions_status">${escapeHtml(commentMentionState.error)}</div>`);
+      return;
+    }
+
+    if (!commentMentionState.suggestions.length) {
+      mentions.removeAttr('hidden').html('<div class="_JX_comment_mentions_status">No people found.</div>');
+      return;
+    }
+
+    mentions.removeAttr('hidden').html(commentMentionState.suggestions.map(function (candidate, index) {
+      const selectedClass = index === commentMentionState.selectedIndex ? ' is-selected' : '';
+      const secondary = candidate.secondaryText
+        ? `<span class="_JX_comment_mention_secondary">${escapeHtml(candidate.secondaryText)}</span>`
+        : '';
+      return `
+        <button class="_JX_comment_mention_option${selectedClass}" type="button" data-mention-index="${index}">
+          <span>
+            <span class="_JX_comment_mention_primary">${escapeHtml(candidate.displayName)}</span>
+            ${secondary}
+          </span>
+        </button>
+      `;
+    }).join(''));
+  }
+
+  function resetCommentMentionState() {
+    commentMentionRequestId += 1;
+    debouncedLoadCommentMentionSuggestions.cancel();
+    commentMentionState = emptyCommentMentionState();
+    renderCommentMentionSuggestions();
+  }
+
+  function getActiveCommentMention(inputElement) {
+    if (!inputElement) {
+      return null;
+    }
+
+    const value = inputElement.value || '';
+    const caretStart = typeof inputElement.selectionStart === 'number' ? inputElement.selectionStart : value.length;
+    const caretEnd = typeof inputElement.selectionEnd === 'number' ? inputElement.selectionEnd : caretStart;
+    if (caretStart !== caretEnd) {
+      return null;
+    }
+
+    const beforeCaret = value.slice(0, caretStart);
+    const mentionMatch = beforeCaret.match(/(^|[\s(])@([^\s@]{1,50})$/);
+    if (!mentionMatch) {
+      return null;
+    }
+
+    let end = caretEnd;
+    while (end < value.length && !/\s/.test(value.charAt(end))) {
+      end += 1;
+    }
+
+    return {
+      end,
+      query: mentionMatch[2],
+      start: caretStart - mentionMatch[2].length - 1
+    };
+  }
+
+  async function loadCommentMentionSuggestions(mention) {
+    const requestId = ++commentMentionRequestId;
+    try {
+      const suggestions = await searchCommentMentionCandidates(mention.query);
+      if (requestId !== commentMentionRequestId) {
+        return;
+      }
+
+      commentMentionState = {
+        error: '',
+        loading: false,
+        query: mention.query,
+        range: mention,
+        selectedIndex: 0,
+        suggestions,
+        visible: true
+      };
+    } catch (error) {
+      if (requestId !== commentMentionRequestId) {
+        return;
+      }
+
+      commentMentionState = {
+        error: 'Could not load people.',
+        loading: false,
+        query: mention.query,
+        range: mention,
+        selectedIndex: 0,
+        suggestions: [],
+        visible: true
+      };
+    }
+
+    renderCommentMentionSuggestions();
+  }
+
+  const debouncedLoadCommentMentionSuggestions = debounce(function (mention) {
+    loadCommentMentionSuggestions(mention).catch(() => {});
+  }, 150);
+
+  function syncCommentMentionSuggestions(inputElement) {
+    const mention = getActiveCommentMention(inputElement);
+    if (!mention) {
+      resetCommentMentionState();
+      return;
+    }
+
+    commentMentionState = {
+      error: '',
+      loading: true,
+      query: mention.query,
+      range: mention,
+      selectedIndex: 0,
+      suggestions: [],
+      visible: true
+    };
+    renderCommentMentionSuggestions();
+    debouncedLoadCommentMentionSuggestions(mention);
+  }
+
+  function moveCommentMentionSelection(delta) {
+    if (!commentMentionState.visible || !commentMentionState.suggestions.length) {
+      return;
+    }
+    const suggestionsTotal = commentMentionState.suggestions.length;
+    const nextIndex = (commentMentionState.selectedIndex + delta + suggestionsTotal) % suggestionsTotal;
+    commentMentionState = {
+      ...commentMentionState,
+      selectedIndex: nextIndex
+    };
+    renderCommentMentionSuggestions();
+  }
+
+  function applyCommentMentionSelection(index) {
+    const {input} = getCommentComposerElements();
+    const inputElement = input.get(0);
+    const candidate = commentMentionState.suggestions[index];
+    const mentionRange = commentMentionState.range;
+    if (!inputElement || !candidate || !mentionRange) {
+      return;
+    }
+
+    const nextValue = inputElement.value.slice(0, mentionRange.start) +
+      `${candidate.mentionMarkup} ` +
+      inputElement.value.slice(mentionRange.end);
+    input.val(nextValue);
+    inputElement.focus();
+    const caretPosition = mentionRange.start + candidate.mentionMarkup.length + 1;
+    inputElement.setSelectionRange(caretPosition, caretPosition);
+    resetCommentMentionState();
+    syncCommentComposerState();
   }
 
   function syncCommentComposerState() {
@@ -536,6 +777,7 @@ async function mainAsyncLocal() {
       return;
     }
 
+    resetCommentMentionState();
     const elements = getCommentComposerElements();
     const commentText = elements.input.val().trim();
     if (!commentText) {
@@ -568,6 +810,7 @@ async function mainAsyncLocal() {
     if (!elements.root.length || elements.root.attr('data-saving') === 'true') {
       return;
     }
+    resetCommentMentionState();
     elements.input.val('');
     setCommentComposerError('');
     syncCommentComposerState();
@@ -1139,6 +1382,63 @@ async function mainAsyncLocal() {
 
   $(document.body).on('input', '._JX_comment_input', function () {
     syncCommentComposerState();
+    syncCommentMentionSuggestions(this);
+  });
+
+  $(document.body).on('click', '._JX_comment_input', function () {
+    syncCommentMentionSuggestions(this);
+  });
+
+  $(document.body).on('keyup', '._JX_comment_input', function (e) {
+    if (['ArrowUp', 'ArrowDown', 'Enter', 'Tab', 'Escape'].indexOf(e.key) !== -1) {
+      return;
+    }
+    syncCommentMentionSuggestions(this);
+  });
+
+  $(document.body).on('keydown', '._JX_comment_input', function (e) {
+    if (e.key === 'Escape' && commentMentionState.visible) {
+      e.preventDefault();
+      resetCommentMentionState();
+      return;
+    }
+
+    if (!commentMentionState.visible || !commentMentionState.suggestions.length) {
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      moveCommentMentionSelection(1);
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      moveCommentMentionSelection(-1);
+      return;
+    }
+
+    if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault();
+      applyCommentMentionSelection(commentMentionState.selectedIndex);
+    }
+  });
+
+  $(document.body).on('click', '._JX_comment_mention_option', function (e) {
+    e.preventDefault();
+    const index = Number(e.currentTarget.getAttribute('data-mention-index'));
+    if (Number.isNaN(index)) {
+      return;
+    }
+    applyCommentMentionSelection(index);
+  });
+
+  $(document.body).on('mousedown', function (e) {
+    if ($(e.target).closest('._JX_comment_compose').length) {
+      return;
+    }
+    resetCommentMentionState();
   });
 
   $(document.body).on('click', '._JX_comment_save', function (e) {
@@ -1190,6 +1490,7 @@ async function mainAsyncLocal() {
   function hideContainer() {
     lastHoveredKey = '';
     activeCommentContext = null;
+    resetCommentMentionState();
     containerPinned = false;
     container.css({
       left: -5000,
@@ -1457,4 +1758,6 @@ if (!window.__JX__script_injected__) {
 }
 
 window.__JX__script_injected__ = true;
+
+
 

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -1780,7 +1780,7 @@ async function mainAsyncLocal() {
     if (!sprint) {
       return '';
     }
-    return sprint.state ? `${sprint.name} (${sprint.state})` : sprint.name;
+    return sprint.state ? `${sprint.name} (${String(sprint.state).toUpperCase()})` : sprint.name;
   }
 
   function normalizeFixVersionSortName(name) {
@@ -1794,27 +1794,80 @@ async function mainAsyncLocal() {
     });
   }
 
-  async function getProjectVersionOptions(issueData, cacheKey, emptyLabel) {
+  function normalizeMultiSelectOptionIds(optionIds) {
+    return [...new Set((Array.isArray(optionIds) ? optionIds : [])
+      .map(optionId => String(optionId || '').trim())
+      .filter(Boolean))];
+  }
+
+  function areSameOptionIds(left, right) {
+    const leftIds = normalizeMultiSelectOptionIds(left).sort();
+    const rightIds = normalizeMultiSelectOptionIds(right).sort();
+    if (leftIds.length !== rightIds.length) {
+      return false;
+    }
+    return leftIds.every((optionId, index) => optionId === rightIds[index]);
+  }
+
+  function resolveMultiSelectOptions(optionIds, options, fallbackOptions = []) {
+    const optionMap = new Map();
+    (Array.isArray(fallbackOptions) ? fallbackOptions : []).forEach(option => {
+      const optionId = String(option?.id || '').trim();
+      if (optionId) {
+        optionMap.set(optionId, option);
+      }
+    });
+    (Array.isArray(options) ? options : []).forEach(option => {
+      const optionId = String(option?.id || '').trim();
+      if (optionId) {
+        optionMap.set(optionId, option);
+      }
+    });
+    return normalizeMultiSelectOptionIds(optionIds)
+      .map(optionId => optionMap.get(optionId))
+      .filter(Boolean);
+  }
+
+  function buildNextMultiSelectState(editState, changes = {}) {
+    const selectedOptionIds = normalizeMultiSelectOptionIds(changes.selectedOptionIds ?? editState.selectedOptionIds);
+    const originalOptionIds = normalizeMultiSelectOptionIds(changes.originalOptionIds ?? editState.originalOptionIds);
+    const options = changes.options ?? editState.options;
+    const selectedOptions = resolveMultiSelectOptions(
+      selectedOptionIds,
+      options,
+      changes.selectedOptions ?? editState.selectedOptions
+    );
+    return {
+      ...editState,
+      ...changes,
+      options,
+      selectedOptionIds,
+      selectedOptions,
+      originalOptionIds,
+      hasChanges: !areSameOptionIds(selectedOptionIds, originalOptionIds)
+    };
+  }
+
+  async function getProjectVersionOptions(issueData, cacheKey) {
     const projectKey = String(issueData?.key || '').split('-')[0];
     if (!projectKey) {
       return [];
     }
     return getCachedValue(fieldOptionsCache, `${cacheKey}__${projectKey}`, async () => {
       const versions = await get(`${INSTANCE_URL}rest/api/2/project/${encodeURIComponent(projectKey)}/versions`);
-      const options = (Array.isArray(versions) ? versions : [])
+      return (Array.isArray(versions) ? versions : [])
         .filter(version => version?.name && !version?.archived)
         .sort(compareFixVersionOptions)
         .map(version => buildEditOption(version.id, version.name, {rawValue: version}));
-      return [buildEditOption('', emptyLabel), ...options];
     });
   }
 
   async function getFixVersionOptions(issueData) {
-    return getProjectVersionOptions(issueData, 'fixVersions', 'No fix version');
+    return getProjectVersionOptions(issueData, 'fixVersions');
   }
 
   async function getAffectsVersionOptions(issueData) {
-    return getProjectVersionOptions(issueData, 'versions', 'No affects version');
+    return getProjectVersionOptions(issueData, 'versions');
   }
 
   async function getCandidateSprintBoards(issueData) {
@@ -1922,17 +1975,21 @@ async function mainAsyncLocal() {
       return {
         fieldKey,
         label: 'Affects version',
+        selectionMode: 'multi',
         currentText: formatVersionText(currentVersions),
-        currentOptionId: currentVersions.length === 1 ? String(currentVersions[0]?.id || '') : null,
+        currentSelections: currentVersions
+          .filter(version => version?.id && version?.name)
+          .map(version => buildEditOption(version.id, version.name, {rawValue: version})),
+        initialInputValue: '',
         loadOptions: () => getAffectsVersionOptions(issueData),
-        save: option => {
+        save: selectedOptions => {
           return requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
             fields: {
-              versions: option.id ? [{id: option.id}] : []
+              versions: selectedOptions.map(option => ({id: option.id}))
             }
           });
         },
-        successMessage: option => option.id ? `Affects version set to ${option.label}` : 'Affects version cleared'
+        successMessage: selectedOptions => selectedOptions.length ? 'Affects versions updated' : 'Affects versions cleared'
       };
     }
 
@@ -1941,17 +1998,21 @@ async function mainAsyncLocal() {
       return {
         fieldKey,
         label: 'Fix version',
+        selectionMode: 'multi',
         currentText: formatVersionText(currentFixVersions),
-        currentOptionId: currentFixVersions.length === 1 ? String(currentFixVersions[0]?.id || '') : null,
+        currentSelections: currentFixVersions
+          .filter(version => version?.id && version?.name)
+          .map(version => buildEditOption(version.id, version.name, {rawValue: version})),
+        initialInputValue: '',
         loadOptions: () => getFixVersionOptions(issueData),
-        save: option => {
+        save: selectedOptions => {
           return requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
             fields: {
-              fixVersions: option.id ? [{id: option.id}] : []
+              fixVersions: selectedOptions.map(option => ({id: option.id}))
             }
           });
         },
-        successMessage: option => option.id ? `Fix version set to ${option.label}` : 'Fix version cleared'
+        successMessage: selectedOptions => selectedOptions.length ? 'Fix versions updated' : 'Fix versions cleared'
       };
     }
 
@@ -1960,10 +2021,16 @@ async function mainAsyncLocal() {
       return {
         fieldKey,
         label: 'Sprint',
+        selectionMode: 'single',
         currentText: formatSprintText(currentSprints),
         currentOptionId: currentSprints.length === 1 ? String(currentSprints[0]?.id || '') : null,
+        currentSelections: currentSprints.length === 1
+          ? [buildEditOption(currentSprints[0]?.id, formatSprintOptionLabel(currentSprints[0]), {rawValue: currentSprints[0]})]
+          : [],
+        initialInputValue: formatSprintText(currentSprints),
         loadOptions: () => getSprintOptions(issueData),
-        save: async option => {
+        save: async selectedOptions => {
+          const option = selectedOptions[0] || buildEditOption('', 'No sprint');
           const sprintFieldId = pickSprintFieldId(issueData, await getSprintFieldIds(INSTANCE_URL));
           if (!sprintFieldId) {
             throw new Error('Could not resolve the Sprint field');
@@ -1974,7 +2041,10 @@ async function mainAsyncLocal() {
             }
           });
         },
-        successMessage: option => option.id ? `Sprint set to ${option.label}` : 'Sprint cleared'
+        successMessage: selectedOptions => {
+          const option = selectedOptions[0] || buildEditOption('', 'No sprint');
+          return option.id ? `Sprint set to ${option.label}` : 'Sprint cleared';
+        }
       };
     }
 
@@ -1993,12 +2063,25 @@ async function mainAsyncLocal() {
   function buildEditableFieldChip(fieldKey, baseChip, state) {
     const editState = state?.editState;
     if (editState?.fieldKey === fieldKey) {
+      const isMultiSelect = editState.selectionMode === 'multi';
+      const selectedOptionIds = new Set(isMultiSelect
+        ? normalizeMultiSelectOptionIds(editState.selectedOptionIds)
+        : (editState.selectedOptionId === null || typeof editState.selectedOptionId === 'undefined'
+            ? []
+            : [String(editState.selectedOptionId)]));
       const options = filterEditOptions(editState.options, editState.inputValue).map(option => ({
         ...option,
         fieldKey,
-        isSelected: editState.selectedOptionId === option.id,
+        isSelected: selectedOptionIds.has(option.id),
+        isMultiSelect,
         title: option.label
       }));
+      const selectedValues = isMultiSelect
+        ? (editState.selectedOptions || []).map(option => ({
+            ...option,
+            title: option.label
+          }))
+        : [];
       return {
         ...baseChip,
         isEditable: true,
@@ -2007,7 +2090,7 @@ async function mainAsyncLocal() {
         fieldKey,
         editLabel: editState.label,
         inputValue: editState.inputValue,
-        inputPlaceholder: `Type to filter ${editState.label.toLowerCase()} values`,
+        inputPlaceholder: editState.inputPlaceholder || `Type to filter ${editState.label.toLowerCase()} values`,
         inputDisabled: !!(editState.loadingOptions || editState.saving),
         loadingText: editState.loadingOptions
           ? `Loading ${editState.label.toLowerCase()} values...`
@@ -2017,7 +2100,13 @@ async function mainAsyncLocal() {
         options,
         hasOptions: options.length > 0,
         editEmptyText: editState.loadingOptions ? 'Loading values...' : 'No matching values',
-        editError: editState.errorMessage || ''
+        editError: editState.errorMessage || '',
+        isMultiSelect,
+        showActionButtons: isMultiSelect,
+        showSelectedValues: isMultiSelect && selectedValues.length > 0,
+        selectedValues,
+        saveDisabled: !!(editState.loadingOptions || editState.saving || !editState.hasChanges),
+        discardDisabled: !!editState.saving
       };
     }
     return {
@@ -2321,35 +2410,19 @@ async function mainAsyncLocal() {
 
     const singleAffectsVersion = affectsVersions.length === 1 ? affectsVersions[0]?.name : '';
     const singleFixVersion = fixVersions.length === 1 ? fixVersions[0]?.name : '';
-    const canEditAffectsVersions = affectsVersions.length <= 1;
-    const canEditFixVersions = fixVersions.length <= 1;
     const row2Chips = [
       displayFields.sprint ? buildEditableFieldChip('sprint', buildFilterChip(
         `Sprint: ${formatSprintText(sprints) || '--'}`,
         ''
       ), state) : null,
-      displayFields.affects ? (
-        canEditAffectsVersions
-          ? buildEditableFieldChip('versions', buildFilterChip(
-            `Affects: ${formatVersionText(affectsVersions) || '--'}`,
-            singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
-          ), state)
-          : buildFilterChip(
-            `Affects: ${formatVersionText(affectsVersions) || '--'}`,
-            ''
-          )
-      ) : null,
-      displayFields.fixVersions ? (
-        canEditFixVersions
-          ? buildEditableFieldChip('fixVersions', buildFilterChip(
-            `Fix version: ${formatVersionText(fixVersions) || '--'}`,
-            singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
-          ), state)
-          : buildFilterChip(
-            `Fix version: ${formatVersionText(fixVersions) || '--'}`,
-            ''
-          )
-      ) : null,
+      displayFields.affects ? buildEditableFieldChip('versions', buildFilterChip(
+        `Affects: ${formatVersionText(affectsVersions) || '--'}`,
+        singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
+      ), state) : null,
+      displayFields.fixVersions ? buildEditableFieldChip('fixVersions', buildFilterChip(
+        `Fix version: ${formatVersionText(fixVersions) || '--'}`,
+        singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
+      ), state) : null,
       ...customFieldChips[2]
     ].filter(Boolean);
 
@@ -2647,15 +2720,23 @@ async function mainAsyncLocal() {
     if (!definition) {
       return;
     }
-    const initialValue = '';
+    const isMultiSelect = definition.selectionMode === 'multi';
+    const initialValue = definition.initialInputValue ?? definition.currentText ?? '';
+    const currentSelections = Array.isArray(definition.currentSelections) ? definition.currentSelections : [];
     popupState = {
       ...popupState,
       editState: {
         fieldKey,
         label: definition.label,
+        selectionMode: definition.selectionMode || 'single',
         inputValue: initialValue,
+        inputPlaceholder: `Type to filter ${definition.label.toLowerCase()} values`,
         options: [],
-        selectedOptionId: definition.currentOptionId,
+        selectedOptionId: isMultiSelect ? null : definition.currentOptionId,
+        selectedOptionIds: isMultiSelect ? normalizeMultiSelectOptionIds(currentSelections.map(option => option.id)) : [],
+        selectedOptions: isMultiSelect ? currentSelections : [],
+        originalOptionIds: isMultiSelect ? normalizeMultiSelectOptionIds(currentSelections.map(option => option.id)) : [],
+        hasChanges: false,
         loadingOptions: true,
         saving: false,
         errorMessage: '',
@@ -2670,19 +2751,29 @@ async function mainAsyncLocal() {
       if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey) {
         return;
       }
-      const selectedOption = (Array.isArray(options) ? options : []).find(option => option.id === popupState.editState.selectedOptionId);
-      const nextInputValue = '';
-      popupState = {
-        ...popupState,
-        editState: {
-          ...popupState.editState,
-          inputValue: nextInputValue,
-          options,
-          loadingOptions: false,
-          selectionStart: nextInputValue.length,
-          selectionEnd: nextInputValue.length
-        }
-      };
+      if (popupState.editState.selectionMode === 'multi') {
+        popupState = {
+          ...popupState,
+          editState: buildNextMultiSelectState(popupState.editState, {
+            options,
+            loadingOptions: false
+          })
+        };
+      } else {
+        const selectedOption = (Array.isArray(options) ? options : []).find(option => option.id === popupState.editState.selectedOptionId);
+        const nextInputValue = selectedOption ? selectedOption.label : popupState.editState.inputValue;
+        popupState = {
+          ...popupState,
+          editState: {
+            ...popupState.editState,
+            inputValue: nextInputValue,
+            options,
+            loadingOptions: false,
+            selectionStart: nextInputValue.length,
+            selectionEnd: nextInputValue.length
+          }
+        };
+      }
       await renderIssuePopup(popupState);
     } catch (error) {
       const errorMessage = buildEditFieldError(error);
@@ -2691,11 +2782,16 @@ async function mainAsyncLocal() {
       }
       popupState = {
         ...popupState,
-        editState: {
-          ...popupState.editState,
-          loadingOptions: false,
-          errorMessage
-        }
+        editState: popupState.editState.selectionMode === 'multi'
+          ? buildNextMultiSelectState(popupState.editState, {
+              loadingOptions: false,
+              errorMessage
+            })
+          : {
+              ...popupState.editState,
+              loadingOptions: false,
+              errorMessage
+            }
       };
       await renderIssuePopup(popupState);
       snackBar(errorMessage);
@@ -2718,6 +2814,19 @@ async function mainAsyncLocal() {
       return;
     }
     const normalizedValue = String(nextValue || '');
+    if (popupState.editState.selectionMode === 'multi') {
+      popupState = {
+        ...popupState,
+        editState: buildNextMultiSelectState(popupState.editState, {
+          inputValue: normalizedValue,
+          errorMessage: '',
+          selectionStart,
+          selectionEnd
+        })
+      };
+      renderIssuePopup(popupState).catch(() => {});
+      return;
+    }
     const exactOption = (popupState.editState.options || []).find(option => {
       return option.label.toLowerCase() === normalizedValue.trim().toLowerCase();
     });
@@ -2743,6 +2852,21 @@ async function mainAsyncLocal() {
     if (!option) {
       return;
     }
+    if (popupState.editState.selectionMode === 'multi') {
+      const selectedOptionIds = normalizeMultiSelectOptionIds(popupState.editState.selectedOptionIds);
+      const nextSelectedOptionIds = selectedOptionIds.includes(option.id)
+        ? selectedOptionIds.filter(candidateId => candidateId !== option.id)
+        : [...selectedOptionIds, option.id];
+      popupState = {
+        ...popupState,
+        editState: buildNextMultiSelectState(popupState.editState, {
+          selectedOptionIds: nextSelectedOptionIds,
+          errorMessage: ''
+        })
+      };
+      renderIssuePopup(popupState).catch(() => {});
+      return;
+    }
     popupState = {
       ...popupState,
       editState: {
@@ -2757,21 +2881,40 @@ async function mainAsyncLocal() {
     renderIssuePopup(popupState).catch(() => {});
   }
 
-  function resolveSelectedEditOption(editState) {
+  function resolveSelectedEditOptions(editState) {
     if (!editState) {
-      return null;
+      return [];
+    }
+    if (editState.selectionMode === 'multi') {
+      return Array.isArray(editState.selectedOptions) ? editState.selectedOptions : [];
     }
     if (editState.selectedOptionId !== null && typeof editState.selectedOptionId !== 'undefined') {
       const selectedOption = (editState.options || []).find(option => option.id === editState.selectedOptionId);
       if (selectedOption) {
-        return selectedOption;
+        return [selectedOption];
       }
     }
     const normalizedInput = String(editState.inputValue || '').trim().toLowerCase();
     if (!normalizedInput) {
-      return null;
+      return [];
     }
-    return (editState.options || []).find(option => option.label.toLowerCase() === normalizedInput) || null;
+    const exactOption = (editState.options || []).find(option => option.label.toLowerCase() === normalizedInput);
+    return exactOption ? [exactOption] : [];
+  }
+
+  function toggleMultiSelectOptionFromInput(fieldKey) {
+    if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey || popupState.editState.selectionMode !== 'multi') {
+      return;
+    }
+    const normalizedInput = String(popupState.editState.inputValue || '').trim().toLowerCase();
+    if (!normalizedInput) {
+      return;
+    }
+    const exactOption = (popupState.editState.options || []).find(option => option.label.toLowerCase() === normalizedInput);
+    if (!exactOption) {
+      return;
+    }
+    selectFieldEditOption(exactOption.id);
   }
 
   async function submitFieldEdit(fieldKey) {
@@ -2782,8 +2925,12 @@ async function mainAsyncLocal() {
     if (!definition) {
       return;
     }
-    const selectedOption = resolveSelectedEditOption(popupState.editState);
-    if (!selectedOption) {
+    const selectedOptions = resolveSelectedEditOptions(popupState.editState);
+    if (popupState.editState.selectionMode === 'multi') {
+      if (!popupState.editState.hasChanges) {
+        return;
+      }
+    } else if (!selectedOptions.length) {
       const errorMessage = 'Pick an existing value from the dropdown before pressing Enter';
       popupState = {
         ...popupState,
@@ -2799,17 +2946,22 @@ async function mainAsyncLocal() {
 
     popupState = {
       ...popupState,
-      editState: {
-        ...popupState.editState,
-        saving: true,
-        errorMessage: ''
-      }
+      editState: popupState.editState.selectionMode === 'multi'
+        ? buildNextMultiSelectState(popupState.editState, {
+            saving: true,
+            errorMessage: ''
+          })
+        : {
+            ...popupState.editState,
+            saving: true,
+            errorMessage: ''
+          }
     };
     await renderIssuePopup(popupState);
 
     try {
-      await definition.save(selectedOption);
-      await refreshPopupIssueState(definition.successMessage(selectedOption), {showSnackBar: true});
+      await definition.save(selectedOptions);
+      await refreshPopupIssueState(definition.successMessage(selectedOptions));
     } catch (error) {
       const errorMessage = buildEditFieldError(error);
       if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey) {
@@ -2817,11 +2969,16 @@ async function mainAsyncLocal() {
       }
       popupState = {
         ...popupState,
-        editState: {
-          ...popupState.editState,
-          saving: false,
-          errorMessage
-        }
+        editState: popupState.editState.selectionMode === 'multi'
+          ? buildNextMultiSelectState(popupState.editState, {
+              saving: false,
+              errorMessage
+            })
+          : {
+              ...popupState.editState,
+              saving: false,
+              errorMessage
+            }
       };
       await renderIssuePopup(popupState);
       snackBar(errorMessage);
@@ -2939,10 +3096,17 @@ async function mainAsyncLocal() {
     startFieldEdit(fieldKey).catch(() => {});
   });
 
-  $(document.body).on('click', '._JX_edit_cancel', function (e) {
+  $(document.body).on('click', '._JX_edit_cancel, ._JX_edit_discard', function (e) {
     e.preventDefault();
     e.stopPropagation();
     cancelFieldEdit();
+  });
+
+  $(document.body).on('click', '._JX_edit_save', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const fieldKey = e.currentTarget.getAttribute('data-field-key') || '';
+    submitFieldEdit(fieldKey).catch(() => {});
   });
 
   $(document.body).on('click', '._JX_edit_option', function (e) {
@@ -2959,9 +3123,18 @@ async function mainAsyncLocal() {
   $(document.body).on('keydown', '._JX_edit_input', function (e) {
     e.stopPropagation();
     const fieldKey = e.currentTarget.getAttribute('data-field-key') || '';
+    const editState = popupState?.editState;
     if (e.key === 'Enter') {
       e.preventDefault();
-      submitFieldEdit(fieldKey).catch(() => {});
+      if (editState?.fieldKey === fieldKey && editState.selectionMode === 'multi') {
+        if (e.ctrlKey || e.metaKey) {
+          submitFieldEdit(fieldKey).catch(() => {});
+        } else {
+          toggleMultiSelectOptionFromInput(fieldKey);
+        }
+      } else {
+        submitFieldEdit(fieldKey).catch(() => {});
+      }
       return;
     }
     if (e.key === 'Escape') {

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -69,6 +69,22 @@ function buildJiraKeyMatcher(projectKeys) {
   };
 }
 
+function buildFallbackJiraKeyMatcher() {
+  const jiraTicketRegex = /\b[A-Z][A-Z0-9]{1,14}[- ]\d+\b/g;
+
+  return function (text) {
+    let matches;
+    const result = [];
+    const input = text || '';
+
+    while ((matches = jiraTicketRegex.exec(input)) !== null) {
+      result.push(matches[0]);
+    }
+    jiraTicketRegex.lastIndex = 0;
+    return result;
+  };
+}
+
 chrome.runtime.onMessage.addListener(function (msg) {
   if (msg.action === 'message') {
     snackBar(msg.message);
@@ -76,6 +92,7 @@ chrome.runtime.onMessage.addListener(function (msg) {
 });
 
 let ui_tips_shown_local = [];
+const CONNECTION_ERROR_PATTERN = /(failed to fetch|networkerror|network request failed|load failed|err_|timed?\s*out)/i;
 
 async function showTip(tipName, tipMessage) {
   if (ui_tips_shown_local.indexOf(tipName) !== -1) {
@@ -116,6 +133,27 @@ async function getImageDataUrl(url) {
   }
 }
 
+function isJiraConnectionFailure(error) {
+  const message = String(error?.message || error?.inner || error || '');
+  return CONNECTION_ERROR_PATTERN.test(message);
+}
+
+function notifyJiraConnectionFailure(instanceUrl, error) {
+  if (!isJiraConnectionFailure(error)) {
+    return false;
+  }
+
+  let host = '';
+  try {
+    host = new URL(instanceUrl).hostname;
+  } catch (ex) {
+    host = '';
+  }
+
+  snackBar(`Could not reach Jira${host ? ` at ${host}` : ''}. Check your VPN or network connection.`, 1500);
+  return true;
+}
+
 async function mainAsyncLocal() {
   const $ = require('jquery');
   const draggable = require('jquery-ui/ui/widgets/draggable');
@@ -140,15 +178,21 @@ async function mainAsyncLocal() {
     pullRequests: true,
     ...(config.displayFields || {})
   };
-  const jiraProjects = await get(await getInstanceUrl() + 'rest/api/2/project');
-
-  if (!size(jiraProjects)) {
-    console.log('Couldn\'t find any jira projects...');
-    return;
+  let jiraProjects = [];
+  let getJiraKeys = buildFallbackJiraKeyMatcher();
+  try {
+    jiraProjects = await get(await getInstanceUrl() + 'rest/api/2/project');
+  } catch (ex) {
+    // Keep hover support alive offline; only notify on explicit hover fetch failures.
   }
-  const getJiraKeys = buildJiraKeyMatcher(jiraProjects.map(function (project) {
-    return project.key;
-  }));
+
+  if (size(jiraProjects)) {
+    getJiraKeys = buildJiraKeyMatcher(jiraProjects.map(function (project) {
+      return project.key;
+    }));
+  } else {
+    console.log("Couldn't load Jira projects, using fallback issue-key matcher.");
+  }
   const annotationTemplate = await fetch(chrome.runtime.getURL('resources/annotation.html')).then(response => response.text());
   const loaderGifUrl = chrome.runtime.getURL('resources/ajax-loader.gif');
   const imageProxyCache = {};
@@ -979,9 +1023,10 @@ async function mainAsyncLocal() {
             }),
             prs: [],
             description: displayFields.description ? normalizedDescription : '',
-            hasBodyContent: (displayFields.description && !!normalizedDescription) ||
-              (displayFields.attachments && previewAttachments.length > 0) ||
-              (displayFields.comments && commentsForDisplay.length > 0),
+            hasBodyContent: true,
+            emptyBodyText: (!normalizedDescription && previewAttachments.length === 0 && commentsForDisplay.length === 0)
+              ? 'No description, attachments or comments.'
+              : '',
             attachments,
             previewAttachments: displayFields.attachments ? previewAttachments : [],
             commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
@@ -1039,7 +1084,8 @@ async function mainAsyncLocal() {
           if (!containerPinned) {
             container.css(computeVisibleContainerPosition(pointerX, pointerY));
           }
-        })(cancelToken).catch(() => {
+        })(cancelToken).catch((error) => {
+          notifyJiraConnectionFailure(INSTANCE_URL, error);
           lastHoveredKey = '';
         });
       } else if (!containerPinned) {
@@ -1055,3 +1101,5 @@ if (!window.__JX__script_injected__) {
 }
 
 window.__JX__script_injected__ = true;
+
+

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -134,6 +134,16 @@ async function getImageDataUrl(url) {
   }
 }
 
+async function requestJson(method, url, body) {
+  const response = await sendMessage({action: 'requestJson', method, url, body});
+  if (Object.prototype.hasOwnProperty.call(response, 'result')) {
+    return response.result;
+  }
+  const err = new Error(response.error || 'Request failed');
+  err.inner = response.error;
+  throw err;
+}
+
 function isJiraConnectionFailure(error) {
   const message = String(error?.message || error?.inner || error || '');
   return CONNECTION_ERROR_PATTERN.test(message);
@@ -199,6 +209,8 @@ async function mainAsyncLocal() {
   const cacheTtlMs = 60 * 1000;
   const issueCache = new Map();
   const pullRequestCache = new Map();
+  const fieldOptionsCache = new Map();
+  let popupState = null;
 
   function toAbsoluteJiraUrl(url) {
     if (!url) {
@@ -728,16 +740,20 @@ async function mainAsyncLocal() {
     const seen = {};
     const sprints = [];
 
-    const pushSprint = (name, state) => {
+    const pushSprint = (name, state, id) => {
       if (!name) {
         return;
       }
-      const key = `${name}__${state || ''}`;
+      const key = id ? `id:${id}` : `${name}__${state || ''}`;
       if (seen[key]) {
         return;
       }
       seen[key] = true;
-      sprints.push({name, state: state || ''});
+      sprints.push({
+        id: id ? String(id) : '',
+        name,
+        state: state || ''
+      });
     };
 
     sprintValues.forEach(value => {
@@ -747,12 +763,17 @@ async function mainAsyncLocal() {
           return;
         }
         if (typeof entry === 'string') {
+          const idMatch = entry.match(/id=([^,\]]+)/i);
           const nameMatch = entry.match(/name=([^,\]]+)/i);
           const stateMatch = entry.match(/state=([^,\]]+)/i);
-          pushSprint(nameMatch && nameMatch[1] ? nameMatch[1] : entry, stateMatch && stateMatch[1]);
+          pushSprint(
+            nameMatch && nameMatch[1] ? nameMatch[1] : entry,
+            stateMatch && stateMatch[1],
+            idMatch && idMatch[1] ? idMatch[1] : ''
+          );
           return;
         }
-        pushSprint(entry.name || entry.goal || entry.id, entry.state);
+        pushSprint(entry.name || entry.goal || entry.id, entry.state, entry.id);
       });
     });
     return sprints;
@@ -890,6 +911,211 @@ async function mainAsyncLocal() {
       }));
   }
 
+  function buildEditFieldError(error) {
+    return error?.message || error?.inner || 'Update failed';
+  }
+
+  function pickSprintFieldId(issueData, sprintFieldIds) {
+    const populatedFieldId = (sprintFieldIds || []).find(fieldId => {
+      const value = issueData?.fields?.[fieldId];
+      return Array.isArray(value) ? value.length > 0 : !!value;
+    });
+    return populatedFieldId || sprintFieldIds?.[0] || '';
+  }
+
+  function buildEditOption(id, label, extra = {}) {
+    return {
+      id: id === '' ? '' : String(id || ''),
+      label: String(label || ''),
+      searchText: String(label || '').toLowerCase(),
+      ...extra
+    };
+  }
+
+  function formatSprintOptionLabel(sprint) {
+    if (!sprint) {
+      return '';
+    }
+    return sprint.state ? `${sprint.name} (${sprint.state})` : sprint.name;
+  }
+
+  function normalizeFixVersionSortName(name) {
+    return String(name || '').trim().replace(/^v(?=\d)/i, '');
+  }
+
+  function compareFixVersionOptions(left, right) {
+    return normalizeFixVersionSortName(right?.name).localeCompare(normalizeFixVersionSortName(left?.name), undefined, {
+      numeric: true,
+      sensitivity: 'base'
+    });
+  }
+
+  async function getFixVersionOptions(issueData) {
+    const projectKey = String(issueData?.key || '').split('-')[0];
+    if (!projectKey) {
+      return [];
+    }
+    return getCachedValue(fieldOptionsCache, `fixVersions__${projectKey}`, async () => {
+      const versions = await get(`${INSTANCE_URL}rest/api/2/project/${encodeURIComponent(projectKey)}/versions`);
+      const options = (Array.isArray(versions) ? versions : [])
+        .filter(version => version?.name && !version?.archived)
+        .sort(compareFixVersionOptions)
+        .map(version => buildEditOption(version.id, version.name, {rawValue: version}));
+      return [buildEditOption('', 'No fix version'), ...options];
+    });
+  }
+
+  function compareSprintState(left, right) {
+    const order = {
+      active: 0,
+      future: 1,
+      closed: 2
+    };
+    return (order[String(left || '').toLowerCase()] ?? 99) - (order[String(right || '').toLowerCase()] ?? 99);
+  }
+
+  async function getSprintOptions(issueData) {
+    const projectKey = String(issueData?.key || '').split('-')[0];
+    if (!projectKey) {
+      return [];
+    }
+    const sprintFieldIds = await getSprintFieldIds(INSTANCE_URL);
+    if (!sprintFieldIds.length) {
+      return [];
+    }
+    return getCachedValue(fieldOptionsCache, `sprint__${projectKey}`, async () => {
+      const boardResponse = await get(`${INSTANCE_URL}rest/agile/1.0/board?projectKeyOrId=${encodeURIComponent(projectKey)}&maxResults=50`);
+      const boards = Array.isArray(boardResponse?.values) ? boardResponse.values : [];
+      const sprintMap = new Map();
+      const sprintResponses = await Promise.allSettled(boards.map(board => {
+        return get(`${INSTANCE_URL}rest/agile/1.0/board/${board.id}/sprint?state=active,future&maxResults=50`);
+      }));
+
+      sprintResponses.forEach(result => {
+        if (result.status !== 'fulfilled') {
+          return;
+        }
+        const sprints = Array.isArray(result.value?.values) ? result.value.values : [];
+        sprints.forEach(sprint => {
+          if (sprint?.id && sprint?.name) {
+            sprintMap.set(String(sprint.id), sprint);
+          }
+        });
+      });
+
+      readSprintsFromIssue(issueData).forEach(sprint => {
+        if (sprint?.id && sprint?.name && !sprintMap.has(String(sprint.id))) {
+          sprintMap.set(String(sprint.id), sprint);
+        }
+      });
+
+      const options = [...sprintMap.values()]
+        .sort((left, right) => {
+          const stateOrder = compareSprintState(left?.state, right?.state);
+          if (stateOrder !== 0) {
+            return stateOrder;
+          }
+          return String(left?.name || '').localeCompare(String(right?.name || ''));
+        })
+        .map(sprint => buildEditOption(sprint.id, formatSprintOptionLabel(sprint), {rawValue: sprint}));
+
+      return [buildEditOption('', 'No sprint'), ...options];
+    });
+  }
+
+  function getEditableFieldDefinition(fieldKey, issueData) {
+    if (fieldKey === 'fixVersions') {
+      const currentFixVersions = issueData?.fields?.fixVersions || [];
+      return {
+        fieldKey,
+        label: 'Fix version',
+        currentText: formatFixVersionText(currentFixVersions),
+        currentOptionId: currentFixVersions.length === 1 ? String(currentFixVersions[0]?.id || '') : null,
+        loadOptions: () => getFixVersionOptions(issueData),
+        save: option => {
+          return requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
+            fields: {
+              fixVersions: option.id ? [{id: option.id}] : []
+            }
+          });
+        },
+        successMessage: option => option.id ? `Fix version set to ${option.label}` : 'Fix version cleared'
+      };
+    }
+
+    if (fieldKey === 'sprint') {
+      const currentSprints = readSprintsFromIssue(issueData);
+      return {
+        fieldKey,
+        label: 'Sprint',
+        currentText: formatSprintText(currentSprints),
+        currentOptionId: currentSprints.length === 1 ? String(currentSprints[0]?.id || '') : null,
+        loadOptions: () => getSprintOptions(issueData),
+        save: async option => {
+          const sprintFieldId = pickSprintFieldId(issueData, await getSprintFieldIds(INSTANCE_URL));
+          if (!sprintFieldId) {
+            throw new Error('Could not resolve the Sprint field');
+          }
+          await requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, {
+            fields: {
+              [sprintFieldId]: option.id ? (Number(option.id) || option.id) : []
+            }
+          });
+        },
+        successMessage: option => option.id ? `Sprint set to ${option.label}` : 'Sprint cleared'
+      };
+    }
+
+    return null;
+  }
+
+  function filterEditOptions(options, inputValue) {
+    const normalizedInput = String(inputValue || '').trim().toLowerCase();
+    const list = Array.isArray(options) ? options : [];
+    const filtered = normalizedInput
+      ? list.filter(option => option.searchText.includes(normalizedInput))
+      : list;
+    return filtered;
+  }
+
+  function buildEditableFieldChip(fieldKey, baseChip, state) {
+    const editState = state?.editState;
+    if (editState?.fieldKey === fieldKey) {
+      const options = filterEditOptions(editState.options, editState.inputValue).map(option => ({
+        ...option,
+        fieldKey,
+        isSelected: editState.selectedOptionId === option.id,
+        title: option.label
+      }));
+      return {
+        ...baseChip,
+        isEditable: true,
+        isEditing: true,
+        isRightAligned: fieldKey === 'fixVersions',
+        fieldKey,
+        editLabel: editState.label,
+        inputValue: editState.inputValue,
+        inputPlaceholder: `Type to filter ${editState.label.toLowerCase()} values`,
+        inputDisabled: !!(editState.loadingOptions || editState.saving),
+        loadingText: editState.loadingOptions
+          ? `Loading ${editState.label.toLowerCase()} values...`
+          : editState.saving
+            ? `Saving ${editState.label.toLowerCase()}...`
+            : '',
+        options,
+        hasOptions: options.length > 0,
+        editEmptyText: editState.loadingOptions ? 'Loading values...' : 'No matching values',
+        editError: editState.errorMessage || ''
+      };
+    }
+    return {
+      ...baseChip,
+      isEditable: true,
+      fieldKey,
+      editTitle: `Edit ${baseChip.text}`
+    };
+  }
+
   function getRelativeHref(href) {
     const documentHref = document.location.href.split('#')[0];
     if (href.startsWith(documentHref)) {
@@ -937,6 +1163,429 @@ async function mainAsyncLocal() {
   `);
   $(document.body).append(container);
   $(document.body).append(previewOverlay);
+
+  async function resolvePullRequestsForIssue(issueData) {
+    if (!displayFields.pullRequests) {
+      return [];
+    }
+    try {
+      const pullRequestResponse = await getPullRequestDataCached(issueData.id);
+      return normalizePullRequests(pullRequestResponse);
+    } catch (ex) {
+      console.log('[Jira HotLinker] Pull request fetch failed', {
+        issueKey: issueData?.key,
+        issueId: issueData?.id,
+        error: ex?.message || String(ex)
+      });
+      return [];
+    }
+  }
+
+  async function buildPopupDisplayData(state) {
+    const {key, issueData, pullRequests} = state;
+    const normalizedDescription = await normalizeRichHtml(issueData.renderedFields.description, {
+      imageMaxHeight: 180
+    });
+    const commentsForDisplay = await buildCommentsForDisplay(issueData);
+    const fixVersions = issueData.fields.fixVersions || [];
+    const affectsVersions = issueData.fields.versions || [];
+    const sprints = readSprintsFromIssue(issueData);
+    const commentsTotal = commentsForDisplay.length;
+    const attachments = issueData.fields.attachment || [];
+    const previewAttachments = buildPreviewAttachments(attachments);
+    const labels = issueData.fields.labels || [];
+    const customFieldChips = buildCustomFieldChips(issueData, customFields);
+    const epicOrParent = await readEpicOrParent(issueData);
+    const issueTypeName = issueData.fields.issuetype?.name;
+    const statusName = issueData.fields.status?.name;
+    const priorityName = issueData.fields.priority?.name;
+    const projectKey = key.split('-')[0];
+
+    const row1Chips = [
+      displayFields.issueType ? buildFilterChip(
+        issueTypeName || 'No type',
+        issueTypeName ? `${scopeJqlToProject(projectKey, `issuetype = ${encodeJqlValue(issueTypeName)}`)}` : '',
+        {iconUrl: issueData.fields.issuetype?.iconUrl || ''}
+      ) : null,
+      displayFields.status ? buildFilterChip(
+        statusName || 'No status',
+        statusName ? `${scopeJqlToProject(projectKey, `status = ${encodeJqlValue(statusName)}`)}` : '',
+        {iconUrl: issueData.fields.status?.iconUrl || ''}
+      ) : null,
+      displayFields.priority ? buildFilterChip(
+        priorityName || 'No priority',
+        priorityName ? `${scopeJqlToProject(projectKey, `priority = ${encodeJqlValue(priorityName)}`)}` : '',
+        {iconUrl: issueData.fields.priority?.iconUrl || ''}
+      ) : null,
+      displayFields.epicParent ? {
+        text: epicOrParent
+          ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
+          : 'Parent: --',
+        linkUrl: epicOrParent?.url || '',
+        linkTitle: epicOrParent ? buildLinkHoverTitle('Open parent issue', epicOrParent.key, epicOrParent.url) : ''
+      } : null,
+      ...customFieldChips[1]
+    ].filter(Boolean);
+
+    const singleAffectsVersion = affectsVersions.length === 1 ? affectsVersions[0]?.name : '';
+    const singleFixVersion = fixVersions.length === 1 ? fixVersions[0]?.name : '';
+    const row2Chips = [
+      displayFields.sprint ? buildEditableFieldChip('sprint', buildFilterChip(
+        `Sprint: ${formatSprintText(sprints) || '--'}`,
+        ''
+      ), state) : null,
+      displayFields.affects ? buildFilterChip(
+        `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`,
+        singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
+      ) : null,
+      displayFields.fixVersions ? buildEditableFieldChip('fixVersions', buildFilterChip(
+        `Fix version: ${formatFixVersionText(fixVersions) || '--'}`,
+        singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
+      ), state) : null,
+      ...customFieldChips[2]
+    ].filter(Boolean);
+
+    const singleLabel = labels.length === 1 ? labels[0] : '';
+    const row3Chips = [
+      displayFields.labels ? buildFilterChip(
+        `Labels: ${labels.filter(Boolean).join(', ') || '--'}`,
+        singleLabel ? `${scopeJqlToProject(projectKey, `labels = ${encodeJqlValue(singleLabel)}`)}` : ''
+      ) : null,
+      ...customFieldChips[3]
+    ].filter(Boolean);
+
+    const copyTicketMeta = ticket => ({
+      copyUrl: ticket.url,
+      copyTicket: ticket.key,
+      copyTitle: ticket.summary
+    });
+    const issueUrl = INSTANCE_URL + 'browse/' + key;
+
+    const visibleCommentsTotal = displayFields.comments ? commentsTotal : 0;
+    const visibleAttachments = displayFields.attachments ? previewAttachments : [];
+    const displayData = {
+      urlTitle: `[${key}] ${issueData.fields.summary}`,
+      ticketKey: key,
+      ticketTitle: issueData.fields.summary,
+      url: issueUrl,
+      urlHoverTitle: buildLinkHoverTitle('Open issue in Jira', `[${key}] ${issueData.fields.summary}`, issueUrl),
+      ...copyTicketMeta({
+        key,
+        summary: issueData.fields.summary,
+        url: issueUrl
+      }),
+      prs: [],
+      description: displayFields.description ? normalizedDescription : '',
+      hasBodyContent: true,
+      emptyBodyText: (!normalizedDescription && visibleAttachments.length === 0 && visibleCommentsTotal === 0)
+        ? 'No description, attachments or comments.'
+        : '',
+      attachments,
+      previewAttachments: visibleAttachments,
+      commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
+      issuetype: issueData.fields.issuetype,
+      status: issueData.fields.status,
+      priority: issueData.fields.priority,
+      issueTypeText: displayFields.issueType ? (issueTypeName || 'No type') : '',
+      statusText: displayFields.status ? (statusName || 'No status') : '',
+      sprintText: displayFields.sprint ? (formatSprintText(sprints) || 'No sprint') : '',
+      fixVersionText: displayFields.fixVersions ? (formatFixVersionText(fixVersions) || 'No fix version') : '',
+      row1Chips,
+      row2Chips,
+      row3Chips,
+      hasComments: visibleCommentsTotal > 0,
+      commentsTotal: visibleCommentsTotal,
+      attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
+      reporter: displayFields.reporter ? issueData.fields.reporter : null,
+      assignee: displayFields.assignee ? issueData.fields.assignee : null,
+      commentUrl: issueUrl,
+      hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
+      activityIndicators: [],
+      loaderGifUrl,
+    };
+    if (issueData.fields.comment?.comments?.[0]?.id) {
+      displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
+    }
+    if (displayFields.pullRequests && size(pullRequests)) {
+      const filteredPullRequests = pullRequests.filter(pr => {
+        return pr && pr.url !== location.href;
+      });
+      displayData.prs = filteredPullRequests.map(pr => {
+        return {
+          id: pr.id,
+          url: pr.url,
+          linkUrl: pr.url,
+          linkTitle: buildLinkHoverTitle('Open pull request', formatPullRequestTitle(pr), pr.url),
+          title: formatPullRequestTitle(pr),
+          status: pr.status,
+          authorName: formatPullRequestAuthor(pr),
+          branchText: formatPullRequestBranch(pr)
+        };
+      });
+    }
+    displayData.activityIndicators = buildActivityIndicators(
+      displayFields.attachments ? attachments : [],
+      visibleCommentsTotal,
+      displayData.prs.length
+    );
+    return displayData;
+  }
+
+  async function renderIssuePopup(state) {
+    if (!state?.issueData) {
+      return;
+    }
+    const displayData = await buildPopupDisplayData(state);
+    if (state !== popupState) {
+      return;
+    }
+    container.html(Mustache.render(annotationTemplate, displayData));
+    if (!containerPinned) {
+      container.css(computeVisibleContainerPosition(state.pointerX, state.pointerY));
+    }
+    if (state.editState?.fieldKey) {
+      const input = container.find('._JX_edit_input')[0];
+      if (input) {
+        input.focus();
+        const maxIndex = input.value.length;
+        const selectionStart = Math.min(maxIndex, Number.isInteger(state.editState.selectionStart) ? state.editState.selectionStart : maxIndex);
+        const selectionEnd = Math.min(maxIndex, Number.isInteger(state.editState.selectionEnd) ? state.editState.selectionEnd : maxIndex);
+        input.setSelectionRange(selectionStart, selectionEnd);
+      }
+    }
+  }
+
+  function invalidatePopupCaches() {
+    if (!popupState?.key) {
+      return;
+    }
+    issueCache.delete(popupState.key);
+    if (popupState.issueData?.id) {
+      const issueId = String(popupState.issueData.id);
+      [...pullRequestCache.keys()].forEach(cacheKey => {
+        if (String(cacheKey).includes(issueId)) {
+          pullRequestCache.delete(cacheKey);
+        }
+      });
+    }
+  }
+
+  async function refreshPopupIssueState(successMessage = '') {
+    if (!popupState?.key) {
+      return;
+    }
+    const popupKey = popupState.key;
+    invalidatePopupCaches();
+    const refreshedIssueData = await getIssueMetaData(popupKey);
+    await normalizeIssueImages(refreshedIssueData);
+    const refreshedPullRequests = await resolvePullRequestsForIssue(refreshedIssueData);
+    if (!popupState || popupState.key !== popupKey) {
+      return;
+    }
+    popupState = {
+      ...popupState,
+      issueData: refreshedIssueData,
+      pullRequests: refreshedPullRequests,
+      editState: null
+    };
+    await renderIssuePopup(popupState);
+    if (successMessage) {
+      snackBar(successMessage);
+    }
+  }
+
+  async function startFieldEdit(fieldKey) {
+    if (!popupState?.issueData) {
+      return;
+    }
+    if (popupState.editState?.fieldKey === fieldKey) {
+      return;
+    }
+    const definition = getEditableFieldDefinition(fieldKey, popupState.issueData);
+    if (!definition) {
+      return;
+    }
+    const initialValue = definition.currentText || '';
+    popupState = {
+      ...popupState,
+      editState: {
+        fieldKey,
+        label: definition.label,
+        inputValue: initialValue,
+        options: [],
+        selectedOptionId: definition.currentOptionId,
+        loadingOptions: true,
+        saving: false,
+        errorMessage: '',
+        selectionStart: initialValue.length,
+        selectionEnd: initialValue.length
+      }
+    };
+    await renderIssuePopup(popupState);
+
+    try {
+      const options = await definition.loadOptions();
+      if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey) {
+        return;
+      }
+      const selectedOption = (Array.isArray(options) ? options : []).find(option => option.id === popupState.editState.selectedOptionId);
+      const nextInputValue = selectedOption ? selectedOption.label : popupState.editState.inputValue;
+      popupState = {
+        ...popupState,
+        editState: {
+          ...popupState.editState,
+          inputValue: nextInputValue,
+          options,
+          loadingOptions: false,
+          selectionStart: nextInputValue.length,
+          selectionEnd: nextInputValue.length
+        }
+      };
+      await renderIssuePopup(popupState);
+    } catch (error) {
+      const errorMessage = buildEditFieldError(error);
+      if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey) {
+        return;
+      }
+      popupState = {
+        ...popupState,
+        editState: {
+          ...popupState.editState,
+          loadingOptions: false,
+          errorMessage
+        }
+      };
+      await renderIssuePopup(popupState);
+      snackBar(errorMessage);
+    }
+  }
+
+  function cancelFieldEdit() {
+    if (!popupState?.editState) {
+      return;
+    }
+    popupState = {
+      ...popupState,
+      editState: null
+    };
+    renderIssuePopup(popupState).catch(() => {});
+  }
+
+  function updateFieldEditInput(nextValue, selectionStart, selectionEnd) {
+    if (!popupState?.editState) {
+      return;
+    }
+    const normalizedValue = String(nextValue || '');
+    const exactOption = (popupState.editState.options || []).find(option => {
+      return option.label.toLowerCase() === normalizedValue.trim().toLowerCase();
+    });
+    popupState = {
+      ...popupState,
+      editState: {
+        ...popupState.editState,
+        inputValue: normalizedValue,
+        selectedOptionId: exactOption ? exactOption.id : null,
+        errorMessage: '',
+        selectionStart,
+        selectionEnd
+      }
+    };
+    renderIssuePopup(popupState).catch(() => {});
+  }
+
+  function selectFieldEditOption(optionId) {
+    if (!popupState?.editState) {
+      return;
+    }
+    const option = (popupState.editState.options || []).find(candidate => candidate.id === optionId);
+    if (!option) {
+      return;
+    }
+    popupState = {
+      ...popupState,
+      editState: {
+        ...popupState.editState,
+        inputValue: option.label,
+        selectedOptionId: option.id,
+        errorMessage: '',
+        selectionStart: option.label.length,
+        selectionEnd: option.label.length
+      }
+    };
+    renderIssuePopup(popupState).catch(() => {});
+  }
+
+  function resolveSelectedEditOption(editState) {
+    if (!editState) {
+      return null;
+    }
+    if (editState.selectedOptionId !== null && typeof editState.selectedOptionId !== 'undefined') {
+      const selectedOption = (editState.options || []).find(option => option.id === editState.selectedOptionId);
+      if (selectedOption) {
+        return selectedOption;
+      }
+    }
+    const normalizedInput = String(editState.inputValue || '').trim().toLowerCase();
+    if (!normalizedInput) {
+      return null;
+    }
+    return (editState.options || []).find(option => option.label.toLowerCase() === normalizedInput) || null;
+  }
+
+  async function submitFieldEdit(fieldKey) {
+    if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey || popupState.editState.loadingOptions || popupState.editState.saving) {
+      return;
+    }
+    const definition = getEditableFieldDefinition(fieldKey, popupState.issueData);
+    if (!definition) {
+      return;
+    }
+    const selectedOption = resolveSelectedEditOption(popupState.editState);
+    if (!selectedOption) {
+      const errorMessage = 'Pick an existing value from the dropdown before pressing Enter';
+      popupState = {
+        ...popupState,
+        editState: {
+          ...popupState.editState,
+          errorMessage
+        }
+      };
+      await renderIssuePopup(popupState);
+      snackBar(errorMessage);
+      return;
+    }
+
+    popupState = {
+      ...popupState,
+      editState: {
+        ...popupState.editState,
+        saving: true,
+        errorMessage: ''
+      }
+    };
+    await renderIssuePopup(popupState);
+
+    try {
+      await definition.save(selectedOption);
+      await refreshPopupIssueState(definition.successMessage(selectedOption));
+    } catch (error) {
+      const errorMessage = buildEditFieldError(error);
+      if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey) {
+        return;
+      }
+      popupState = {
+        ...popupState,
+        editState: {
+          ...popupState.editState,
+          saving: false,
+          errorMessage
+        }
+      };
+      await renderIssuePopup(popupState);
+      snackBar(errorMessage);
+    }
+  }
+
   new draggable({
     handle: '._JX_title, ._JX_status',
     cancel: 'a, button, input, textarea, img, ._JX_description, ._JX_comments, ._JX_comment_body, ._JX_description_text, ._JX_related_pr'
@@ -1008,6 +1657,60 @@ async function mainAsyncLocal() {
     copyPrettyLink(e.currentTarget).catch(() => snackBar('There was an error!'));
   });
 
+  $(document.body).on('click', '._JX_field_chip_edit', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const fieldKey = e.currentTarget.getAttribute('data-field-key') || '';
+    startFieldEdit(fieldKey).catch(() => {});
+  });
+
+  $(document.body).on('click', '._JX_edit_cancel', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    cancelFieldEdit();
+  });
+
+  $(document.body).on('click', '._JX_edit_option', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    selectFieldEditOption(e.currentTarget.getAttribute('data-option-id'));
+  });
+
+  $(document.body).on('input', '._JX_edit_input', function (e) {
+    e.stopPropagation();
+    updateFieldEditInput(e.currentTarget.value, e.currentTarget.selectionStart, e.currentTarget.selectionEnd);
+  });
+
+  $(document.body).on('keydown', '._JX_edit_input', function (e) {
+    e.stopPropagation();
+    const fieldKey = e.currentTarget.getAttribute('data-field-key') || '';
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      submitFieldEdit(fieldKey).catch(() => {});
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      cancelFieldEdit();
+    }
+  });
+
+  $(document.body).on('mousedown', function (e) {
+    if (!popupState?.editState) {
+      return;
+    }
+    if ($(e.target).closest('._JX_edit_popover, ._JX_field_chip_edit').length) {
+      return;
+    }
+    if ($(e.target).closest('._JX_container').length === 0) {
+      cancelFieldEdit();
+      return;
+    }
+    if ($(e.target).closest('._JX_field_chip_editable_group').length === 0 && $(e.target).closest('._JX_edit_popover').length === 0) {
+      cancelFieldEdit();
+    }
+  });
+
   function closePreviewOverlay() {
     previewOverlay.removeClass('is-open');
     previewOverlay.find('img').attr('src', '');
@@ -1047,6 +1750,7 @@ async function mainAsyncLocal() {
 
   function hideContainer() {
     lastHoveredKey = '';
+    popupState = null;
     containerPinned = false;
     container.css({
       left: -5000,
@@ -1119,6 +1823,13 @@ async function mainAsyncLocal() {
         clearTimeout(hideTimeOut);
         const key = keys[0].replace(' ', '-');
         if (lastHoveredKey === key && container.html()) {
+          if (popupState) {
+            popupState = {
+              ...popupState,
+              pointerX: e.pageX,
+              pointerY: e.pageY
+            };
+          }
           if (!containerPinned) {
             container.css(computeVisibleContainerPosition(e.pageX, e.pageY));
           }
@@ -1147,156 +1858,15 @@ async function mainAsyncLocal() {
           if (cancelToken.cancel) {
             return;
           }
-          const normalizedDescription = await normalizeRichHtml(issueData.renderedFields.description, {
-            imageMaxHeight: 180
-          });
-          const commentsForDisplay = await buildCommentsForDisplay(issueData);
-          const fixVersions = issueData.fields.fixVersions || [];
-          const affectsVersions = issueData.fields.versions || [];
-          const sprints = readSprintsFromIssue(issueData);
-          const commentsTotal = commentsForDisplay.length;
-          const attachments = issueData.fields.attachment || [];
-          const previewAttachments = buildPreviewAttachments(attachments);
-          const labels = issueData.fields.labels || [];
-          const customFieldChips = buildCustomFieldChips(issueData, customFields);
-          const epicOrParent = await readEpicOrParent(issueData);
-          const issueTypeName = issueData.fields.issuetype?.name;
-          const statusName = issueData.fields.status?.name;
-          const priorityName = issueData.fields.priority?.name;
-          const projectKey = key.split('-')[0];
-
-          const row1Chips = [
-            displayFields.issueType ? buildFilterChip(
-              issueTypeName || 'No type',
-              issueTypeName ? `${scopeJqlToProject(projectKey, `issuetype = ${encodeJqlValue(issueTypeName)}`)}` : '',
-              {iconUrl: issueData.fields.issuetype?.iconUrl || ''}
-            ) : null,
-            displayFields.status ? buildFilterChip(
-              statusName || 'No status',
-              statusName ? `${scopeJqlToProject(projectKey, `status = ${encodeJqlValue(statusName)}`)}` : '',
-              {iconUrl: issueData.fields.status?.iconUrl || ''}
-            ) : null,
-            displayFields.priority ? buildFilterChip(
-              priorityName || 'No priority',
-              priorityName ? `${scopeJqlToProject(projectKey, `priority = ${encodeJqlValue(priorityName)}`)}` : '',
-              {iconUrl: issueData.fields.priority?.iconUrl || ''}
-            ) : null,
-            displayFields.epicParent ? {
-              text: epicOrParent
-                ? `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`
-                : 'Parent: --',
-              linkUrl: epicOrParent?.url || '',
-              linkTitle: epicOrParent ? buildLinkHoverTitle('Open parent issue', epicOrParent.key, epicOrParent.url) : ''
-            } : null,
-            ...customFieldChips[1]
-          ].filter(Boolean);
-
-          const singleAffectsVersion = affectsVersions.length === 1 ? affectsVersions[0]?.name : '';
-          const singleFixVersion = fixVersions.length === 1 ? fixVersions[0]?.name : '';
-          const row2Chips = [
-            displayFields.sprint ? buildFilterChip(
-              `Sprint: ${formatSprintText(sprints) || '--'}`,
-              ''
-            ) : null,
-            displayFields.affects ? buildFilterChip(
-              `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`,
-              singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
-            ) : null,
-            displayFields.fixVersions ? buildFilterChip(
-              `Fix version: ${formatFixVersionText(fixVersions) || '--'}`,
-              singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
-            ) : null,
-            ...customFieldChips[2]
-          ].filter(Boolean);
-
-          const singleLabel = labels.length === 1 ? labels[0] : '';
-          const row3Chips = [
-            displayFields.labels ? buildFilterChip(
-              `Labels: ${labels.filter(Boolean).join(', ') || '--'}`,
-              singleLabel ? `${scopeJqlToProject(projectKey, `labels = ${encodeJqlValue(singleLabel)}`)}` : ''
-            ) : null,
-            ...customFieldChips[3]
-          ].filter(Boolean);
-
-          const copyTicketMeta = (ticket) => ({
-            copyUrl: ticket.url,
-            copyTicket: ticket.key,
-            copyTitle: ticket.summary
-          });
-          const issueUrl = INSTANCE_URL + 'browse/' + key;
-
-          const visibleCommentsTotal = displayFields.comments ? commentsTotal : 0;
-          const visibleAttachments = displayFields.attachments ? previewAttachments : [];
-          const displayData = {
-            urlTitle: `[${key}] ${issueData.fields.summary}`,
-            ticketKey: key,
-            ticketTitle: issueData.fields.summary,
-            url: issueUrl,
-            urlHoverTitle: buildLinkHoverTitle('Open issue in Jira', `[${key}] ${issueData.fields.summary}`, issueUrl),
-            ...copyTicketMeta({
-              key,
-              summary: issueData.fields.summary,
-              url: issueUrl
-            }),
-            prs: [],
-            description: displayFields.description ? normalizedDescription : '',
-            hasBodyContent: true,
-            emptyBodyText: (!normalizedDescription && visibleAttachments.length === 0 && visibleCommentsTotal === 0)
-              ? 'No description, attachments or comments.'
-              : '',
-            attachments,
-            previewAttachments: visibleAttachments,
-            commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
-            issuetype: issueData.fields.issuetype,
-            status: issueData.fields.status,
-            priority: issueData.fields.priority,
-            issueTypeText: displayFields.issueType ? (issueTypeName || 'No type') : '',
-            statusText: displayFields.status ? (statusName || 'No status') : '',
-            sprintText: displayFields.sprint ? (formatSprintText(sprints) || 'No sprint') : '',
-            fixVersionText: displayFields.fixVersions ? (formatFixVersionText(fixVersions) || 'No fix version') : '',
-            row1Chips,
-            row2Chips,
-            row3Chips,
-            hasComments: visibleCommentsTotal > 0,
-            commentsTotal: visibleCommentsTotal,
-            attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
-            reporter: displayFields.reporter ? issueData.fields.reporter : null,
-            assignee: displayFields.assignee ? issueData.fields.assignee : null,
-            commentUrl: issueUrl,
-            hasFieldSummary: row1Chips.length > 0 || row2Chips.length > 0 || row3Chips.length > 0,
-            activityIndicators: [],
-            loaderGifUrl,
+          popupState = {
+            key,
+            issueData,
+            pullRequests,
+            pointerX,
+            pointerY,
+            editState: null
           };
-          if (issueData.fields.comment?.comments?.[0]?.id) {
-            displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
-          }
-          if (displayFields.pullRequests && size(pullRequests)) {
-            const filteredPullRequests = pullRequests.filter(function (pr) {
-              return pr && pr.url !== location.href;
-            });
-            displayData.prs = filteredPullRequests.map(function (pr) {
-              return {
-                id: pr.id,
-                url: pr.url,
-                linkUrl: pr.url,
-                linkTitle: buildLinkHoverTitle('Open pull request', formatPullRequestTitle(pr), pr.url),
-                title: formatPullRequestTitle(pr),
-                status: pr.status,
-                authorName: formatPullRequestAuthor(pr),
-                branchText: formatPullRequestBranch(pr)
-              };
-            });
-          }
-          displayData.activityIndicators = buildActivityIndicators(
-            displayFields.attachments ? attachments : [],
-            visibleCommentsTotal,
-            displayData.prs.length
-          );
-          // TODO: fix scrolling in google docs
-          container.html(Mustache.render(annotationTemplate, displayData));
-          if (!containerPinned) {
-            container.css(computeVisibleContainerPosition(pointerX, pointerY));
-          }
+          await renderIssuePopup(popupState);
         })(cancelToken).catch((error) => {
           notifyJiraConnectionFailure(INSTANCE_URL, error);
           lastHoveredKey = '';
@@ -1314,6 +1884,22 @@ if (!window.__JX__script_injected__) {
 }
 
 window.__JX__script_injected__ = true;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -1,6 +1,7 @@
 /*global chrome */
 import size from 'lodash/size';
 import debounce from 'lodash/debounce';
+import regexEscape from 'escape-string-regexp';
 import Mustache from 'mustache';
 import {waitForDocument} from 'src/utils';
 import {sendMessage, storageGet, storageSet} from 'src/chrome';
@@ -46,7 +47,15 @@ async function getSprintFieldIds(instanceUrl) {
  * @returns {Function}
  */
 function buildJiraKeyMatcher(projectKeys) {
-  const projectMatches = projectKeys.join('|');
+  const escapedKeys = (projectKeys || [])
+    .filter(Boolean)
+    .map(key => regexEscape(key));
+  if (!escapedKeys.length) {
+    return function () {
+      return [];
+    };
+  }
+  const projectMatches = escapedKeys.join('|');
   const jiraTicketRegex = new RegExp('(?:' + projectMatches + ')[- ]\\d+', 'ig');
 
   return function (text) {
@@ -86,7 +95,7 @@ storageGet({'ui_tips_shown': []}).then(function ({ui_tips_shown}) {
 });
 
 async function get(url) {
-  var response = await sendMessage({action: "get", url: url});
+  const response = await sendMessage({action: 'get', url: url});
   if (response.result) {
     return response.result;
   } else if (response.error) {
@@ -113,6 +122,24 @@ async function mainAsyncLocal() {
 
   const config = await getConfig();
   const INSTANCE_URL = config.instanceUrl;
+  const displayFields = {
+    issueType: true,
+    status: true,
+    priority: true,
+    sprint: true,
+    fixVersions: true,
+    affects: true,
+    labels: true,
+    account: true,
+    epicParent: true,
+    attachments: true,
+    comments: true,
+    description: true,
+    reporter: true,
+    assignee: true,
+    pullRequests: true,
+    ...(config.displayFields || {})
+  };
   const jiraProjects = await get(await getInstanceUrl() + 'rest/api/2/project');
 
   if (!size(jiraProjects)) {
@@ -122,9 +149,12 @@ async function mainAsyncLocal() {
   const getJiraKeys = buildJiraKeyMatcher(jiraProjects.map(function (project) {
     return project.key;
   }));
-  const annotationTemplate = await get(chrome.runtime.getURL('resources/annotation.html'));
+  const annotationTemplate = await fetch(chrome.runtime.getURL('resources/annotation.html')).then(response => response.text());
   const loaderGifUrl = chrome.runtime.getURL('resources/ajax-loader.gif');
   const imageProxyCache = {};
+  const cacheTtlMs = 60 * 1000;
+  const issueCache = new Map();
+  const pullRequestCache = new Map();
 
   function toAbsoluteJiraUrl(url) {
     if (!url) {
@@ -241,13 +271,58 @@ async function mainAsyncLocal() {
     }).format(createdAt);
   }
 
+  function sanitizeRichHtml(rawHtml) {
+    const temp = document.createElement('div');
+    temp.innerHTML = rawHtml || '';
+
+    const blockedTags = [
+      'script', 'style', 'iframe', 'object', 'embed', 'link', 'meta', 'base',
+      'form', 'input', 'button', 'textarea', 'select', 'svg', 'math'
+    ];
+    blockedTags.forEach(tagName => {
+      Array.from(temp.querySelectorAll(tagName)).forEach(node => node.remove());
+    });
+
+    const elements = Array.from(temp.querySelectorAll('*'));
+    elements.forEach(element => {
+      Array.from(element.attributes).forEach(attribute => {
+        const name = attribute.name.toLowerCase();
+        const value = attribute.value || '';
+
+        if (name.startsWith('on') || name === 'srcdoc' || name === 'style') {
+          element.removeAttribute(attribute.name);
+          return;
+        }
+
+        if (name === 'href') {
+          const normalized = value.trim();
+          if (/^(javascript|data):/i.test(normalized)) {
+            element.removeAttribute(attribute.name);
+          }
+          return;
+        }
+
+        if (name === 'src') {
+          const normalized = value.trim();
+          const safeImageDataUrl = /^data:image\/(gif|png|jpeg|jpg|webp);/i.test(normalized);
+          const safeHttpUrl = /^https?:/i.test(normalized);
+          if (!safeImageDataUrl && !safeHttpUrl) {
+            element.removeAttribute(attribute.name);
+          }
+          return;
+        }
+      });
+    });
+
+    return temp;
+  }
+
   async function normalizeRichHtml(html, options = {}) {
     if (!html) {
       return '';
     }
     const {imageMaxHeight} = options;
-    const temp = document.createElement('div');
-    temp.innerHTML = html;
+    const temp = sanitizeRichHtml(html);
 
     const imageNodes = Array.from(temp.querySelectorAll('img[src]'));
     await Promise.all(imageNodes.map(async img => {
@@ -317,25 +392,129 @@ async function mainAsyncLocal() {
   }
 
   function getPullRequestData(issueId, applicationType) {
-    return get(INSTANCE_URL + 'rest/dev-status/1.0/issue/details?issueId=' + issueId + '&applicationType=' + applicationType + '&dataType=pullrequest');
+    const appTypeQuery = applicationType ? `&applicationType=${encodeURIComponent(applicationType)}` : '';
+    return get(`${INSTANCE_URL}rest/dev-status/1.0/issue/details?issueId=${issueId}${appTypeQuery}&dataType=pullrequest`);
+  }
+
+  async function getCachedValue(cache, key, buildValue) {
+    const existing = cache.get(key);
+    if (existing && (Date.now() - existing.createdAt) < cacheTtlMs) {
+      return existing.value;
+    }
+
+    const value = await buildValue();
+    cache.set(key, {
+      createdAt: Date.now(),
+      value
+    });
+    return value;
   }
 
   async function getIssueMetaData(issueKey) {
-    const sprintFieldIds = await getSprintFieldIds(INSTANCE_URL);
-    const fields = [
-      'description',
-      'id',
-      'reporter',
-      'assignee',
-      'summary',
-      'attachment',
-      'comment',
-      'issuetype',
-      'status',
-      'fixVersions',
-      ...sprintFieldIds
-    ];
-    return get(INSTANCE_URL + 'rest/api/2/issue/' + issueKey + '?fields=' + fields.join(',') + '&expand=renderedFields,names');
+    return getCachedValue(issueCache, issueKey, async () => {
+      const sprintFieldIds = await getSprintFieldIds(INSTANCE_URL);
+      const fields = [
+        'description',
+        'id',
+        'reporter',
+        'assignee',
+        'summary',
+        'attachment',
+        'comment',
+        'issuetype',
+        'status',
+        'priority',
+        'labels',
+        'versions',
+        'parent',
+        'fixVersions',
+        ...sprintFieldIds
+      ];
+      return get(INSTANCE_URL + 'rest/api/2/issue/' + issueKey + '?fields=' + fields.join(',') + '&expand=renderedFields,names');
+    });
+  }
+
+  function getPullRequestDataCached(issueId, applicationType) {
+    const cacheKey = `${issueId}__${applicationType}`;
+    return getCachedValue(pullRequestCache, cacheKey, () => {
+      return getPullRequestData(issueId, applicationType);
+    });
+  }
+
+  async function getIssueSummary(issueKey) {
+    if (!issueKey) {
+      return null;
+    }
+    return getCachedValue(issueCache, `summary__${issueKey}`, async () => {
+      const data = await get(`${INSTANCE_URL}rest/api/2/issue/${issueKey}?fields=summary`);
+      return {
+        key: issueKey,
+        summary: data?.fields?.summary || issueKey
+      };
+    });
+  }
+
+  async function readEpicOrParent(issueData) {
+    const parent = issueData.fields?.parent;
+    if (parent && parent.key) {
+      return {
+        key: parent.key,
+        summary: parent.fields?.summary || parent.key,
+        url: `${INSTANCE_URL}browse/${parent.key}`
+      };
+    }
+
+    const names = issueData.names || {};
+    const fields = issueData.fields || {};
+    const epicFieldId = Object.keys(names).find(fieldId => {
+      const name = String(names[fieldId] || '').toLowerCase();
+      return name === 'epic link' || name === 'epic';
+    });
+    const epicKey = epicFieldId ? fields[epicFieldId] : null;
+    if (!epicKey || typeof epicKey !== 'string') {
+      return null;
+    }
+    try {
+      const epic = await getIssueSummary(epicKey);
+      return {
+        key: epic.key,
+        summary: epic.summary || epic.key,
+        url: `${INSTANCE_URL}browse/${epic.key}`
+      };
+    } catch (ex) {
+      return {
+        key: epicKey,
+        summary: epicKey,
+        url: `${INSTANCE_URL}browse/${epicKey}`
+      };
+    }
+  }
+
+  function readAccountValues(issueData) {
+    const names = issueData.names || {};
+    const fields = issueData.fields || {};
+    const accountFieldIds = Object.keys(names).filter(fieldId => {
+      return String(names[fieldId] || '').toLowerCase().includes('account');
+    });
+    const values = [];
+    accountFieldIds.forEach(fieldId => {
+      const value = fields[fieldId];
+      if (!value) {
+        return;
+      }
+      const entries = Array.isArray(value) ? value : [value];
+      entries.forEach(entry => {
+        if (!entry) {
+          return;
+        }
+        if (typeof entry === 'string') {
+          values.push(entry);
+          return;
+        }
+        values.push(entry.name || entry.value || entry.key || entry.id);
+      });
+    });
+    return [...new Set(values.filter(Boolean))];
   }
 
   function readSprintsFromIssue(issueData) {
@@ -392,6 +571,43 @@ async function mainAsyncLocal() {
       .map(sprint => sprint.state ? `${sprint.name} (${sprint.state})` : sprint.name)
       .filter(Boolean)
       .join(', ');
+  }
+
+  function encodeJqlValue(value) {
+    return `"${String(value || '').replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+
+  function buildJqlUrl(jql) {
+    return `${INSTANCE_URL}issues/?jql=${encodeURIComponent(jql)}`;
+  }
+
+  function toSearchChip(fieldName, value, label = value) {
+    if (!value) {
+      return null;
+    }
+    const jql = `${fieldName} = ${encodeJqlValue(value)}`;
+    return {
+      text: label,
+      url: buildJqlUrl(jql)
+    };
+  }
+
+  function toIssueSearchChip(issueTypeName, statusName, value, label = value) {
+    if (!value) {
+      return null;
+    }
+    const criteria = [];
+    if (issueTypeName) {
+      criteria.push(`issuetype = ${encodeJqlValue(issueTypeName)}`);
+    }
+    if (statusName) {
+      criteria.push(`status = ${encodeJqlValue(statusName)}`);
+    }
+    criteria.push(`text ~ ${encodeJqlValue(value)}`);
+    return {
+      text: label,
+      url: buildJqlUrl(criteria.join(' AND '))
+    };
   }
 
   function buildAttachmentChips(attachments) {
@@ -492,11 +708,10 @@ async function mainAsyncLocal() {
     handle: '._JX_title, ._JX_status',
   }, container);
   
-  function buildPrettyLinkPayload() {
-    const titleLink = document.getElementById('_JX_title_link');
-    const url = titleLink?.getAttribute('href') || '';
-    const ticket = titleLink?.getAttribute('data-ticket') || '';
-    const title = titleLink?.getAttribute('data-title') || '';
+  function buildPrettyLinkPayload(sourceElement) {
+    const url = sourceElement?.getAttribute('data-url') || sourceElement?.getAttribute('href') || '';
+    const ticket = sourceElement?.getAttribute('data-ticket') || '';
+    const title = sourceElement?.getAttribute('data-title') || '';
     const label = `[${ticket}] ${title}`.trim();
     const link = document.createElement('a');
     link.href = url;
@@ -524,8 +739,8 @@ async function mainAsyncLocal() {
     });
   }
 
-  async function copyPrettyLink() {
-    const {html, text} = buildPrettyLinkPayload();
+  async function copyPrettyLink(sourceElement) {
+    const {html, text} = buildPrettyLinkPayload(sourceElement);
     try {
       if (navigator.clipboard && window.ClipboardItem && navigator.clipboard.write) {
         await navigator.clipboard.write([
@@ -554,9 +769,9 @@ async function mainAsyncLocal() {
     }
   }
 
-  $(document.body).on('click', '._JX_title_copy', function (e) {
+  $(document.body).on('click', '._JX_copy_link', function (e) {
     e.preventDefault();
-    copyPrettyLink().catch(() => snackBar('There was an error!'));
+    copyPrettyLink(e.currentTarget).catch(() => snackBar('There was an error!'));
   });
 
   function closePreviewOverlay() {
@@ -597,6 +812,7 @@ async function mainAsyncLocal() {
   });
 
   function hideContainer() {
+    lastHoveredKey = '';
     containerPinned = false;
     container.css({
       left: -5000,
@@ -632,6 +848,7 @@ async function mainAsyncLocal() {
 
   let hideTimeOut;
   let containerPinned = false;
+  let lastHoveredKey = '';
   container.on('dragstop', () => {
     if (!containerPinned) {
       snackBar('Ticket Pinned! Hit esc to close !');
@@ -660,13 +877,20 @@ async function mainAsyncLocal() {
       if (!size(keys) && element.href) {
         keys = getJiraKeys(getRelativeHref(element.href));
       }
-      if (!size(keys) && element.parentElement.href) {
+      if (!size(keys) && element.parentElement && element.parentElement.href) {
         keys = getJiraKeys(getRelativeHref(element.parentElement.href));
       }
 
       if (size(keys)) {
         clearTimeout(hideTimeOut);
-        const key = keys[0].replace(" ", "-");
+        const key = keys[0].replace(' ', '-');
+        if (lastHoveredKey === key && container.html()) {
+          if (!containerPinned) {
+            container.css(computeVisibleContainerPosition(e.pageX, e.pageY));
+          }
+          return;
+        }
+        lastHoveredKey = key;
         const pointerX = e.pageX;
         const pointerY = e.pageY;
         (async function (cancelToken) {
@@ -674,8 +898,8 @@ async function mainAsyncLocal() {
           await normalizeIssueImages(issueData);
           let pullRequests = [];
           try {
-            const githubPrs = await getPullRequestData(issueData.id, 'github');
-            pullRequests = githubPrs.detail[0].pullRequests;
+            const githubPrs = await getPullRequestDataCached(issueData.id, 'github');
+            pullRequests = githubPrs.detail?.[0]?.pullRequests || [];
           } catch (ex) {
             // probably no access
           }
@@ -688,39 +912,116 @@ async function mainAsyncLocal() {
           });
           const commentsForDisplay = await buildCommentsForDisplay(issueData);
           const fixVersions = issueData.fields.fixVersions || [];
+          const affectsVersions = issueData.fields.versions || [];
           const sprints = readSprintsFromIssue(issueData);
           const commentsTotal = commentsForDisplay.length;
           const attachments = issueData.fields.attachment || [];
           const previewAttachments = buildPreviewAttachments(attachments);
+          const labels = issueData.fields.labels || [];
+          const accountValues = readAccountValues(issueData);
+          const epicOrParent = await readEpicOrParent(issueData);
+          const issueTypeName = issueData.fields.issuetype?.name;
+          const statusName = issueData.fields.status?.name;
+          const priorityName = issueData.fields.priority?.name;
+
+          const statusChips = [
+            displayFields.issueType ? {text: issueTypeName || 'No type'} : null,
+            displayFields.status ? {text: statusName || 'No status'} : null,
+            displayFields.priority ? {text: priorityName || 'No priority'} : null
+          ].filter(Boolean);
+
+          const sprintChips = displayFields.sprint ? sprints
+            .map(sprint => {
+              const label = sprint.state ? `${sprint.name} (${sprint.state})` : sprint.name;
+              return toSearchChip('Sprint', sprint.name, label);
+            })
+            .filter(Boolean) : [];
+          const sprintFallbackText = displayFields.sprint && !sprintChips.length ? 'Sprint: --' : '';
+
+          const fixVersionChips = displayFields.fixVersions ? fixVersions
+            .map(version => toSearchChip('fixVersion', version.name))
+            .filter(Boolean) : [];
+          const fixVersionFallbackText = displayFields.fixVersions && !fixVersionChips.length ? 'Fix version: --' : '';
+
+          const labelChips = displayFields.labels ? labels
+            .map(label => toIssueSearchChip(issueTypeName, statusName, label))
+            .filter(Boolean) : [];
+
+          const accountChips = displayFields.account ? accountValues
+            .map(accountValue => ({text: accountValue}))
+            .filter(Boolean) : [];
+
+          const epicParentChips = displayFields.epicParent && epicOrParent
+            ? [{
+              text: `Parent: [${epicOrParent.key}] ${epicOrParent.summary}`,
+            }]
+            : [];
+
+          const affectsText = displayFields.affects
+            ? `Affects: ${affectsVersions.map(version => version.name).filter(Boolean).join(', ') || '--'}`
+            : '';
+
+          const copyTicketMeta = (ticket) => ({
+            copyUrl: ticket.url,
+            copyTicket: ticket.key,
+            copyTitle: ticket.summary
+          });
+
           const displayData = {
             urlTitle: `[${key}] ${issueData.fields.summary}`,
             ticketKey: key,
             ticketTitle: issueData.fields.summary,
             url: INSTANCE_URL + 'browse/' + key,
+            ...copyTicketMeta({
+              key,
+              summary: issueData.fields.summary,
+              url: INSTANCE_URL + 'browse/' + key
+            }),
             prs: [],
-            description: normalizedDescription,
-            hasBodyContent: !!normalizedDescription || previewAttachments.length > 0 || commentsForDisplay.length > 0,
+            description: displayFields.description ? normalizedDescription : '',
+            hasBodyContent: (displayFields.description && !!normalizedDescription) ||
+              (displayFields.attachments && previewAttachments.length > 0) ||
+              (displayFields.comments && commentsForDisplay.length > 0),
             attachments,
-            previewAttachments,
-            commentsForDisplay,
+            previewAttachments: displayFields.attachments ? previewAttachments : [],
+            commentsForDisplay: displayFields.comments ? commentsForDisplay : [],
             issuetype: issueData.fields.issuetype,
             status: issueData.fields.status,
-            issueTypeText: issueData.fields.issuetype?.name || 'No type',
-            statusText: issueData.fields.status?.name || 'No status',
-            hasComments: commentsTotal > 0,
-            commentsTotal,
-            fixVersionText: formatFixVersionText(fixVersions) || 'No fix version',
-            sprintText: formatSprintText(sprints) || 'No sprint',
-            attachmentChips: buildAttachmentChips(attachments),
-            reporter: issueData.fields.reporter,
-            assignee: issueData.fields.assignee,
+            priority: issueData.fields.priority,
+            issueTypeText: displayFields.issueType ? (issueTypeName || 'No type') : '',
+            statusText: displayFields.status ? (statusName || 'No status') : '',
+            sprintText: displayFields.sprint ? (formatSprintText(sprints) || 'No sprint') : '',
+            fixVersionText: displayFields.fixVersions ? (formatFixVersionText(fixVersions) || 'No fix version') : '',
+            statusChips,
+            epicParentChips,
+            sprintChips,
+            sprintFallbackText,
+            fixVersionChips,
+            fixVersionFallbackText,
+            labelChips,
+            accountChips,
+            affectsText,
+            hasComments: displayFields.comments && commentsTotal > 0,
+            commentsTotal: displayFields.comments ? commentsTotal : 0,
+            attachmentChips: displayFields.attachments ? buildAttachmentChips(attachments) : [],
+            reporter: displayFields.reporter ? issueData.fields.reporter : null,
+            assignee: displayFields.assignee ? issueData.fields.assignee : null,
             commentUrl: INSTANCE_URL + 'browse/' + key,
+            hasFieldSummary: statusChips.length > 0 ||
+              epicParentChips.length > 0 ||
+              !!affectsText ||
+              sprintChips.length > 0 ||
+              !!sprintFallbackText ||
+              fixVersionChips.length > 0 ||
+              !!fixVersionFallbackText ||
+              labelChips.length > 0 ||
+              accountChips.length > 0,
             loaderGifUrl,
           };
           if (issueData.fields.comment?.comments?.[0]?.id) {
             displayData.commentUrl = `${displayData.url}#comment-${issueData.fields.comment.comments[0].id}`;
           }
-          if (size(pullRequests)) {
+          if (displayFields.pullRequests && size(pullRequests)) {
             displayData.prs = pullRequests.filter(function (pr) {
               return pr.url !== location.href;
             }).map(function (pr) {
@@ -738,8 +1039,11 @@ async function mainAsyncLocal() {
           if (!containerPinned) {
             container.css(computeVisibleContainerPosition(pointerX, pointerY));
           }
-        })(cancelToken);
+        })(cancelToken).catch(() => {
+          lastHoveredKey = '';
+        });
       } else if (!containerPinned) {
+        lastHoveredKey = '';
         hideTimeOut = setTimeout(hideContainer, 250);
       }
     }

--- a/jira-plugin/src/content.jsx
+++ b/jira-plugin/src/content.jsx
@@ -206,7 +206,6 @@ function notifyJiraConnectionFailure(instanceUrl, error) {
 async function mainAsyncLocal() {
   const $ = require('jquery');
   const draggable = require('jquery-ui/ui/widgets/draggable');
-  const DEBUG_CUSTOM_FIELD_ID = 'customfield_11200';
 
   const config = await getConfig();
   const INSTANCE_URL = config.instanceUrl;
@@ -271,6 +270,7 @@ async function mainAsyncLocal() {
   const issueSearchRecentCache = new Map();
   const labelSuggestionCache = new Map();
   const labelLocalOptionsCache = new Map();
+  const tempoAccountSearchCache = new Map();
   let labelSuggestionSupportPromise = null;
   let preferredAssigneeIdentifier = '';
   let editSearchRequestCounter = 0;
@@ -1247,6 +1247,7 @@ async function mainAsyncLocal() {
       const fields = [
         'description',
         'id',
+        'project',
         'reporter',
         'assignee',
         'summary',
@@ -1310,21 +1311,13 @@ async function mainAsyncLocal() {
         allowedValues: []
       };
     }
-    const result = {
+    return {
       editable: true,
       fieldKey: resolvedFieldKey,
       fieldMeta: editMetaField,
       operations: Array.isArray(editMetaField.operations) ? editMetaField.operations : [],
       allowedValues: Array.isArray(editMetaField.allowedValues) ? editMetaField.allowedValues : []
     };
-    if (resolvedFieldKey === DEBUG_CUSTOM_FIELD_ID) {
-      console.log('[JiraHotLinker][customfield_11200] getEditableFieldCapability', {
-        issueKey: issueData.key,
-        resolvedFieldKey,
-        result
-      });
-    }
-    return result;
   }
 
   async function getTransitionOptions(issueKey) {
@@ -1813,6 +1806,106 @@ async function mainAsyncLocal() {
     return `${fieldName}: ${primitive || '--'}`;
   }
 
+  function buildCustomFieldJqlOperand(value, supportDescriptor, fieldMeta) {
+    if (value === undefined || value === null || value === '') {
+      return '';
+    }
+    if (isTempoAccountField(fieldMeta)) {
+      const accountId = value?.id || value;
+      return String(accountId || '').trim();
+    }
+    if (supportDescriptor?.valueKind === 'primitive') {
+      return encodeJqlValue(String(value));
+    }
+    const comparableValue = value?.value || value?.name || value?.displayName || value?.key || value?.id;
+    return comparableValue ? encodeJqlValue(String(comparableValue)) : '';
+  }
+
+  function buildCustomFieldChipData(fieldId, fieldName, rawValue, fieldMeta, supportDescriptor) {
+    const currentValues = Array.isArray(rawValue) ? rawValue.filter(value => value !== undefined && value !== null && value !== '') : [rawValue].filter(value => value !== undefined && value !== null && value !== '');
+    const jqlValues = currentValues
+      .map(value => buildCustomFieldJqlOperand(value, supportDescriptor, fieldMeta))
+      .filter(Boolean);
+    const jqlClause = !jqlValues.length
+      ? ''
+      : jqlValues.length === 1
+        ? `${fieldName} = ${jqlValues[0]}`
+        : `${fieldName} in (${jqlValues.join(', ')})`;
+    const linkLabel = Array.isArray(rawValue)
+      ? currentValues.map(entry => getCustomFieldPrimitive(entry)).filter(Boolean).join(', ')
+      : getCustomFieldPrimitive(rawValue);
+    return buildFilterChip(buildCustomFieldValueText(fieldName, rawValue), jqlClause, {
+      linkLabel
+    });
+  }
+
+  function isTempoAccountField(fieldMeta) {
+    const schemaType = String(fieldMeta?.schema?.type || '').toLowerCase();
+    const schemaCustom = String(fieldMeta?.schema?.custom || '').toLowerCase();
+    return schemaType === 'account' || schemaCustom.includes('tempo-accounts');
+  }
+
+  function buildTempoAccountOption(account) {
+    const id = account?.id;
+    const key = String(account?.key || '').trim();
+    const name = String(account?.name || key || '').trim();
+    if (!id || !name) {
+      return null;
+    }
+    const customerName = String(account?.customer?.name || '').trim();
+    const categoryName = String(account?.category?.name || '').trim();
+    const metaText = [key, customerName, categoryName].filter(Boolean).join(' | ');
+    return buildEditOption(String(id), name, {
+      metaText,
+      searchText: `${name} ${key} ${customerName} ${categoryName}`,
+      rawValue: account
+    });
+  }
+
+  async function searchTempoAccounts(queryText, issueData) {
+    const projectId = String(issueData?.fields?.project?.id || '').trim();
+    if (!projectId) {
+      return [];
+    }
+    const normalizedQuery = String(queryText || '').trim();
+    const cacheKey = `${projectId}__${normalizedQuery.toLowerCase()}`;
+    return getCachedValue(tempoAccountSearchCache, cacheKey, async () => {
+      const tqlQuery = `status=OPEN AND (project=${projectId} OR project=GLOBAL)`;
+      const url = `${INSTANCE_URL}rest/tempo-accounts/1/account/search?tqlQuery=${encodeURIComponent(tqlQuery)}&query=${encodeURIComponent(normalizedQuery)}&limit=15&offset=0`;
+      const response = await get(url);
+      const accounts = Array.isArray(response?.accounts) ? response.accounts : [];
+      return accounts
+        .map(buildTempoAccountOption)
+        .filter(Boolean);
+    });
+  }
+
+  async function saveTempoAccountSelection(issueData, fieldId, selectedOptions) {
+    const selectedOption = selectedOptions[0];
+    if (!selectedOption?.id) {
+      throw new Error('Pick an account before saving');
+    }
+    const accountId = Number(selectedOption.id);
+    const accountKey = String(selectedOption?.rawValue?.key || '').trim();
+    const payloadCandidates = [
+      {fields: {[fieldId]: {id: accountId}}},
+      {fields: {[fieldId]: accountId}},
+      {fields: {[fieldId]: {id: String(selectedOption.id)}}},
+      ...(accountKey ? [{fields: {[fieldId]: {key: accountKey}}}] : [])
+    ];
+
+    let lastError;
+    for (const payload of payloadCandidates) {
+      try {
+        await requestJson('PUT', `${INSTANCE_URL}rest/api/2/issue/${issueData.key}`, payload);
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError || new Error('Could not update account');
+  }
+
   function getCustomFieldSupportDescriptor(fieldMeta) {
     const schemaType = String(fieldMeta?.schema?.type || '').toLowerCase();
     const itemType = String(fieldMeta?.schema?.items || '').toLowerCase();
@@ -1908,38 +2001,53 @@ async function mainAsyncLocal() {
       }));
   }
 
+  async function getCustomFieldEditorDefinition(fieldId, issueData) {
+    const capability = await getEditableFieldCapability(issueData, fieldId);
+    const fieldMeta = capability.fieldMeta;
+    const fieldName = String(issueData?.names?.[fieldId] || fieldMeta?.name || fieldId);
+
+    if (capability.editable && fieldMeta && isTempoAccountField(fieldMeta)) {
+      const currentAccount = issueData?.fields?.[fieldId];
+      const currentOption = currentAccount
+        ? buildTempoAccountOption(currentAccount)
+        : null;
+      return {
+        fieldKey: fieldId,
+        editorType: 'tempo-account-search',
+        label: fieldName,
+        fieldMeta,
+        supportDescriptor: {selectionMode: 'single', valueKind: 'tempo-account'},
+        selectionMode: 'single',
+        currentText: currentAccount ? buildCustomFieldValueText(fieldName, currentAccount) : `${fieldName}: --`,
+        currentOptionId: currentOption?.id || null,
+        currentSelections: currentOption ? [currentOption] : [],
+        initialInputValue: '',
+        inputPlaceholder: 'Search accounts',
+        loadOptions: async () => mergeEditOptions(currentOption ? [currentOption] : [], await searchTempoAccounts('', issueData)),
+        searchOptions: query => searchTempoAccounts(query, issueData),
+        save: selectedOptions => saveTempoAccountSelection(issueData, fieldId, selectedOptions),
+        successMessage: selectedOptions => {
+          const selectedOption = selectedOptions[0];
+          return selectedOption?.label
+            ? `${fieldName} set to ${selectedOption.label}`
+            : `${fieldName} updated`;
+        }
+      };
+    }
+
+    return getSupportedCustomFieldDefinition(fieldId, issueData);
+  }
+
   async function getSupportedCustomFieldDefinition(fieldId, issueData) {
     const capability = await getEditableFieldCapability(issueData, fieldId);
     const fieldMeta = capability.fieldMeta;
     const fieldName = String(issueData?.names?.[fieldId] || fieldMeta?.name || fieldId);
-    if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
-      console.log('[JiraHotLinker][customfield_11200] precheck', {
-        issueKey: issueData?.key,
-        fieldId,
-        fieldName,
-        capability,
-        fieldMeta
-      });
-    }
     if (!capability.editable || !fieldMeta || !Array.isArray(capability.allowedValues) || !capability.allowedValues.length) {
-      if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
-        console.log('[JiraHotLinker][customfield_11200] rejected-before-support-descriptor', {
-          editable: capability.editable,
-          hasFieldMeta: !!fieldMeta,
-          hasAllowedValuesArray: Array.isArray(capability.allowedValues),
-          allowedValuesLength: Array.isArray(capability.allowedValues) ? capability.allowedValues.length : null
-        });
-      }
       return null;
     }
 
     const supportDescriptor = getCustomFieldSupportDescriptor(fieldMeta);
     if (!supportDescriptor) {
-      if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
-        console.log('[JiraHotLinker][customfield_11200] rejected-support-descriptor', {
-          schema: fieldMeta?.schema
-        });
-      }
       return null;
     }
 
@@ -1957,35 +2065,15 @@ async function mainAsyncLocal() {
       .map(entry => buildCustomFieldOption(fieldName, entry))
       .filter(Boolean);
     const allOptions = mergeEditOptions(currentSelections, allowedOptions);
-    if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
-      console.log('[JiraHotLinker][customfield_11200] normalized-options', {
-        supportDescriptor,
-        operations,
-        currentValue,
-        currentSelections,
-        allowedValues: capability.allowedValues,
-        allowedOptions,
-        allOptions
-      });
-    }
 
     if (!allOptions.length) {
-      if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
-        console.log('[JiraHotLinker][customfield_11200] rejected-empty-options');
-      }
       return null;
     }
 
     if (isMultiValue && !operations.includes('set')) {
-      if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
-        console.log('[JiraHotLinker][customfield_11200] rejected-no-set-operation', {operations});
-      }
       return null;
     }
     if (!isMultiValue && !operations.includes('set')) {
-      if (fieldId === DEBUG_CUSTOM_FIELD_ID) {
-        console.log('[JiraHotLinker][customfield_11200] rejected-no-set-operation', {operations});
-      }
       return null;
     }
 
@@ -1993,6 +2081,8 @@ async function mainAsyncLocal() {
       fieldKey: fieldId,
       editorType: isMultiValue ? 'multi-select' : 'single-select',
       label: fieldName,
+      fieldMeta,
+      supportDescriptor,
       selectionMode: isMultiValue ? 'multi' : 'single',
       currentText: buildCustomFieldValueText(fieldName, currentValue),
       currentOptionId: !isMultiValue && currentSelections[0] ? currentSelections[0].id : null,
@@ -2039,10 +2129,9 @@ async function mainAsyncLocal() {
     }
     if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
       const textValue = String(entry);
-      return {
-        text: fieldName ? `${fieldName}: ${textValue}` : textValue,
-        linkUrl: ''
-      };
+      return buildFilterChip(fieldName ? `${fieldName}: ${textValue}` : textValue, `${fieldName} = ${encodeJqlValue(textValue)}`, {
+        linkLabel: textValue
+      });
     }
     const primaryText = entry.name || entry.value || entry.displayName || entry.id || entry.key;
     if (!primaryText) {
@@ -2051,10 +2140,9 @@ async function mainAsyncLocal() {
     const formattedValue = entry.key && (entry.name || entry.value)
       ? `[${entry.key}] ${entry.name || entry.value}`
       : String(primaryText);
-    return {
-      text: fieldName ? `${fieldName}: ${formattedValue}` : formattedValue,
-      linkUrl: ''
-    };
+    return buildFilterChip(fieldName ? `${fieldName}: ${formattedValue}` : formattedValue, `${fieldName} = ${encodeJqlValue(String(primaryText))}`, {
+      linkLabel: String(primaryText)
+    });
   }
   async function buildCustomFieldChips(issueData, customFields, state) {
     const names = issueData.names || {};
@@ -2066,12 +2154,15 @@ async function mainAsyncLocal() {
         continue;
       }
       const fieldName = String(names[fieldId] || fieldId);
-      const supportedDefinition = await getSupportedCustomFieldDefinition(fieldId, issueData).catch(() => null);
+      const supportedDefinition = await getCustomFieldEditorDefinition(fieldId, issueData).catch(() => null);
       if (supportedDefinition) {
-        chipsByRow[row].push(buildEditableFieldChip(fieldId, {
-          text: buildCustomFieldValueText(fieldName, rawValue),
-          linkUrl: ''
-        }, state, {
+        chipsByRow[row].push(buildEditableFieldChip(fieldId, buildCustomFieldChipData(
+          fieldId,
+          fieldName,
+          rawValue,
+          supportedDefinition.fieldMeta,
+          supportedDefinition.supportDescriptor
+        ), state, {
           canEdit: true,
           editTitle: `Edit ${fieldName}`
         }));
@@ -2081,7 +2172,12 @@ async function mainAsyncLocal() {
       entries.forEach(entry => {
         const chip = formatCustomFieldChip(fieldName, entry);
         if (chip && chip.text) {
-          chipsByRow[row].push(chip);
+          const nonEditableReason = getNonEditableFieldReason();
+          chipsByRow[row].push({
+            ...chip,
+            chipTitle: appendTooltipText(chip.chipTitle || chip.linkTitle || '', nonEditableReason),
+            linkTitle: appendTooltipText(chip.linkTitle || '', nonEditableReason)
+          });
         }
       });
     }
@@ -2199,8 +2295,19 @@ async function mainAsyncLocal() {
     return formatFixVersionText(versions);
   }
 
+  function getVisibleSprintsForDisplay(sprints) {
+    const sprintList = Array.isArray(sprints) ? sprints : [];
+    const activeSprints = sprintList.filter(sprint => String(sprint?.state || '').toLowerCase() === 'active');
+    return activeSprints.length
+      ? activeSprints
+      : (sprintList.every(sprint => String(sprint?.state || '').toLowerCase() === 'closed')
+          ? sprintList.slice(-1)
+          : sprintList);
+  }
+
   function formatSprintText(sprints) {
-    return (sprints || [])
+    const visibleSprints = getVisibleSprintsForDisplay(sprints);
+    return visibleSprints
       .map(sprint => sprint.state ? `${sprint.name} (${sprint.state})` : sprint.name)
       .filter(Boolean)
       .join(', ');
@@ -2214,11 +2321,78 @@ async function mainAsyncLocal() {
     return `${INSTANCE_URL}issues/?jql=${encodeURIComponent(jql)}`;
   }
 
+  function buildViewAllIssuesTitle(valueText) {
+    const normalizedValueText = String(valueText || '').trim();
+    return normalizedValueText
+      ? `View all "${normalizedValueText}" issues`
+      : 'View matching issues';
+  }
+
+  function ensureTooltipSentence(text) {
+    const normalizedText = String(text || '').trim();
+    if (!normalizedText) {
+      return '';
+    }
+    return /[.!?]$/.test(normalizedText)
+      ? normalizedText
+      : `${normalizedText}.`;
+  }
+
   function buildLinkHoverTitle(actionText, detailText, url) {
-    return [actionText, detailText, url]
-      .map(part => String(part || '').trim())
+    return [actionText, detailText]
+      .map(part => ensureTooltipSentence(part))
       .filter(Boolean)
       .join('\n');
+  }
+
+  function appendTooltipText(baseText, extraText) {
+    const parts = [ensureTooltipSentence(baseText), ensureTooltipSentence(extraText)].filter(Boolean);
+    return parts.join('\n\n');
+  }
+
+  function getNonEditableFieldReason() {
+    return 'Jira doesn\'t allow changing this field in the current issue state';
+  }
+
+  function constrainEditPopoversToViewport() {
+    const viewportPadding = 8;
+    container.find('._JX_edit_popover').each(function () {
+      const popover = this;
+      const anchor = popover.parentElement;
+      if (!anchor) {
+        return;
+      }
+
+      popover.style.position = '';
+      popover.style.left = '';
+      popover.style.right = '';
+      popover.style.top = '';
+      popover.style.width = '';
+      popover.style.maxWidth = '';
+
+      const maxWidth = Math.max(260, window.innerWidth - (viewportPadding * 2));
+      const popoverWidth = Math.min(320, maxWidth);
+      popover.style.maxWidth = `${maxWidth}px`;
+      popover.style.width = `${popoverWidth}px`;
+
+      const anchorRect = anchor.getBoundingClientRect();
+      const fitsRight = anchorRect.left + popoverWidth <= window.innerWidth - viewportPadding;
+      if (fitsRight) {
+        popover.style.left = '0';
+        popover.style.right = 'auto';
+        return;
+      }
+
+      const fitsLeft = anchorRect.right - popoverWidth >= viewportPadding;
+      if (fitsLeft) {
+        popover.style.left = 'auto';
+        popover.style.right = '0';
+        return;
+      }
+
+      popover.style.left = `${Math.max(viewportPadding - anchorRect.left, 0)}px`;
+      popover.style.right = 'auto';
+    });
   }
 
   function scopeJqlToProject(projectKey, clause) {
@@ -2233,7 +2407,7 @@ async function mainAsyncLocal() {
     return {
       text,
       linkUrl,
-      linkTitle: linkUrl ? buildLinkHoverTitle(extra.linkAction || 'Search Jira', text, linkUrl) : '',
+      linkTitle: linkUrl ? buildLinkHoverTitle(extra.linkAction || buildViewAllIssuesTitle(extra.linkLabel || text), extra.linkDetail || '') : '',
       ...extra
     };
   }
@@ -3106,7 +3280,7 @@ async function mainAsyncLocal() {
     }
 
     if (String(fieldKey || '').startsWith('customfield_')) {
-      const customFieldDefinition = await getSupportedCustomFieldDefinition(fieldKey, issueData);
+      const customFieldDefinition = await getCustomFieldEditorDefinition(fieldKey, issueData);
       if (customFieldDefinition) {
         return customFieldDefinition;
       }
@@ -3164,7 +3338,7 @@ async function mainAsyncLocal() {
           title: option.label
         }))
       : [];
-    const isSearchEditor = editState.editorType === 'user-search' || editState.editorType === 'issue-search' || editState.editorType === 'label-search';
+    const isSearchEditor = editState.editorType === 'user-search' || editState.editorType === 'issue-search' || editState.editorType === 'label-search' || editState.editorType === 'tempo-account-search';
     const inputDisabled = !!(editState.saving || (editState.loadingOptions && !isSearchEditor));
     const loadingText = editState.loadingOptions
       ? (isSearchEditor ? `Searching ${editState.label.toLowerCase()}...` : `Loading ${editState.label.toLowerCase()} values...`)
@@ -3196,7 +3370,12 @@ async function mainAsyncLocal() {
 
   function buildEditableFieldChip(fieldKey, baseChip, state, options = {}) {
     if (options.canEdit === false) {
-      return baseChip;
+      const nonEditableReason = options.nonEditableReason || getNonEditableFieldReason();
+      return {
+        ...baseChip,
+        chipTitle: appendTooltipText(baseChip.chipTitle || baseChip.linkTitle || '', nonEditableReason),
+        linkTitle: appendTooltipText(baseChip.linkTitle || '', nonEditableReason)
+      };
     }
     const activeEdit = buildActiveEditPresentation(fieldKey, state, {
       isRightAligned: options.isRightAligned
@@ -3206,7 +3385,8 @@ async function mainAsyncLocal() {
         ...baseChip,
         ...activeEdit,
         isEditable: true,
-        hideInlineEditButton: !!options.hideInlineEditButton
+        hideInlineEditButton: !!options.hideInlineEditButton,
+        editTitle: 'Discard'
       };
     }
     return {
@@ -3275,7 +3455,7 @@ async function mainAsyncLocal() {
       displayName,
       placeholderText: assignee ? '' : 'Unassigned',
       isEditable: !!canEditAssignee,
-      editTitle: assignee ? 'Edit assignee' : 'Assign issue',
+      editTitle: activeEdit ? 'Discard' : (assignee ? 'Edit assignee' : 'Assign issue'),
       ...(activeEdit || {})
     };
   }
@@ -3565,7 +3745,7 @@ async function mainAsyncLocal() {
       displayFields.issueType ? buildEditableFieldChip('issuetype', buildFilterChip(
         issueTypeName || 'No type',
         issueTypeName ? `${scopeJqlToProject(projectKey, `issuetype = ${encodeJqlValue(issueTypeName)}`)}` : '',
-        {iconUrl: issueData.fields.issuetype?.iconUrl || ''}
+        {iconUrl: issueData.fields.issuetype?.iconUrl || '', linkLabel: issueTypeName}
       ), state, {
         canEdit: issueTypeEditable,
         editTitle: 'Edit issue type'
@@ -3573,15 +3753,15 @@ async function mainAsyncLocal() {
       displayFields.status ? buildEditableFieldChip('status', buildFilterChip(
         statusName || 'No status',
         statusName ? `${scopeJqlToProject(projectKey, `status = ${encodeJqlValue(statusName)}`)}` : '',
-        {iconUrl: issueData.fields.status?.iconUrl || ''}
+        {iconUrl: issueData.fields.status?.iconUrl || '', linkLabel: statusName}
       ), state, {
         canEdit: statusEditable,
-        editTitle: 'Change status via transition'
+        editTitle: 'Change status'
       }) : null,
       displayFields.priority ? buildEditableFieldChip('priority', buildFilterChip(
         priorityName || 'No priority',
         priorityName ? `${scopeJqlToProject(projectKey, `priority = ${encodeJqlValue(priorityName)}`)}` : '',
-        {iconUrl: issueData.fields.priority?.iconUrl || ''}
+        {iconUrl: issueData.fields.priority?.iconUrl || '', linkLabel: priorityName}
       ), state, {
         canEdit: priorityEditable,
         editTitle: 'Edit priority'
@@ -3593,9 +3773,8 @@ async function mainAsyncLocal() {
         linkUrl: linkageData?.currentLink?.url || '',
         linkTitle: linkageData?.currentLink
           ? buildLinkHoverTitle(
-              `Open ${String(linkageData.label || 'linked').toLowerCase()} issue`,
-              linkageData.currentLink.key,
-              linkageData.currentLink.url
+              linkageData.mode === 'epicLink' ? 'View epic issue' : 'View parent issue',
+              `[${linkageData.currentLink.key}] ${linkageData.currentLink.summary}`
             )
           : ''
       }, state, {
@@ -3607,23 +3786,38 @@ async function mainAsyncLocal() {
 
     const singleAffectsVersion = affectsVersions.length === 1 ? affectsVersions[0]?.name : '';
     const singleFixVersion = fixVersions.length === 1 ? fixVersions[0]?.name : '';
+    const visibleSprints = getVisibleSprintsForDisplay(sprints);
+    const sprintClauses = visibleSprints
+      .map(sprint => sprint?.id
+        ? `sprint = ${sprint.id}`
+        : (sprint?.name ? `sprint = ${encodeJqlValue(sprint.name)}` : ''))
+      .filter(Boolean);
+    const sprintJql = sprintClauses.length
+      ? scopeJqlToProject(
+          projectKey,
+          sprintClauses.length === 1 ? sprintClauses[0] : `(${sprintClauses.join(' OR ')})`
+        )
+      : '';
     const row2Chips = [
       displayFields.sprint ? buildEditableFieldChip('sprint', buildFilterChip(
         `Sprint: ${formatSprintText(sprints) || '--'}`,
-        ''
+        sprintJql,
+        {linkLabel: visibleSprints.length > 1 ? 'listed sprints' : (formatSprintText(sprints) || '')}
       ), state, {
         canEdit: !!sprintCapability?.editable
       }) : null,
       displayFields.affects ? buildEditableFieldChip('versions', buildFilterChip(
         `Affects: ${formatVersionText(affectsVersions) || '--'}`,
-        singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : ''
+        singleAffectsVersion ? `${scopeJqlToProject(projectKey, `affectedVersion = ${encodeJqlValue(singleAffectsVersion)}`)}` : '',
+        {linkLabel: singleAffectsVersion}
       ), state, {
         canEdit: !!affectsCapability?.editable,
         isRightAligned: true
       }) : null,
       displayFields.fixVersions ? buildEditableFieldChip('fixVersions', buildFilterChip(
         `Fix version: ${formatVersionText(fixVersions) || '--'}`,
-        singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : ''
+        singleFixVersion ? `${scopeJqlToProject(projectKey, `fixVersion = ${encodeJqlValue(singleFixVersion)}`)}` : '',
+        {linkLabel: singleFixVersion}
       ), state, {
         canEdit: !!fixVersionsCapability?.editable,
         isRightAligned: true
@@ -3635,7 +3829,8 @@ async function mainAsyncLocal() {
     const row3Chips = [
       displayFields.labels ? buildEditableFieldChip('labels', buildFilterChip(
         `Labels: ${labels.filter(Boolean).join(', ') || '--'}`,
-        singleLabel ? `${scopeJqlToProject(projectKey, `labels = ${encodeJqlValue(singleLabel)}`)}` : ''
+        singleLabel ? `${scopeJqlToProject(projectKey, `labels = ${encodeJqlValue(singleLabel)}`)}` : '',
+        {linkLabel: singleLabel}
       ), state, {
         canEdit: labelsEditable,
         editTitle: 'Edit labels'
@@ -3832,6 +4027,7 @@ async function mainAsyncLocal() {
         input.setSelectionRange(selectionStart, selectionEnd);
       }
     }
+    constrainEditPopoversToViewport();
   }
   function invalidatePopupCaches() {
     if (!popupState?.key) {
@@ -3842,6 +4038,7 @@ async function mainAsyncLocal() {
     transitionOptionsCache.delete(popupState.key);
     assigneeLocalOptionsCache.delete(popupState.key);
     labelLocalOptionsCache.delete(popupState.key);
+    tempoAccountSearchCache.clear();
     issueSearchCache.clear();
     [...assigneeSearchCache.keys()].forEach(cacheKey => {
       if (String(cacheKey).startsWith(`${popupState.key}__`)) {
@@ -3948,7 +4145,7 @@ async function mainAsyncLocal() {
       if (!popupState?.editState || popupState.editState.fieldKey !== fieldKey || popupState.editState.searchRequestId !== requestId) {
         return;
       }
-      const mergedOptions = popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search'
+      const mergedOptions = popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search' || popupState.editState.editorType === 'tempo-account-search'
         ? mergeEditOptions(options, popupState.editState.options)
         : options;
       popupState = {
@@ -4060,7 +4257,7 @@ async function mainAsyncLocal() {
       }
       await renderIssuePopup(popupState);
 
-      if (popupState?.editState?.fieldKey === fieldKey && (popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search' || popupState.editState.editorType === 'label-search')) {
+      if (popupState?.editState?.fieldKey === fieldKey && (popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search' || popupState.editState.editorType === 'label-search' || popupState.editState.editorType === 'tempo-account-search')) {
         const searchRequestId = ++editSearchRequestCounter;
         popupState = {
           ...popupState,
@@ -4071,7 +4268,9 @@ async function mainAsyncLocal() {
           }
         };
         await renderIssuePopup(popupState);
-        triggerSearchOptionsForActiveEdit(fieldKey, popupState.editState.inputValue, searchRequestId);
+        if (popupState.editState.editorType !== 'label-search') {
+          triggerSearchOptionsForActiveEdit(fieldKey, popupState.editState.inputValue, searchRequestId);
+        }
       }
     } catch (error) {
       const errorMessage = buildEditFieldError(error);
@@ -4150,6 +4349,7 @@ async function mainAsyncLocal() {
     const canAutoComplete = popupState.editState.editorType !== 'user-search' &&
       popupState.editState.editorType !== 'issue-search' &&
       popupState.editState.editorType !== 'label-search' &&
+      popupState.editState.editorType !== 'tempo-account-search' &&
       popupState.editState.editorType !== 'multi-select' &&
       typeof selectionStart === 'number' &&
       typeof selectionEnd === 'number' &&
@@ -4182,7 +4382,7 @@ async function mainAsyncLocal() {
     };
     renderIssuePopup(popupState).catch(() => {});
 
-    if (popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search' || popupState.editState.editorType === 'label-search') {
+    if (popupState.editState.editorType === 'user-search' || popupState.editState.editorType === 'issue-search' || popupState.editState.editorType === 'label-search' || popupState.editState.editorType === 'tempo-account-search') {
       const searchRequestId = ++editSearchRequestCounter;
       popupState = {
         ...popupState,
@@ -4453,6 +4653,10 @@ async function mainAsyncLocal() {
     e.preventDefault();
     e.stopPropagation();
     const fieldKey = e.currentTarget.getAttribute('data-field-key') || '';
+    if (popupState?.editState?.fieldKey === fieldKey) {
+      cancelFieldEdit();
+      return;
+    }
     startFieldEdit(fieldKey).catch(() => {});
   });
 

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -216,6 +216,15 @@ body ._JX {
     }
   }
 
+  &_section_title {
+    color: #5e6c84;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    margin: 0 0 6px;
+    text-transform: uppercase;
+  }
+
   &_comments {
     border-top: 1px solid #dde4e6;
     margin-top: 6px;

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -13,18 +13,23 @@ body ._JX {
     padding: 10px 10px;
     border: 1px solid #dde4e6;
     display: flex;
+    align-items: center;
     min-width: 0;
     user-select: none;
     -webkit-user-select: none;
 
     &_users {
       display: inline-flex;
+      align-items: center;
+      flex: 0 0 auto;
       margin-left: -3px;
       margin-right: 6px;
       min-width: 20px;
     }
 
     &_user {
+      display: block;
+      flex: 0 0 20px;
       width: 20px;
       height: 20px;
       margin-right: -6px;
@@ -34,6 +39,8 @@ body ._JX {
       border: 1px solid #dfe1e6;
       border-radius: 50%;
       background: #fff;
+      object-fit: cover;
+      overflow: hidden;
     }
 
     &_user_assignee {
@@ -55,6 +62,7 @@ body ._JX {
     }
 
     #_JX_title_link {
+      flex: 1 1 auto;
       font-size: 14px;
       line-height: 1.3;
       min-width: 0;

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -93,6 +93,21 @@ body ._JX {
       min-width: 0;
     }
 
+    &_row_primary {
+      align-items: stretch;
+      flex-wrap: nowrap;
+      justify-content: space-between;
+      gap: 10px;
+    }
+
+    &_row_main {
+      display: flex;
+      flex: 1 1 auto;
+      flex-wrap: wrap;
+      gap: 6px;
+      min-width: 0;
+    }
+
     ._JX_status_icon {
       width: 14px;
       height: 14px;
@@ -139,30 +154,27 @@ body ._JX {
     }
   }
 
-  &_related_pr {
-    max-height: 300px;
-    overflow-y: auto;
-    overflow-x: hidden;
-    border-bottom: 1px solid rgb(221, 228, 230);
+  &_activity_strip {
+    align-items: center;
+    border-left: 1px solid #d9e1ea;
+    color: #52657a;
+    display: inline-flex;
+    flex: 0 0 auto;
+    gap: 10px;
+    padding-left: 10px;
+    white-space: nowrap;
+  }
 
-    td {
-      padding: 10px;
-      border-bottom: 1px solid #dde4e6;
-      min-width: 0;
-      overflow-wrap: anywhere;
-      word-break: break-word;
-    }
+  &_activity_item {
+    align-items: center;
+    display: inline-flex;
+    font-size: 12px;
+    gap: 4px;
+  }
 
-    table {
-      width: 100%;
-      table-layout: fixed;
-    }
-
-    thead td {
-      border-bottom: 1px solid #dde4e6;
-      text-transform: capitalize;
-      font-weight: bold;
-    }
+  &_activity_item strong {
+    font-size: 12px;
+    font-weight: 700;
   }
 
   &_description {
@@ -230,6 +242,59 @@ body ._JX {
     letter-spacing: 0.05em;
     margin: 0 0 6px;
     text-transform: uppercase;
+  }
+
+  &_related_pr {
+    border-top: 1px solid #dde4e6;
+    margin-top: 6px;
+    padding-top: 4px;
+    min-width: 0;
+    font-size: 12px;
+    line-height: 1.35;
+
+    a {
+      font-size: 12px;
+    }
+
+    td {
+      padding: 8px 10px;
+      border-bottom: 1px solid #dde4e6;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+      vertical-align: top;
+    }
+
+    table {
+      width: 100%;
+      table-layout: fixed;
+      border-collapse: collapse;
+    }
+
+    thead td {
+      border-bottom: 1px solid #dde4e6;
+      color: #5e6c84;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    tbody td:first-child {
+      width: 42%;
+    }
+
+    tbody td:nth-child(2) {
+      width: 18%;
+    }
+
+    tbody td:nth-child(3) {
+      width: 24%;
+    }
+
+    tbody td:nth-child(4) {
+      width: 16%;
+    }
   }
 
   &_comments {
@@ -348,11 +413,6 @@ body ._JX {
     color: #172b4d !important;
   }
 
-  &_avatar {
-    width: 20px;
-    height: 20px;
-  }
-
   &_PR_STATUS {
     border: 1px solid #a5b3c2;
     border-radius: 3px;
@@ -458,6 +518,23 @@ body ._JX {
     cursor: pointer !important;
   }
 }
+@media (max-width: 640px) {
+  body ._JX {
+    &_status_row_primary {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    &_activity_strip {
+      border-left: none;
+      border-top: 1px solid #d9e1ea;
+      padding-left: 0;
+      padding-top: 8px;
+      width: 100%;
+    }
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   body ._JX {
     &_container {

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -80,11 +80,18 @@ body ._JX {
     background-color: #f2f8fa;
     border-bottom: 1px solid #dde4e6;
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: 6px;
     padding: 8px;
     user-select: none;
     -webkit-user-select: none;
+
+    &_row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      min-width: 0;
+    }
 
     ._JX_status_icon {
       width: 14px;
@@ -323,7 +330,8 @@ body ._JX {
     border: 1px solid #dfe1e6;
     border-radius: 20px;
     color: #172b4d;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     font-size: 12px;
     line-height: 18px;
     padding: 2px 10px;

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -42,28 +42,15 @@ body ._JX {
     background-color: #f2f8fa;
     border-bottom: 1px solid #dde4e6;
     display: flex;
-
-    > div,
-    > a {
-      flex-grow: 1;
-      justify-content: space-evenly;
-      border-right: 1px solid #dde4e6;
-      padding: 5px 10px;
-
-      &:last-child {
-        border-right: none;
-      }
-    }
-
-    > a {
-      text-decoration: none !important;
-    }
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px;
 
     ._JX_status_icon {
-      position: relative;
-      top: 3px;
-      margin-right: 3px;
-      width: 16px;
+      width: 14px;
+      height: 14px;
+      margin-right: 4px;
+      vertical-align: text-bottom;
     }
   }
 
@@ -133,6 +120,20 @@ body ._JX {
       padding-left: 15px;
       margin-bottom: 15px;
     }
+
+    &_text img {
+      max-width: 100%;
+      max-height: 180px;
+      height: auto;
+      width: auto;
+    }
+
+    &_attachments {
+      border-top: 1px solid #dde4e6;
+      margin-top: 10px;
+      padding-top: 8px;
+      overflow: hidden;
+    }
   }
 
   &_field_group {
@@ -163,6 +164,15 @@ body ._JX {
     font-size: 12px;
     line-height: 18px;
     padding: 2px 10px;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &_field_chip_link {
+    text-decoration: none !important;
+    color: #172b4d !important;
   }
 
   &_avatar {

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -56,6 +56,43 @@ body ._JX {
       margin-left: 8px;
     }
 
+    &_user_placeholder {
+      align-items: center;
+      color: #5e6c84;
+      display: inline-flex;
+      font-size: 11px;
+      font-weight: 700;
+      justify-content: center;
+    }
+
+    &_assignee_slot {
+      align-items: center;
+      display: inline-flex;
+      position: relative;
+    }
+
+    &_assignee_slot.is-editing {
+      z-index: 30;
+    }
+
+    &_assignee_slot ._JX_assignee_edit_button {
+      margin-left: 2px;
+    }
+
+    &_copy {
+      color: #172b4d;
+      background-color: transparent;
+      border: none;
+      cursor: pointer;
+      vertical-align: middle;
+      position: relative;
+      top: 2px;
+
+      &:hover {
+        color: #8993a4;
+      }
+    }
+
     &_copy {
       padding: 0;
     }
@@ -798,6 +835,8 @@ body ._JX {
 
   &_field_chip_editable_group:hover ._JX_field_chip_edit,
   &_field_chip_editable_group.is-editing ._JX_field_chip_edit,
+  &_title_assignee_slot:hover ._JX_field_chip_edit,
+  &_title_assignee_slot.is-editing ._JX_field_chip_edit,
   &_field_chip_edit:focus-visible {
     opacity: 1;
   }
@@ -821,6 +860,11 @@ body ._JX {
     top: calc(100% + 8px);
     width: 320px;
     z-index: 40;
+  }
+
+  &_assignee_edit_popover {
+    left: 0;
+    top: calc(100% + 6px);
   }
 
   &_edit_popover_right {
@@ -948,6 +992,23 @@ body ._JX {
     background: #e9f2ff;
   }
 
+  &_edit_option_icon,
+  &_edit_option_avatar {
+    border-radius: 50%;
+    flex: 0 0 auto;
+    height: 16px;
+    object-fit: cover;
+    width: 16px;
+  }
+
+  &_edit_option_text {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
   &_edit_option_check {
     color: #0c66e4;
     display: inline-flex;
@@ -958,7 +1019,18 @@ body ._JX {
   }
 
   &_edit_option_label {
+    line-height: 1.2;
     min-width: 0;
+  }
+
+  &_edit_option_meta {
+    color: #6b778c;
+    font-size: 11px;
+    line-height: 1.2;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &_edit_actions {

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -718,9 +718,14 @@ body ._JX {
 
   &_comment_actions {
     display: flex;
-    gap: 8px;
-    justify-content: flex-end;
+    align-items: center;
+    justify-content: space-between;
     margin-top: 8px;
+  }
+
+  &_comment_actions_buttons {
+    display: flex;
+    gap: 8px;
   }
 
   &_comment_save,
@@ -1249,4 +1254,25 @@ body ._JX {
   }
 }
 
+body ._JX {
+  &_footer_settings {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: #8993a4;
+    text-decoration: none;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
 
+    &:hover {
+      color: #5e6c84;
+    }
+
+    svg {
+      opacity: 0.7;
+    }
+  }
+}

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -28,6 +28,7 @@ body ._JX {
       color: #172b4d;
       background-color: transparent;
       border: none;
+      cursor: pointer;
       vertical-align: middle;
       position: relative;
       top: 2px;
@@ -35,6 +36,11 @@ body ._JX {
       &:hover {
         color: #8993a4;
       }
+    }
+
+    #_JX_title_link {
+      font-size: 14px;
+      line-height: 1.3;
     }
   }
 
@@ -57,6 +63,7 @@ body ._JX {
   &_annotation {
     max-width: 600px;
     color: #24292f;
+    font-family: 'Nunito', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     border: 1px solid #dde4e6;
     border-radius: 3px;
     background-color: white;
@@ -122,10 +129,16 @@ body ._JX {
     }
 
     &_text img {
+      cursor: pointer;
       max-width: 100%;
       max-height: 180px;
       height: auto;
       width: auto;
+    }
+
+    &_text {
+      font-size: 14px;
+      line-height: 1.35;
     }
 
     &_attachments {
@@ -133,6 +146,53 @@ body ._JX {
       margin-top: 10px;
       padding-top: 8px;
       overflow: hidden;
+    }
+  }
+
+  &_comments {
+    border-top: 1px solid #dde4e6;
+    margin-top: 6px;
+    padding-top: 4px;
+  }
+
+  &_comment {
+    border-bottom: 1px solid #dde4e6;
+    margin-bottom: 4px;
+    padding-bottom: 4px;
+
+    &:last-child {
+      border-bottom: none;
+      margin-bottom: 0;
+      padding-bottom: 0;
+    }
+  }
+
+  &_comment_meta {
+    color: #5e6c84;
+    font-size: 11px;
+    margin-bottom: 3px;
+    text-align: left;
+  }
+
+  &_comment_author {
+    color: #172b4d;
+    font-weight: bold;
+  }
+
+  &_comment_body {
+    font-size: 14px;
+    line-height: 1.35;
+    word-break: break-word;
+
+    a {
+      text-decoration: underline;
+    }
+
+    img {
+      cursor: pointer;
+      display: block;
+      margin-top: 6px;
+      max-width: 100%;
     }
   }
 
@@ -219,17 +279,34 @@ body ._JX {
     margin: 5px;
     border: 1px solid rgb(221, 228, 230) !important;
     cursor: pointer;
-    height: 145px;
-    width: 200px;
+    height: auto;
+    width: auto;
+    max-width: 100%;
     position: relative;
     overflow: hidden;
+
+    a,
+    img {
+      cursor: pointer !important;
+    }
+
+    > a > img:not(._JX_file_loader) {
+      display: block;
+      height: auto;
+      max-height: 100px;
+      max-width: 100%;
+      width: auto;
+    }
   }
 
   &_thumb_filename {
     position: absolute;
     white-space: nowrap;
-    width: 200px;
+    width: 100%;
     background-color: white;
+    color: #172b4d;
+    font-size: 14px;
+    line-height: 18px;
     max-height: 20px;
     text-overflow: ellipsis;
     overflow: hidden;
@@ -242,6 +319,30 @@ body ._JX {
     top: 23%;
     left: 35%;
     position: absolute;
+  }
+
+  &_preview_overlay {
+    align-items: center;
+    background: rgba(0, 0, 0, 0.84);
+    display: none;
+    inset: 0;
+    justify-content: center;
+    position: fixed;
+    z-index: 2147483647;
+
+    &.is-open {
+      display: flex;
+    }
+  }
+
+  &_preview_image {
+    max-height: 96vh;
+    max-width: 96vw;
+    object-fit: contain;
+  }
+
+  img._JX_previewable {
+    cursor: pointer !important;
   }
 }
 @media (prefers-color-scheme: dark) {

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -47,20 +47,17 @@ body ._JX {
       margin-right: 0;
     }
 
-    &_copy {
-      color: #172b4d;
-      background-color: transparent;
-      border: none;
-      cursor: pointer;
-      vertical-align: middle;
-      position: relative;
-      top: 2px;
-
-      &:hover {
-        color: #8993a4;
-      }
+    &_controls {
+      display: inline-flex;
+      align-items: center;
+      flex: 0 0 auto;
+      gap: 6px;
+      margin-left: 8px;
     }
 
+    &_copy {
+      padding: 0;
+    }
     #_JX_title_link {
       flex: 1 1 auto;
       font-size: 14px;
@@ -71,7 +68,131 @@ body ._JX {
     }
   }
 
-  &_subtitle {
+  &_control_button {
+    align-items: center;
+    appearance: none;
+    background: linear-gradient(180deg, #fff 0%, #f4f7fb 100%);
+    border: 1px solid #c4d2df;
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(9, 30, 66, 0.08);
+    color: #44546f;
+    cursor: pointer;
+    display: inline-flex;
+    gap: 3px;
+    height: 30px;
+    justify-content: center;
+    min-width: 30px;
+    padding: 0 8px;
+    transition: background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease, color 120ms ease, transform 120ms ease;
+
+    &:hover {
+      background: #eef4fb;
+      border-color: #8eb3da;
+      color: #1f4f82;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #4c9aff;
+      outline-offset: 2px;
+    }
+
+    &:active {
+      transform: translateY(1px);
+    }
+
+    svg {
+      display: block;
+    }
+  }
+
+  &_actions {
+    position: relative;
+    flex: 0 0 auto;
+  }
+
+  &_actions_toggle {
+    padding-right: 6px;
+
+    &.is-open {
+      background: linear-gradient(180deg, #d8e9ff 0%, #eef5ff 100%);
+      border-color: #76a4d5;
+      box-shadow: 0 0 0 3px rgba(76, 154, 255, 0.14);
+      color: #0c4a7a;
+    }
+
+    &.is-open ._JX_actions_toggle_chevron {
+      transform: rotate(180deg);
+    }
+  }
+
+  &_actions_toggle_chevron {
+    opacity: 0.72;
+    transition: transform 120ms ease;
+  }
+
+  &_actions_menu {
+    background: #fff;
+    border: 1px solid #c7d5e3;
+    border-radius: 10px;
+    box-shadow: 0 14px 32px rgba(9, 30, 66, 0.16), 0 2px 6px rgba(9, 30, 66, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 220px;
+    padding: 8px;
+    position: absolute;
+    right: 0;
+    top: calc(100% + 8px);
+    z-index: 3;
+
+    &::before {
+      background: #fff;
+      border-left: 1px solid #c7d5e3;
+      border-top: 1px solid #c7d5e3;
+      content: '';
+      height: 10px;
+      position: absolute;
+      right: 11px;
+      top: -6px;
+      transform: rotate(45deg);
+      width: 10px;
+    }
+  }
+
+  &_action_divider {
+    border-top: 1px solid #d7e1ec;
+    margin: 6px 4px;
+  }
+
+  &_action_item {
+    appearance: none;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    color: #172b4d;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.3;
+    padding: 9px 11px;
+    text-align: left;
+    transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+
+    &:hover {
+      background: #eef4fb;
+      border-color: #c7daee;
+      color: #0c4a7a;
+    }
+
+    &.is-loading,
+    &.is-disabled,
+    &:disabled {
+      background: #f4f5f7;
+      border-color: transparent;
+      color: #7a869a;
+      cursor: wait;
+    }
+  }  &_subtitle {
     border-top: none;
     padding-left: 36px;
   }
@@ -177,6 +298,22 @@ body ._JX {
     font-weight: 700;
   }
 
+  &_action_notice {
+    border-bottom: 1px solid #dde4e6;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 8px 10px;
+  }
+
+  &_action_notice_success {
+    background: #edf9f1;
+    color: #18693d;
+  }
+
+  &_action_notice_error {
+    background: #fff3f1;
+    color: #ae2e24;
+  }
   &_description {
     max-height: 400px;
     overflow-y: auto;
@@ -564,3 +701,6 @@ body ._JX {
     }
   }
 }
+
+
+

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -14,6 +14,8 @@ body ._JX {
     border: 1px solid #dde4e6;
     display: flex;
     min-width: 0;
+    user-select: none;
+    -webkit-user-select: none;
 
     &_users {
       display: inline-flex;
@@ -73,6 +75,8 @@ body ._JX {
     flex-wrap: wrap;
     gap: 6px;
     padding: 8px;
+    user-select: none;
+    -webkit-user-select: none;
 
     ._JX_status_icon {
       width: 14px;
@@ -86,6 +90,8 @@ body ._JX {
     max-width: 600px;
     width: min(600px, calc(100vw - 24px));
     overflow-x: hidden;
+    user-select: text;
+    -webkit-user-select: text;
     color: #24292f;
     font-family: 'Nunito', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     border: 1px solid #dde4e6;
@@ -172,6 +178,9 @@ body ._JX {
       line-height: 1.35;
       overflow-wrap: anywhere;
       word-break: break-word;
+      white-space: normal;
+      user-select: text;
+      -webkit-user-select: text;
 
       a {
         overflow-wrap: anywhere;
@@ -180,6 +189,14 @@ body ._JX {
 
       * {
         max-width: 100%;
+        min-width: 0;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+
+      pre,
+      code {
+        white-space: pre-wrap;
       }
     }
 
@@ -227,6 +244,9 @@ body ._JX {
     line-height: 1.35;
     overflow-wrap: anywhere;
     word-break: break-word;
+    white-space: normal;
+    user-select: text;
+    -webkit-user-select: text;
 
     a {
       font-size: 11px;
@@ -244,6 +264,14 @@ body ._JX {
 
     * {
       max-width: 100%;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    pre,
+    code {
+      white-space: pre-wrap;
     }
   }
 

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -2,6 +2,7 @@ body ._JX {
   &_container {
     position: absolute;
     z-index: 99999;
+    width: max-content;
 
     &.container-pinned {
       position: fixed !important;
@@ -30,12 +31,12 @@ body ._JX {
 
     &_user {
       display: block;
-      flex: 0 0 20px;
-      width: 20px;
-      height: 20px;
+      flex: 0 0 32px;
+      width: 32px;
+      height: 32px;
       margin-right: -6px;
       align-self: center;
-      min-width: 20px;
+      min-width: 32px;
       margin-top: -2px;
       border: 1px solid #dfe1e6;
       border-radius: 50%;
@@ -77,20 +78,6 @@ body ._JX {
 
     &_assignee_slot ._JX_assignee_edit_button {
       margin-left: 2px;
-    }
-
-    &_copy {
-      color: #172b4d;
-      background-color: transparent;
-      border: none;
-      cursor: pointer;
-      vertical-align: middle;
-      position: relative;
-      top: 2px;
-
-      &:hover {
-        color: #8993a4;
-      }
     }
 
     &_copy {
@@ -259,6 +246,8 @@ body ._JX {
       flex-wrap: nowrap;
       justify-content: space-between;
       gap: 10px;
+      padding-bottom: 6px;
+      border-bottom: 1px solid #d0dbe5;
     }
 
     &_row_main {
@@ -478,6 +467,10 @@ body ._JX {
     tbody td:nth-child(4) {
       width: 16%;
     }
+
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
   }
 
   &_comments {
@@ -521,7 +514,7 @@ body ._JX {
     -webkit-user-select: text;
 
     a {
-      font-size: 11px;
+      font-size: 12px;
       text-decoration: underline;
       overflow-wrap: anywhere;
       word-break: break-word;
@@ -535,6 +528,7 @@ body ._JX {
     }
 
     * {
+      font-size: 12px;
       max-width: 100%;
       min-width: 0;
       overflow-wrap: anywhere;
@@ -1168,7 +1162,7 @@ body ._JX {
     width: 100%;
     background-color: white;
     color: #172b4d;
-    font-size: 14px;
+    font-size: 12px;
     line-height: 18px;
     max-height: 20px;
     text-overflow: ellipsis;

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -364,6 +364,77 @@ body ._JX {
     }
   }
 
+  &_comments_empty {
+    color: #5e6c84;
+    font-size: 12px;
+    margin-bottom: 8px;
+  }
+
+  &_comment_compose {
+    border-top: 1px solid #dde4e6;
+    margin-top: 10px;
+    padding-top: 10px;
+  }
+
+  &_comment_input {
+    border: 1px solid #c7d1db;
+    border-radius: 6px;
+    font: inherit;
+    min-height: 78px;
+    padding: 8px 10px;
+    resize: vertical;
+    width: 100%;
+  }
+
+  &_comment_error {
+    color: #ae2e24;
+    font-size: 12px;
+    font-weight: 700;
+    min-height: 18px;
+    padding-top: 6px;
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  &_comment_actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 8px;
+  }
+
+  &_comment_save,
+  &_comment_discard {
+    appearance: none;
+    border: 1px solid #c7d1db;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1;
+    padding: 8px 12px;
+  }
+
+  &_comment_save {
+    background: #1f6feb;
+    border-color: #1f6feb;
+    color: #fff;
+  }
+
+  &_comment_discard {
+    background: #fff;
+    color: #253858;
+  }
+
+  &_comment_save:disabled,
+  &_comment_discard:disabled {
+    background: #f3f4f6;
+    border-color: #d7dde5;
+    color: #7a869a;
+    cursor: not-allowed;
+  }
   &_empty_body {
     color: #5e6c84;
     font-size: 13px;
@@ -564,3 +635,4 @@ body ._JX {
     }
   }
 }
+

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -135,6 +135,36 @@ body ._JX {
     }
   }
 
+  &_field_group {
+    padding: 10px;
+    border-bottom: 1px solid #dde4e6;
+  }
+
+  &_field_label {
+    color: #5e6c84;
+    font-size: 12px;
+    font-weight: bold;
+    margin-bottom: 6px;
+    text-transform: uppercase;
+  }
+
+  &_field_values {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  &_field_chip {
+    background: #ebecf0;
+    border: 1px solid #dfe1e6;
+    border-radius: 20px;
+    color: #172b4d;
+    display: inline-block;
+    font-size: 12px;
+    line-height: 18px;
+    padding: 2px 10px;
+  }
+
   &_avatar {
     width: 20px;
     height: 20px;

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -15,6 +15,7 @@ body ._JX {
     display: flex;
     align-items: center;
     min-width: 0;
+    overflow: visible;
     user-select: none;
     -webkit-user-select: none;
 
@@ -83,6 +84,7 @@ body ._JX {
     flex-direction: column;
     gap: 6px;
     padding: 8px;
+    overflow: visible;
     user-select: none;
     -webkit-user-select: none;
 
@@ -91,6 +93,7 @@ body ._JX {
       flex-wrap: wrap;
       gap: 6px;
       min-width: 0;
+      overflow: visible;
     }
 
     &_row_primary {
@@ -106,6 +109,7 @@ body ._JX {
       flex-wrap: wrap;
       gap: 6px;
       min-width: 0;
+      overflow: visible;
     }
 
     ._JX_status_icon {
@@ -119,7 +123,7 @@ body ._JX {
   &_annotation {
     max-width: 600px;
     width: min(600px, calc(100vw - 24px));
-    overflow-x: hidden;
+    overflow: visible;
     user-select: text;
     -webkit-user-select: text;
     color: #24292f;
@@ -180,7 +184,7 @@ body ._JX {
   &_description {
     max-height: 400px;
     overflow-y: auto;
-    overflow-x: hidden;
+    overflow: visible;
     border-bottom: 1px solid #dde4e6;
     overflow-wrap: anywhere;
     word-break: break-word;
@@ -398,6 +402,7 @@ body ._JX {
     display: inline-flex;
     align-items: center;
     font-size: 12px;
+    gap: 4px;
     line-height: 18px;
     padding: 2px 10px;
     max-width: 100%;
@@ -413,6 +418,181 @@ body ._JX {
     color: #172b4d !important;
   }
 
+  &_field_chip_content {
+    min-width: 0;
+  }
+
+  &_field_chip_editable_group {
+    overflow: visible;
+    padding-right: 4px;
+    position: relative;
+  }
+
+  &_field_chip_editable_group.is-editing {
+    z-index: 20;
+  }
+
+  &_field_chip_edit {
+    align-items: center;
+    background: transparent;
+    border: none;
+    border-radius: 999px;
+    color: #52657a;
+    cursor: pointer;
+    display: inline-flex;
+    flex: 0 0 auto;
+    height: 20px;
+    justify-content: center;
+    margin-left: 2px;
+    opacity: 0;
+    padding: 0;
+    transition: opacity 0.12s ease, background-color 0.12s ease, color 0.12s ease;
+    width: 20px;
+  }
+
+  &_field_chip_editable_group:hover ._JX_field_chip_edit,
+  &_field_chip_editable_group.is-editing ._JX_field_chip_edit,
+  &_field_chip_edit:focus-visible {
+    opacity: 1;
+  }
+
+  &_field_chip_edit:hover {
+    background: #dfe1e6;
+    color: #172b4d;
+  }
+
+  &_edit_popover {
+    background: #fff;
+    border: 1px solid #d0d7de;
+    border-radius: 10px;
+    box-shadow: 0 14px 30px rgba(15, 23, 42, 0.18);
+    color: #172b4d;
+    left: 0;
+    min-width: 320px;
+    max-width: min(360px, calc(100vw - 48px));
+    padding: 10px;
+    position: absolute;
+    top: calc(100% + 8px);
+    width: 320px;
+    z-index: 40;
+  }
+
+  &_edit_popover_right {
+    left: auto;
+    right: 0;
+  }
+
+  &_edit_field_label {
+    color: #5e6c84;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    margin-bottom: 6px;
+    text-transform: uppercase;
+  }
+
+  &_edit_input_shell {
+    align-items: stretch;
+    display: flex;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  &_edit_input {
+    background: #fff;
+    border: 1px solid #7a869a;
+    border-radius: 6px;
+    color: #172b4d;
+    flex: 1 1 auto;
+    font-family: inherit;
+    font-size: 12px;
+    line-height: 16px;
+    min-width: 0;
+    padding: 7px 9px;
+  }
+
+  &_edit_input::placeholder {
+    color: #6b778c;
+    opacity: 1;
+  }
+
+  &_edit_input:focus {
+    border-color: #0c66e4;
+    box-shadow: 0 0 0 2px rgba(12, 102, 228, 0.18);
+    outline: none;
+  }
+
+  &_edit_cancel {
+    background: #f7f8f9;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    color: #344563;
+    cursor: pointer;
+    flex: 0 0 auto;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 16px;
+    padding: 7px 10px;
+  }
+
+  &_edit_cancel:hover {
+    background: #ebecf0;
+  }
+
+  &_edit_dropdown {
+    background: #fff;
+    border: 1px solid #d0d7de;
+    border-radius: 8px;
+    box-shadow: inset 0 1px 0 rgba(9, 30, 66, 0.04);
+    display: flex;
+    flex-direction: column;
+    margin-top: 8px;
+    max-height: 220px;
+    overflow-y: auto;
+  }
+
+  &_edit_option {
+    background: transparent;
+    border: none;
+    color: #172b4d;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 12px;
+    line-height: 16px;
+    padding: 9px 10px;
+    text-align: left;
+  }
+
+  &_edit_option:hover,
+  &_edit_option.is-selected {
+    background: #e9f2ff;
+  }
+
+  &_edit_empty,
+  &_edit_hint,
+  &_edit_error {
+    font-size: 12px;
+    line-height: 1.4;
+  }
+
+  &_edit_hint,
+  &_edit_error {
+    margin-top: 6px;
+  }
+
+  &_edit_empty,
+  &_edit_hint {
+    color: #5e6c84;
+  }
+
+  &_edit_empty {
+    padding: 9px 10px;
+  }
+
+  &_edit_error {
+    color: #c9372c;
+  }
   &_PR_STATUS {
     border: 1px solid #a5b3c2;
     border-radius: 3px;
@@ -564,3 +744,5 @@ body ._JX {
     }
   }
 }
+
+

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -14,14 +14,27 @@ body ._JX {
     border: 1px solid #dde4e6;
     display: flex;
 
+    &_users {
+      display: inline-flex;
+      margin-left: -3px;
+      margin-right: 6px;
+      min-width: 20px;
+    }
+
     &_user {
       width: 20px;
       height: 20px;
-      margin-right: 6px;
-      margin-left: -3px;
+      margin-right: -6px;
       align-self: center;
       min-width: 20px;
       margin-top: -2px;
+      border: 1px solid #dfe1e6;
+      border-radius: 50%;
+      background: #fff;
+    }
+
+    &_user_assignee {
+      margin-right: 0;
     }
 
     &_copy {
@@ -42,6 +55,11 @@ body ._JX {
       font-size: 14px;
       line-height: 1.3;
     }
+  }
+
+  &_subtitle {
+    border-top: none;
+    padding-left: 36px;
   }
 
   &_status {
@@ -185,6 +203,7 @@ body ._JX {
     word-break: break-word;
 
     a {
+      font-size: 11px;
       text-decoration: underline;
     }
 

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -376,6 +376,10 @@ body ._JX {
     padding-top: 10px;
   }
 
+  &_comment_input_wrap {
+    position: relative;
+  }
+
   &_comment_input {
     border: 1px solid #c7d1db;
     border-radius: 6px;
@@ -384,6 +388,62 @@ body ._JX {
     padding: 8px 10px;
     resize: vertical;
     width: 100%;
+  }
+
+  &_comment_mentions {
+    background: #fff;
+    border: 1px solid #c7d1db;
+    border-radius: 8px;
+    box-shadow: 0 10px 18px rgba(9, 30, 66, 0.12);
+    margin-top: 6px;
+    max-height: 210px;
+    overflow-y: auto;
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  &_comment_mentions_status {
+    color: #5e6c84;
+    font-size: 12px;
+    padding: 9px 10px;
+  }
+
+  &_comment_mention_option {
+    align-items: center;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    border-top: 1px solid #ebecf0;
+    cursor: pointer;
+    display: flex;
+    gap: 8px;
+    padding: 9px 10px;
+    text-align: left;
+    width: 100%;
+
+    &:first-child {
+      border-top: none;
+    }
+
+    &.is-selected {
+      background: #e9f2ff;
+    }
+  }
+
+  &_comment_mention_primary {
+    color: #172b4d;
+    display: block;
+    font-size: 12px;
+    font-weight: 700;
+  }
+
+  &_comment_mention_secondary {
+    color: #5e6c84;
+    display: block;
+    font-size: 11px;
+    margin-top: 2px;
   }
 
   &_comment_error {
@@ -435,6 +495,18 @@ body ._JX {
     color: #7a869a;
     cursor: not-allowed;
   }
+
+  &_mention {
+    background: #e9f2ff;
+    border-radius: 999px;
+    color: #0c66e4;
+    display: inline-flex;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 1px 8px;
+    vertical-align: middle;
+  }
+
   &_empty_body {
     color: #5e6c84;
     font-size: 13px;
@@ -635,4 +707,5 @@ body ._JX {
     }
   }
 }
+
 

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -284,7 +284,7 @@ body ._JX {
     max-height: calc(100vh - 16px);
     max-width: 600px;
     width: min(600px, calc(100vw - 24px));
-    overflow: hidden;
+    overflow: visible;
     user-select: text;
     -webkit-user-select: text;
     color: #24292f;
@@ -569,15 +569,35 @@ body ._JX {
   }
 
   &_comment_input {
+    background: #fff;
     border: 1px solid #c7d1db;
     box-sizing: border-box;
     border-radius: 6px;
-    font: inherit;
+    color: #172b4d;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.45;
     min-height: 78px;
     max-width: 100%;
     padding: 8px 10px;
     resize: vertical;
     width: 100%;
+  }
+
+  &_comment_input::placeholder {
+    color: #6b778c;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.45;
+    opacity: 1;
+  }
+
+  &_comment_input:focus {
+    border-color: #0c66e4;
+    box-shadow: 0 0 0 2px rgba(12, 102, 228, 0.16);
+    outline: none;
   }
 
   &_comment_mentions {
@@ -715,9 +735,10 @@ body ._JX {
     border: 1px solid #c7d1db;
     border-radius: 999px;
     cursor: pointer;
-    font-size: 12px;
+    font-family: inherit;
+    font-size: 13px;
     font-weight: 700;
-    line-height: 1;
+    line-height: 1.2;
     padding: 8px 12px;
   }
 
@@ -853,12 +874,12 @@ body ._JX {
     box-shadow: 0 14px 30px rgba(15, 23, 42, 0.18);
     color: #172b4d;
     left: 0;
-    min-width: 320px;
+    min-width: 260px;
     max-width: min(360px, calc(100vw - 48px));
     padding: 10px;
     position: absolute;
     top: calc(100% + 8px);
-    width: 320px;
+    width: min(320px, calc(100vw - 48px));
     z-index: 40;
   }
 

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -13,6 +13,7 @@ body ._JX {
     padding: 10px 10px;
     border: 1px solid #dde4e6;
     display: flex;
+    min-width: 0;
 
     &_users {
       display: inline-flex;
@@ -54,6 +55,9 @@ body ._JX {
     #_JX_title_link {
       font-size: 14px;
       line-height: 1.3;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
   }
 
@@ -80,6 +84,8 @@ body ._JX {
 
   &_annotation {
     max-width: 600px;
+    width: min(600px, calc(100vw - 24px));
+    overflow-x: hidden;
     color: #24292f;
     font-family: 'Nunito', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     border: 1px solid #dde4e6;
@@ -114,16 +120,21 @@ body ._JX {
 
   &_related_pr {
     max-height: 300px;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     border-bottom: 1px solid rgb(221, 228, 230);
 
     td {
       padding: 10px;
       border-bottom: 1px solid #dde4e6;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
 
     table {
       width: 100%;
+      table-layout: fixed;
     }
 
     thead td {
@@ -135,9 +146,11 @@ body ._JX {
 
   &_description {
     max-height: 400px;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     border-bottom: 1px solid #dde4e6;
-    word-wrap: break-word;
+    overflow-wrap: anywhere;
+    word-break: break-word;
     padding: 10px;
 
     ol,
@@ -157,6 +170,17 @@ body ._JX {
     &_text {
       font-size: 14px;
       line-height: 1.35;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+
+      a {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+
+      * {
+        max-width: 100%;
+      }
     }
 
     &_attachments {
@@ -171,6 +195,7 @@ body ._JX {
     border-top: 1px solid #dde4e6;
     margin-top: 6px;
     padding-top: 4px;
+    min-width: 0;
   }
 
   &_comment {
@@ -200,11 +225,14 @@ body ._JX {
   &_comment_body {
     font-size: 14px;
     line-height: 1.35;
+    overflow-wrap: anywhere;
     word-break: break-word;
 
     a {
       font-size: 11px;
       text-decoration: underline;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
 
     img {
@@ -213,6 +241,17 @@ body ._JX {
       margin-top: 6px;
       max-width: 100%;
     }
+
+    * {
+      max-width: 100%;
+    }
+  }
+
+  &_empty_body {
+    color: #5e6c84;
+    font-size: 13px;
+    line-height: 1.4;
+    padding: 2px 0;
   }
 
   &_field_group {
@@ -246,7 +285,9 @@ body ._JX {
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   &_field_chip_link {

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -117,6 +117,9 @@ body ._JX {
   }
 
   &_annotation {
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 16px);
     max-width: 600px;
     width: min(600px, calc(100vw - 24px));
     overflow-x: hidden;
@@ -178,7 +181,9 @@ body ._JX {
   }
 
   &_description {
-    max-height: 400px;
+    flex: 1 1 auto;
+    max-height: none;
+    min-height: 0;
     overflow-y: auto;
     overflow-x: hidden;
     border-bottom: 1px solid #dde4e6;
@@ -446,6 +451,60 @@ body ._JX {
     margin-top: 2px;
   }
 
+  &_comment_uploads {
+    display: grid;
+    gap: 8px;
+    margin-top: 8px;
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  &_comment_upload {
+    align-items: center;
+    background: #f7f8fa;
+    border: 1px solid #dfe1e6;
+    border-radius: 8px;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 52px 1fr;
+    padding: 8px;
+
+    &.is-error {
+      background: #fff5f5;
+      border-color: #f1c0c0;
+    }
+  }
+
+  &_comment_upload_preview {
+    background: #fff;
+    border: 1px solid #dfe1e6;
+    border-radius: 6px;
+    display: block;
+    height: 52px;
+    object-fit: cover;
+    width: 52px;
+  }
+
+  &_comment_upload_name {
+    color: #172b4d;
+    display: block;
+    font-size: 12px;
+    font-weight: 700;
+  }
+
+  &_comment_upload_status {
+    color: #5e6c84;
+    display: block;
+    font-size: 11px;
+    margin-top: 2px;
+  }
+
+  &_comment_upload.is-error &_comment_upload_status {
+    color: #ae2e24;
+  }
+
   &_comment_error {
     color: #ae2e24;
     font-size: 12px;
@@ -707,5 +766,6 @@ body ._JX {
     }
   }
 }
+
 
 

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -247,7 +247,7 @@ body ._JX {
     max-height: calc(100vh - 16px);
     max-width: 600px;
     width: min(600px, calc(100vw - 24px));
-    overflow: visible;
+    overflow: hidden;
     user-select: text;
     -webkit-user-select: text;
     color: #24292f;
@@ -323,10 +323,10 @@ body ._JX {
   }
   &_description {
     flex: 1 1 auto;
-    max-height: none;
+    max-height: min(520px, calc(100vh - 220px));
     min-height: 0;
     overflow-y: auto;
-    overflow: visible;
+    overflow-x: hidden;
     border-bottom: 1px solid #dde4e6;
     overflow-wrap: anywhere;
     word-break: break-word;
@@ -517,9 +517,14 @@ body ._JX {
   }
 
   &_comment_compose {
+    background: #fff;
     border-top: 1px solid #dde4e6;
-    margin-top: 10px;
-    padding-top: 10px;
+    bottom: -10px;
+    box-shadow: 0 -10px 18px rgba(9, 30, 66, 0.08);
+    margin: 10px -10px -10px;
+    padding: 10px;
+    position: sticky;
+    z-index: 2;
   }
 
   &_comment_input_wrap {
@@ -528,9 +533,11 @@ body ._JX {
 
   &_comment_input {
     border: 1px solid #c7d1db;
+    box-sizing: border-box;
     border-radius: 6px;
     font: inherit;
     min-height: 78px;
+    max-width: 100%;
     padding: 8px 10px;
     resize: vertical;
     width: 100%;
@@ -1083,3 +1090,5 @@ body ._JX {
     }
   }
 }
+
+

--- a/jira-plugin/src/content.scss
+++ b/jira-plugin/src/content.scss
@@ -868,7 +868,8 @@ body ._JX {
     outline: none;
   }
 
-  &_edit_cancel {
+  &_edit_cancel,
+  &_edit_discard {
     background: #f7f8f9;
     border: 1px solid #d0d7de;
     border-radius: 6px;
@@ -882,8 +883,37 @@ body ._JX {
     padding: 7px 10px;
   }
 
-  &_edit_cancel:hover {
+  &_edit_cancel:hover,
+  &_edit_discard:hover {
     background: #ebecf0;
+  }
+
+  &_edit_cancel:disabled,
+  &_edit_discard:disabled,
+  &_edit_save:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+
+  &_edit_selected_values {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 8px;
+  }
+
+  &_edit_selected_chip {
+    background: #e9f2ff;
+    border: 1px solid #bcd6f7;
+    border-radius: 999px;
+    color: #12315b;
+    font-size: 12px;
+    line-height: 16px;
+    max-width: 100%;
+    overflow: hidden;
+    padding: 4px 10px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &_edit_dropdown {
@@ -899,12 +929,15 @@ body ._JX {
   }
 
   &_edit_option {
+    align-items: center;
     background: transparent;
     border: none;
     color: #172b4d;
     cursor: pointer;
+    display: flex;
     font-family: inherit;
     font-size: 12px;
+    gap: 8px;
     line-height: 16px;
     padding: 9px 10px;
     text-align: left;
@@ -913,6 +946,44 @@ body ._JX {
   &_edit_option:hover,
   &_edit_option.is-selected {
     background: #e9f2ff;
+  }
+
+  &_edit_option_check {
+    color: #0c66e4;
+    display: inline-flex;
+    flex: 0 0 14px;
+    font-size: 12px;
+    font-weight: 700;
+    justify-content: center;
+  }
+
+  &_edit_option_label {
+    min-width: 0;
+  }
+
+  &_edit_actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 8px;
+  }
+
+  &_edit_save {
+    background: #0c66e4;
+    border: 1px solid #0c66e4;
+    border-radius: 6px;
+    color: #fff;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 16px;
+    padding: 7px 12px;
+  }
+
+  &_edit_save:hover {
+    background: #0055cc;
+    border-color: #0055cc;
   }
 
   &_edit_empty,

--- a/jira-plugin/src/snack.js
+++ b/jira-plugin/src/snack.js
@@ -3,9 +3,16 @@ import {waitForDocument} from 'src/utils';
 
 waitForDocument(() => require('src/snack.scss'));
 
-export function snackBar(message, timeout = 6000) {
+let activeSnackElement = null;
+let activeSnackTimer = null;
+
+function getOrCreateSnack() {
   const $ = require('jquery');
-  const content = $(`
+  if (activeSnackElement && activeSnackElement.length) {
+    return activeSnackElement;
+  }
+
+  activeSnackElement = $(`
       <div class="_JX_snack">
           <div class="_JX_snack_icon">
             <img src="${chrome.runtime.getURL('resources/jiralink128.png')}" class="_JX_snack_icon_img" />
@@ -13,11 +20,21 @@ export function snackBar(message, timeout = 6000) {
           <div class="_JX_snack_message"></div>
       </div>
   `);
+  $(document.body).append(activeSnackElement);
+  return activeSnackElement;
+}
+
+export function snackBar(message, timeout = 6000) {
+  const content = getOrCreateSnack();
   content.find('._JX_snack_message').text(message || '');
-  $('._JX_snack').removeClass('_JX_snack_show');
-  $(document.body).append(content);
   content.addClass('_JX_snack_show');
-  setTimeout(function () {
-    content.removeClass('_JX_snack_show').on('transitionend', () => content.remove());
+
+  if (activeSnackTimer) {
+    clearTimeout(activeSnackTimer);
+  }
+
+  activeSnackTimer = setTimeout(function () {
+    content.removeClass('_JX_snack_show');
+    activeSnackTimer = null;
   }, timeout);
 }

--- a/jira-plugin/src/snack.js
+++ b/jira-plugin/src/snack.js
@@ -10,9 +10,10 @@ export function snackBar(message, timeout = 6000) {
           <div class="_JX_snack_icon">
             <img src="${chrome.runtime.getURL('resources/jiralink128.png')}" class="_JX_snack_icon_img" />
           </div>
-          <div class="_JX_snack_message">${message}</div>
+          <div class="_JX_snack_message"></div>
       </div>
   `);
+  content.find('._JX_snack_message').text(message || '');
   $('._JX_snack').removeClass('_JX_snack_show');
   $(document.body).append(content);
   content.addClass('_JX_snack_show');

--- a/jira-plugin/src/snack.scss
+++ b/jira-plugin/src/snack.scss
@@ -8,10 +8,6 @@ body ._JX {
     min-width: 50px;
     transform: translateX(-50%) translateY(100%) translateY(20px) !important;
     transition: transform 300ms !important;
-    &_show {
-      transition: transform 150ms !important;
-      transform: translateX(-50%) !important;
-    }
     background-color: #444444;
     padding: 14px 20px;
     border-radius: 50px;
@@ -19,6 +15,11 @@ body ._JX {
     border: 2px solid white;
     font-size: 16px;
     line-height: 22px;
+
+    &_show {
+      transition: transform 150ms !important;
+      transform: translateX(-50%) !important;
+    }
 
     &_icon {
       box-sizing: border-box !important;

--- a/jira-plugin/src/snack.scss
+++ b/jira-plugin/src/snack.scss
@@ -6,8 +6,7 @@ body ._JX {
     left: 50%;
     min-height: 30px;
     min-width: 50px;
-    transform: translateX(-50%) translateY(100%) translateY(20px) !important;
-    transition: transform 300ms !important;
+    transform: translateX(-50%) !important;
     background-color: #444444;
     padding: 14px 20px;
     border-radius: 50px;
@@ -15,10 +14,10 @@ body ._JX {
     border: 2px solid white;
     font-size: 16px;
     line-height: 22px;
+    display: none;
 
     &_show {
-      transition: transform 150ms !important;
-      transform: translateX(-50%) !important;
+      display: block;
     }
 
     &_icon {
@@ -32,6 +31,7 @@ body ._JX {
       border-radius: 30px;
       width: 39px;
       height: 39px;
+
       &_img {
         width: 27px;
         background-color: white;
@@ -40,6 +40,7 @@ body ._JX {
         left: 6px;
       }
     }
+
     &_message {
       margin-left: 40px;
       color: white;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2518,9 +2518,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5217,9 +5217,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5522,9 +5522,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-hot-linker",
-  "version": "1.7.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-hot-linker",
-      "version": "1.7.1",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "7.17.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,14 +24,14 @@
         "eslint-plugin-react": "7.28.0",
         "jquery": "3.6.0",
         "jquery-ui": "1.14.1",
-        "lodash": "4.17.21",
+        "lodash": "4.17.23",
         "mustache": "4.2.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "sass": "1.89.2",
         "sass-loader": "16.0.5",
         "style-loader": "3.3.1",
-        "webpack": "5.101.0",
+        "webpack": "5.105.4",
         "webpack-bundle-analyzer": "4.5.0",
         "webpack-cli": "4.9.2"
       }
@@ -1855,9 +1855,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.10.tgz",
-      "integrity": "sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2245,13 +2245,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -2469,9 +2469,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2553,9 +2553,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2881,6 +2881,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -2938,9 +2951,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -2958,10 +2971,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001726",
-        "electron-to-chromium": "^1.5.173",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3038,9 +3052,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001776",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
+      "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
       "dev": true,
       "funding": [
         {
@@ -3450,9 +3464,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.192",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.192.tgz",
-      "integrity": "sha512-rP8Ez0w7UNw/9j5eSXCe10o1g/8B1P5SM90PCCMVkIRQn2R0LEHWz4Eh9RnxkniuDe1W0cTSOB3MLlkTGDcuCg==",
+      "version": "1.5.307",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
+      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "dev": true,
       "license": "ISC"
     },
@@ -3467,14 +3481,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
-      "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -3583,9 +3597,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4038,9 +4052,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true,
       "funding": [
         {
@@ -5320,13 +5334,17 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/loader-utils": {
@@ -5371,9 +5389,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5595,9 +5613,9 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6111,16 +6129,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -6420,27 +6428,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6613,16 +6600,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/set-function-length": {
@@ -7040,24 +7017,28 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
-      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terser": {
-      "version": "5.43.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
-      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -7069,16 +7050,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
+      "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -7104,9 +7084,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7141,9 +7121,9 @@
       "license": "MIT"
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7329,9 +7309,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7380,9 +7360,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -7435,9 +7415,9 @@
       "license": "MIT"
     },
     "node_modules/watchpack": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7449,9 +7429,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.0.tgz",
-      "integrity": "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==",
+      "version": "5.105.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
+      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7461,25 +7441,25 @@
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.24.0",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.2",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.20.0",
+        "es-module-lexer": "^2.0.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
+        "loader-runner": "^4.3.1",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.3.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.17",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.4"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -7601,9 +7581,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7611,9 +7591,9 @@
       }
     },
     "node_modules/webpack/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7672,9 +7652,9 @@
       "license": "MIT"
     },
     "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@babel/preset-react": "7.16.7",
         "babel-eslint": "10.0.2",
         "babel-loader": "8.2.3",
-        "babel-plugin-lodash": "3.3.4",
         "bluebird": "3.7.2",
         "clipboard": "2.0.10",
         "css-loader": "6.6.0",
@@ -2816,20 +2815,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/babel-plugin-lodash": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
-      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0-beta.49",
-        "@babel/types": "^7.0.0-beta.49",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "require-package-name": "^2.0.1"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,21 @@
   "main": " ",
   "scripts": {
     "analyze": "webpack -p --bail --profile --json > stats.json || webpack-bundle-analyzer stats.json",
+    "build": "webpack --mode=development",
     "dev": "webpack --watch --mode=development",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "pwcli": ".agents/skills/openai-skills-playwright/scripts/playwright_cli.sh",
+    "test": "npm run test:e2e",
+    "test:e2e": "npm run test:e2e:extension",
+    "test:e2e:all": "node scripts/playwright/run-with-blob.js",
+    "test:e2e:extension": "node scripts/playwright/run-with-blob.js --project=extension",
+    "test:e2e:public": "node scripts/playwright/run-with-blob.js --project=public-jira",
+    "test:e2e:live": "node scripts/playwright/run-with-blob.js --project=live-jira",
+    "test:e2e:auth:live": "node scripts/playwright/capture-live-auth.js",
+    "test:e2e:headed": "node scripts/playwright/run-with-blob.js --headed",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:merge-report": "node scripts/playwright/merge-reports.js",
+    "test:e2e:show-report": "playwright show-report tests/output/playwright/report",
+    "test:e2e:reset-report-data": "node scripts/playwright/reset-reports.js"
   },
   "repository": {
     "type": "git",
@@ -23,6 +36,8 @@
     "@babel/core": "7.17.5",
     "@babel/preset-env": "7.16.11",
     "@babel/preset-react": "7.16.7",
+    "@playwright/cli": "^0.1.1",
+    "@playwright/test": "^1.58.2",
     "babel-eslint": "10.0.2",
     "babel-loader": "8.2.3",
     "bluebird": "3.7.2",
@@ -45,4 +60,3 @@
     "webpack-cli": "4.9.2"
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-hot-linker",
-  "version": "1.7.1",
+  "version": "2.0.0",
   "description": "Jira HotLinker, quick access to Jira metadata when hovering over ticket numbers!",
   "main": " ",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
     "eslint-plugin-react": "7.28.0",
     "jquery": "3.6.0",
     "jquery-ui": "1.14.1",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "mustache": "4.2.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "sass": "1.89.2",
+    "sass-loader": "16.0.5",
     "style-loader": "3.3.1",
-    "webpack": "5.101.0",
+    "webpack": "5.105.4",
     "webpack-bundle-analyzer": "4.5.0",
-    "webpack-cli": "4.9.2",
-    "sass-loader": "16.0.5"
+    "webpack-cli": "4.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@babel/preset-react": "7.16.7",
     "babel-eslint": "10.0.2",
     "babel-loader": "8.2.3",
-    "babel-plugin-lodash": "3.3.4",
     "bluebird": "3.7.2",
     "clipboard": "2.0.10",
     "css-loader": "6.6.0",
@@ -46,3 +45,4 @@
     "webpack-cli": "4.9.2"
   }
 }
+

--- a/plans/adaptive-pr-discovery-plan.md
+++ b/plans/adaptive-pr-discovery-plan.md
@@ -1,0 +1,370 @@
+# Adaptive PR Discovery Plan
+
+## Goal
+
+Make pull request rendering resilient across Jira deployments, git providers, and on-prem integration setups by:
+
+- discovering a working Jira development-data endpoint at runtime
+- discovering a working `applicationType` at runtime
+- caching the resolved strategy per Jira instance
+- ensuring PR lookup failures never break the main hover popup
+
+## Current Problems
+
+1. PR fetching is effectively hardcoded to one endpoint and one `applicationType`.
+2. Jira Server/Data Center development APIs are private and differ across deployments.
+3. Some instances expose summary counts but not PR details on the same route.
+4. When discovery logic is mixed directly into popup rendering, regressions can break the whole hover flow.
+
+## Non-Goals
+
+- Do not query GitHub, GitLab, or Bitbucket directly.
+- Do not build provider-specific logic based on hostnames alone.
+- Do not block popup rendering while running large endpoint scans on every hover.
+
+## Desired Runtime Behavior
+
+### Scenario A: Known working Jira instance
+
+- Hover starts.
+- Core issue data loads.
+- Cached PR strategy is reused immediately.
+- PR list is fetched using the cached strategy.
+- If fetch fails once, mark strategy as suspect and continue without PRs.
+
+### Scenario B: First run on a Jira instance
+
+- Hover starts.
+- Core issue data loads.
+- No cached PR strategy exists.
+- Run a bounded discovery sequence.
+- Cache the first working strategy.
+- Render PRs if found; otherwise render popup without PRs.
+
+### Scenario C: Jira knows PR counts but details are unavailable
+
+- Summary endpoint returns pull request count > 0.
+- All detail endpoints return empty or error.
+- Popup renders without PR rows.
+- Debug state records that Jira exposes summary-only development data.
+
+### Scenario D: Endpoint/applicationType changed after Jira upgrade
+
+- Cached strategy starts failing.
+- Mark strategy stale.
+- Re-run discovery.
+- Replace cache entry if a new working strategy is found.
+
+## Proposed Architecture
+
+### 1. Introduce a PR discovery layer
+
+Add a small module-level strategy abstraction in `jira-plugin/src/content.jsx` or extract into a dedicated helper file:
+
+```js
+{
+  endpointVariant: 'dev-status-1-detail',
+  applicationType: 'gitlabselfmanaged',
+  dataType: 'pullrequest',
+  responseShape: 'detail.pullRequests',
+  discoveredAt: 1772850000000,
+  lastVerifiedAt: 1772850000000
+}
+```
+
+This object represents the resolved Jira-specific PR fetch strategy.
+
+### 2. Separate three concerns
+
+Implement three distinct layers:
+
+- `fetchCoreIssueData(issueKey)`
+  - required for popup rendering
+- `discoverPullRequestStrategy(issueId)`
+  - optional, bounded, cached
+- `fetchPullRequests(issueId, strategy)`
+  - optional, normalized, failure-tolerant
+
+Core issue rendering must never depend on discovery success.
+
+### 3. Define endpoint candidates explicitly
+
+Create a fixed ordered candidate list.
+
+Initial detail candidates:
+
+```text
+/rest/dev-status/1.0/issue/detail
+/rest/dev-status/latest/issue/detail
+/rest/dev-status/1.0/issue/details
+/rest/dev-status/latest/issue/details
+```
+
+Initial summary candidates:
+
+```text
+/rest/dev-status/1.0/issue/summary
+/rest/dev-status/latest/issue/summary
+```
+
+Each endpoint candidate should define:
+
+- path template
+- required query params
+- expected response roots (`detail`, `details`, `summary`)
+- whether it is for `summary` or `detail`
+
+### 4. Define application type candidates explicitly
+
+Use a bounded ordered list:
+
+```text
+(none)
+gitlabselfmanaged
+gitlab
+github
+bitbucket
+stash
+```
+
+Rules:
+
+- Summary probes should run without `applicationType` first.
+- Detail probes should test `(none)` first, then provider values.
+- Stop probing after the first candidate that returns parseable PR objects.
+
+### 5. Add response normalization
+
+Implement a single normalization function for all development responses:
+
+```js
+normalizePullRequestPayload(response) => {
+  pullRequests: [],
+  summaryCount: number | null,
+  source: {
+    root: 'detail',
+    shape: 'detail[0].pullRequests'
+  }
+}
+```
+
+Normalization should inspect, in order:
+
+- `response.detail[].pullRequests`
+- `response.detail[].pullrequests`
+- `response.details[].pullRequests`
+- `response.details[].pullrequests`
+- single-object variants with `pullRequests`
+- fallback empty result
+
+This function should never throw.
+
+### 6. Define “working” strategy criteria
+
+A detail strategy is considered working if:
+
+- the HTTP request succeeds, and
+- the response shape is parseable, and
+- either:
+  - PR objects are present, or
+  - the endpoint returns a valid development wrapper consistently
+
+A summary strategy is considered useful if:
+
+- the HTTP request succeeds, and
+- a pull request count can be read from the response
+
+Store summary and detail strategies separately if necessary.
+
+## Caching Design
+
+### Cache keys
+
+Cache by Jira instance origin, not by issue:
+
+```text
+prStrategy::<jira-origin>
+prSummaryStrategy::<jira-origin>
+```
+
+Example:
+
+```text
+prStrategy::https://jira.asseco-see.hr
+```
+
+### Cache payload
+
+```js
+{
+  endpointPath: '/rest/dev-status/1.0/issue/detail',
+  applicationType: 'gitlabselfmanaged',
+  responseShape: 'detail.pullRequests',
+  verified: true,
+  discoveredAt: 1772850000000,
+  lastVerifiedAt: 1772850300000,
+  failureCount: 0
+}
+```
+
+### Cache invalidation
+
+- Reuse cached strategy for up to 7 days.
+- If a cached strategy fails 2 consecutive times, mark it stale.
+- When stale, run discovery again.
+- If discovery still fails, keep popup working and suppress PRs.
+
+## Implementation Steps
+
+### Phase 1: Stabilize current code paths
+
+1. Move all PR fetching behind a single safe wrapper:
+   - `safeFetchPullRequests(issueData, instanceUrl)`
+2. Guarantee this wrapper always resolves to:
+   - `[]`
+   - or a normalized PR array
+3. Ensure all popup rendering uses only the normalized array.
+
+### Phase 2: Build discovery primitives
+
+1. Add endpoint candidate definitions.
+2. Add application type candidate definitions.
+3. Add request builders:
+   - `buildDevStatusSummaryUrl(issueId, endpointVariant)`
+   - `buildDevStatusDetailUrl(issueId, endpointVariant, applicationType)`
+4. Add normalization helpers for summary and detail responses.
+
+### Phase 3: Add strategy discovery
+
+1. Try cached detail strategy first.
+2. If missing or stale, run discovery:
+   - probe summary endpoints first
+   - probe detail endpoints second
+3. Record:
+   - which endpoint succeeded
+   - which `applicationType` succeeded
+   - which response shape matched
+
+### Phase 4: Integrate with popup rendering
+
+1. Load issue data as today.
+2. Start PR fetch in optional flow after issue data.
+3. If PR fetch completes before render cutoff, include PRs.
+4. If not, render popup without PRs.
+5. Optional enhancement:
+   - patch PR rows into already-open popup when late result arrives
+
+### Phase 5: Add diagnostics
+
+Keep debug logging behind a single toggle:
+
+- default off in normal builds
+- enabled by:
+  - local constant
+  - or options flag
+
+Log only:
+
+- chosen strategy
+- failed candidate count
+- summary count if available
+- normalized PR count
+
+Avoid always logging full raw JSON in normal usage.
+
+## Suggested Code Changes
+
+### `jira-plugin/src/content.jsx`
+
+Primary work:
+
+- replace hardcoded PR URL construction
+- add strategy discovery and cache lookup
+- add normalized PR extraction
+- make popup rendering independent from PR fetch failures
+
+Suggested functions:
+
+```js
+getInstanceStrategyCacheKey(instanceUrl)
+getSummaryStrategyCacheKey(instanceUrl)
+loadCachedPullRequestStrategy(instanceUrl)
+storeCachedPullRequestStrategy(instanceUrl, strategy)
+buildDevStatusUrl(issueId, endpointPath, query)
+normalizePullRequestPayload(response)
+normalizePullRequestSummary(response)
+discoverPullRequestStrategy(issueId, instanceUrl)
+safeFetchPullRequests(issueId, instanceUrl)
+```
+
+### `jira-plugin/options/config.js`
+
+Optional future enhancement:
+
+- add `debugPullRequests: false`
+
+This allows enabling diagnostics without shipping noisy logs by default.
+
+### `jira-plugin/options/options.jsx`
+
+Optional future enhancement:
+
+- add a checkbox for `Enable PR debug logging`
+
+This is not required for the first implementation.
+
+## Failure Handling Rules
+
+These rules should remain strict:
+
+1. PR fetch failure must never prevent popup render.
+2. Discovery failure must not retry endlessly on every mousemove.
+3. Unknown response shapes must be logged only in debug mode.
+4. Empty PR results are acceptable if Jira integration is partial.
+
+## Testing Plan
+
+### Manual scenarios
+
+1. Jira instance with working GitHub integration
+   - expect PRs displayed
+2. Jira instance with self-managed GitLab integration
+   - expect discovery to settle on correct endpoint/applicationType
+3. Jira instance with no development integration
+   - expect popup with no PRs and no regression
+4. Jira instance where summary works but details do not
+   - expect popup with no PRs, summary diagnostics only
+5. Temporary Jira outage
+   - expect popup failure only if core issue fetch fails
+   - PR logic should not alter behavior
+
+### Regression checks
+
+- hover popup still appears on Outlook pages
+- no console exceptions from PR logic
+- issue rendering works when PR field is disabled
+- strategy cache is reused between hovers
+
+## Rollout Strategy
+
+### Step 1
+
+Restore robust non-breaking PR fetch behavior.
+
+### Step 2
+
+Implement adaptive endpoint and `applicationType` discovery behind debug logging.
+
+### Step 3
+
+Once validated on the target Jira instance, reduce logging noise and keep only compact strategy diagnostics.
+
+## Expected Result
+
+After this work, the extension should:
+
+- continue showing the popup reliably
+- adapt to different Jira dev-status endpoint variants
+- adapt to different `applicationType` values
+- avoid hardcoding provider assumptions where possible
+- degrade gracefully when Jira exposes incomplete development data

--- a/plans/add-comment-poc-plan.md
+++ b/plans/add-comment-poc-plan.md
@@ -1,0 +1,103 @@
+# Add Comment POC Plan
+## Branch
+poc/add-comment-from-popup
+## Goal
+Allow users to create a Jira comment directly from the hover popup, with save/discard controls and immediate rendering of the new comment on success.
+## Scope
+V1 includes:
+- textarea at bottom of comments section
+- Save and Discard buttons
+- buttons disabled when textarea is empty
+- comment POST to Jira
+- success appends rendered comment locally or via refresh
+- failure shows error and preserves typed content
+V1 excludes:
+- mentions autocomplete
+- markdown toolbar
+- attachments in comments
+- draft persistence across popup close
+## UX
+Placement:
+- bottom of the comments block
+- if there are no comments, still show composer below the empty comments area when comments are enabled
+Behavior:
+- empty textarea: buttons disabled
+- non-empty textarea: Save and Discard active
+- Save -> loading state
+- success:
+  - append new comment to bottom of list
+  - clear textarea
+  - keep popup open
+- Discard -> clear textarea and clear inline error
+- failure:
+  - show inline error
+  - keep text intact
+## Jira/API Strategy
+Likely endpoint:
+- POST /rest/api/2/issue/{issueKey}/comment
+Payload:
+`json
+{ "body": "comment text" }
+`
+Server/DC compatibility note:
+- start with plain-text body
+- do not depend on Atlassian Document Format
+Optional enhancement:
+- after success, refetch comments from issue endpoint instead of constructing local comment object by hand
+## Architecture Changes
+### Background layer
+Extend [background.js](/D:/Jira-HotLinker/jira-plugin/src/background.js):
+- add generic authenticated JSON write request support if quick-actions branch has not already added it
+### Content layer
+Extend [content.jsx](/D:/Jira-HotLinker/jira-plugin/src/content.jsx):
+- add local composer state:
+  - text
+  - saving
+  - error
+- add submit handler
+- add discard handler
+- add success rerender logic
+Preferred success path:
+1. POST comment
+2. refetch issue data for same key
+3. rebuild comments list using existing rendering path
+4. rerender popup
+This avoids duplicating comment formatting logic.
+### Template/CSS
+Update:
+- [annotation.html](/D:/Jira-HotLinker/jira-plugin/resources/annotation.html)
+- [content.scss](/D:/Jira-HotLinker/jira-plugin/src/content.scss)
+Need:
+- textarea
+- save/discard buttons
+- inline error/saving state
+- styling consistent with current popup
+## State Model
+Suggested runtime state:
+`js
+{
+  commentDraft: '',
+  commentSaving: false,
+  commentError: ''
+}
+`
+## Success Criteria
+- users can type and submit a comment from the popup
+- failed saves do not lose text
+- successful saves appear immediately in the popup
+- popup remains open throughout
+## Implementation Order
+1. Add generic write request support in background
+2. Add comment composer markup and styling
+3. Add textarea/button state handling
+4. POST comment to Jira
+5. On success, refetch issue and rerender comments
+6. Add inline error handling and polish
+## Testing
+- save valid comment -> appears at bottom
+- save empty comment -> blocked in UI
+- network/Jira error -> error shown, text preserved
+- multi-line comment -> preserved correctly
+- popup remains responsive after repeated saves
+## Notes
+This is the cleanest write POC because comment creation uses a standard Jira API and already maps naturally onto the existing popup layout.

--- a/plans/clickable-labels-plan.md
+++ b/plans/clickable-labels-plan.md
@@ -1,0 +1,46 @@
+# Clickable Labels Plan
+
+## Goal
+- In display mode, make each label clickable to a JQL search.
+- Make the `Labels` label text clickable to a combined `labels in (...)` JQL search.
+
+## JQL Rules
+- Per label:
+
+```text
+project = "<PROJECT>" AND labels = "<LABEL>"
+```
+
+- Header link:
+
+```text
+project = "<PROJECT>" AND labels in ("a", "b", "c")
+```
+
+## Rendering Strategy
+- Keep Mustache structured data.
+- Replace the single labels chip string with a composite labels chip model:
+  - header link
+  - label items
+  - separators
+- Preserve current labels edit mode and show non-link text while editing.
+
+## Code Areas
+- `jira-plugin/src/content.jsx`
+  - build labels composite chip model
+  - reuse existing JQL escaping and URL helpers
+- `jira-plugin/resources/annotation.html`
+  - add labels-specific display branch inside row-3 rendering
+- `jira-plugin/src/content.scss`
+  - minor spacing/separator styling if needed
+
+## Risks
+- Template complexity increases slightly.
+- Need to ensure labels with quotes, commas, or slashes are escaped correctly.
+- Header query should dedupe truthy labels.
+
+## Tests
+- each label renders as a link
+- header `Labels` renders as a link
+- JQL is encoded correctly
+- labels edit mode still works

--- a/plans/comment-edit-delete-plan.md
+++ b/plans/comment-edit-delete-plan.md
@@ -1,0 +1,58 @@
+# Comment Edit/Delete Plan
+
+## Goal
+- Allow users to edit and delete their own comments from the popup.
+
+## Jira API
+- Edit comment:
+  - `PUT /rest/api/2/issue/{issueKey}/comment/{commentId}`
+- Delete comment:
+  - `DELETE /rest/api/2/issue/{issueKey}/comment/{commentId}`
+
+Edit payload:
+
+```json
+{
+  "body": "updated comment text"
+}
+```
+
+## Ownership Detection
+- Use comment author from `issueData.fields.comment.comments`.
+- Compare against current user using existing Jira user comparison logic.
+- Extend comment display models to retain:
+  - `id`
+  - raw `body`
+  - author identity
+  - `isOwnedByCurrentUser`
+
+## UX
+- Show `Edit` and `Delete` actions only on owned comments.
+- Allow only one comment edit session at a time.
+- Replace comment body with an inline textarea while editing.
+- Use inline delete confirmation, not `window.confirm()`.
+
+## Refresh Strategy
+- After successful edit or delete, invalidate cached issue data and rerender via existing popup refresh flow.
+
+## Code Areas
+- `jira-plugin/src/content.jsx`
+  - enrich comment view model
+  - add comment edit/delete state
+  - add save/cancel/delete handlers
+- `jira-plugin/resources/annotation.html`
+  - add action buttons and inline editor/confirm states
+- `jira-plugin/src/content.scss`
+  - style comment action controls and editor
+
+## Risks
+- Current comment composer is partly DOM/global-state driven; edit/delete should use popup state for stability.
+- Jira permissions may still reject updates even for apparently owned comments.
+- Need to avoid collisions with the existing new-comment composer.
+
+## Tests
+- owned comments show actions
+- non-owned comments do not
+- edit success updates rendered body after refresh
+- delete success removes comment
+- failure preserves draft and shows error

--- a/plans/comment-reactions-plan.md
+++ b/plans/comment-reactions-plan.md
@@ -1,0 +1,60 @@
+# Comment Reactions Plan
+
+## Goal
+- Add emoji reactions to comments in the popup.
+
+## Current Discovery
+- The target Jira instance appears to expose a private endpoint:
+  - `POST /rest/internal/2/reactions`
+- Observed payload:
+
+```json
+{
+  "commentId": "545039",
+  "emojiId": "1f44d"
+}
+```
+
+## Implementation Status
+- Feasible in principle.
+- Experimental because this is a Jira internal API, not a stable public API.
+
+## Required Verification Before Full Build
+- confirm read/list endpoint for existing reactions
+- confirm whether the same endpoint toggles, adds only, or needs a delete endpoint
+- confirm response shape for optimistic UI updates
+- confirm whether extension requests need extra CSRF handling or page-context fetch
+
+## Expected UI
+- Show a compact reaction bar under each comment.
+- Support a small initial emoji set, e.g. thumbs up, eyes, laugh.
+- Highlight the current user's selected reactions.
+
+## Code Areas
+- `jira-plugin/src/content.jsx`
+  - preserve `comment.id`
+  - load reaction metadata per comment
+  - add reaction click handlers and local state
+- `jira-plugin/resources/annotation.html`
+  - reaction bar markup per comment
+- `jira-plugin/src/content.scss`
+  - reaction pill/button styles
+- `jira-plugin/src/background.js`
+  - possibly extend request transport for private/internal endpoints and CSRF headers
+
+## Risks
+- Private API may break across Jira upgrades.
+- Background fetch may not match browser page behavior for internal endpoints.
+- Read endpoint is still unknown.
+- Toggle/remove semantics are still unknown.
+
+## Recommended Build Order
+- Start with endpoint verification and read-path discovery.
+- Only proceed to UI once create/read/toggle behavior is confirmed from extension context.
+
+## Tests
+- render existing reactions
+- add reaction
+- toggle/remove reaction
+- handle request failures without corrupting UI state
+- hide reaction UI if endpoint verification fails

--- a/plans/edit-mode-poc-plan.md
+++ b/plans/edit-mode-poc-plan.md
@@ -1,0 +1,408 @@
+# Edit Mode POC Plan
+## Branch
+poc/edit-mode
+
+## Goal
+Allow users to edit selected Jira fields directly from the hover popup with field-appropriate inline controls, clear save/discard behavior, and immediate popup refresh after a successful write.
+
+## Current Implemented State
+Already implemented on this branch:
+- Fix versions: bounded multi-select from project versions, explicit Save / Discard
+- Affects versions: bounded multi-select from project versions, explicit Save / Discard
+- Sprint: single-select from active/future sprint candidates, inline save flow
+- Shared popup rerender path after save
+- Inline error handling and loading state
+
+## Requirement Review
+### High-confidence next fields
+These have a defensible Jira read/write path and fit the popup well:
+- Priority
+- Status, but only via allowed transitions
+- Assignee
+
+### Medium-confidence fields
+These are feasible, but need tighter product and API decisions first:
+- Parent, but split into two distinct cases:
+  - true `parent` for sub-tasks / parent-linked issue types
+  - `Epic Link` style linkage for standard issues on classic Jira projects
+
+### Low-confidence or separate-spike fields
+These should not be treated as straightforward next-inline edits:
+- Issue Type
+  - challenge: Jira issue type changes are often a move operation, not a normal field update
+  - recommendation: treat as a separate spike, not part of the normal edit-mode rollout
+- Labels
+  - challenge: labels are usually freeform and do not have a clean bounded project-scoped option source
+  - recommendation: only do this if the target Jira instance exposes reliable label suggestions that are good enough for existing-label-only selection
+- Generic custom fields
+  - challenge: there is no safe universal convention for arbitrary custom-field editing
+  - recommendation: support only custom fields that `editmeta` marks editable and that expose a bounded allowed-values model
+
+## Product / UX Decisions
+### Editing model by field type
+Use different interaction patterns by field category instead of forcing everything into one input model.
+
+Single-select inline editor:
+- Sprint
+- Priority
+- Status transition target
+
+Multi-select editor with Save / Discard:
+- Fix versions
+- Affects versions
+- Labels, only if we decide to support existing-label-only selection
+- multi-select custom fields with bounded allowed values
+
+Search-backed single-select editor:
+- Assignee
+- Parent / Epic Link target issue
+- single-user and single-issue custom fields
+
+### Assignee UI
+Challenge:
+- assignee is currently rendered only as an avatar in the title area, not as a chip
+Recommendation:
+- keep the avatar display
+- show a pencil affordance on assignee avatar hover
+- open the same popover editor anchored to the avatar area
+- if unassigned, render a small placeholder avatar slot so the edit affordance still exists
+
+### Status UI
+Challenge:
+- status is not a normal field update
+Recommendation:
+- keep showing the current status chip in the popup
+- clicking edit should open a dropdown of available transitions, not all statuses
+- labels should reflect the transition action or target status clearly
+- save should POST the chosen transition and refresh the issue
+
+### Parent UI
+Challenge:
+- current popup display merges `parent` and Epic-style linkage into one `epicOrParent` presentation
+Recommendation:
+- separate the data model first
+- only show an edit affordance when we can identify which linkage model applies
+- do not pretend `parent` and `Epic Link` are the same field in write logic
+
+## Jira/API Strategy
+### Shared capability discovery
+Add issue-scoped edit capability discovery as the base for most upcoming fields.
+
+Primary source:
+- GET `/rest/api/2/issue/{issueKey}/editmeta`
+
+Use it for:
+- whether a field is editable at all
+- allowed operations
+- allowed values for bounded select fields
+- custom-field schema inspection
+
+Cache:
+- per issue key
+- invalidate after successful save along with existing issue cache invalidation
+
+### Priority
+Read source:
+- `editmeta.fields.priority.allowedValues`
+
+Likely write path:
+- PUT `/rest/api/2/issue/{issueKey}`
+
+Payload:
+```js
+{
+  fields: {
+    priority: { id: priorityId }
+  }
+}
+```
+
+Notes:
+- do not assume the global priority list is valid for every issue without `editmeta`
+- hide edit if `editmeta` does not expose the field as editable
+
+### Status via transitions
+Read source:
+- GET `/rest/api/2/issue/{issueKey}/transitions`
+
+Likely write path:
+- POST `/rest/api/2/issue/{issueKey}/transitions`
+
+Payload:
+```js
+{
+  transition: { id: transitionId }
+}
+```
+
+Notes:
+- dropdown options are transitions, not statuses
+- if no transitions are available, hide or disable the edit affordance
+- if multiple transitions lead to similarly named target states, show enough label detail to disambiguate
+
+### Assignee
+Preferred read sources:
+- current assignee from existing issue payload
+- candidate users from Jira user/assignee suggestion endpoint available on the target instance
+- fallback to `editmeta` if it exposes assignable users, though that is often insufficient alone
+
+Preferred write path:
+- PUT `/rest/api/2/issue/{issueKey}/assignee`
+
+Possible payload shapes vary by Jira deployment:
+```js
+{ name: username }
+```
+or
+```js
+{ accountId: accountId }
+```
+
+Notes:
+- detect the shape supported by the current instance instead of hardcoding one identifier style
+- support unassign if permissions allow it
+- debounce user search and cache recent query results
+
+### Parent / Epic Link
+Read sources:
+- current `parent` from issue payload
+- current Epic-style field via existing field-name resolution
+- candidate issues via issue picker / issue search endpoint
+
+Likely write paths:
+- PUT `/rest/api/2/issue/{issueKey}` with either:
+  - `fields.parent = { key: parentKey }` for supported parent relationships
+  - `fields[epicLinkFieldId] = epicKey` for classic Epic Link style fields
+
+Notes:
+- first detect which linkage applies for the current issue
+- do not expose edit if the applicable field cannot be resolved safely
+- prefer same-project search by default, with project-scoped query expansion when needed
+- preload only lightweight cached context that is clearly relevant:
+  - current parent / epic
+  - recent successful search results for the current project
+  - no large eager issue preloads
+
+### Labels
+Challenge:
+- labels are often freeform and not backed by a bounded allowed-values list
+
+Possible sources to investigate:
+- Jira suggestion endpoint if available on this instance
+- autocomplete APIs used by Jira's own issue editor
+
+Recommendation:
+- do not commit to labels until a reliable existing-label suggestion source is confirmed on the target Jira instance
+- if supported, constrain V1 to selecting and removing existing labels only
+- no freeform label creation in popup V1
+
+### Custom Fields
+Support only fields that pass all of the following:
+- present in configured custom-field list or explicit allowlist
+- exposed by `editmeta` as editable
+- schema maps to a supported interaction type
+- bounded option or search source is known
+
+Initial custom-field types worth supporting:
+- single-select custom field with `allowedValues`
+- multi-select custom field with `allowedValues`
+- single-user picker custom field, if we can reuse assignee search
+- single-issue picker / epic-like field, if we can reuse issue search safely
+
+Do not support in the generic path initially:
+- cascading selects
+- rich text
+- arbitrary text fields
+- numeric/date fields without explicit product need
+- fields that require workflow screens or side effects
+
+### Issue Type
+Recommendation:
+- treat as a separate investigation
+- do not include in the next implementation batch
+
+Reason:
+- issue type changes often require Jira move semantics and field remapping
+- the popup editor is the wrong place to discover move-screen requirements
+
+## Architecture Changes
+### Capability layer
+Add reusable capability helpers in `content.jsx`:
+- `getIssueEditMeta(issueKey)`
+- `getEditableFieldCapability(issueData, fieldKey)`
+- `getTransitionOptions(issueKey)`
+- `searchAssignableUsers(query, issueData)`
+- `searchParentCandidates(query, issueData)`
+- `resolveCustomFieldEditor(fieldMeta, editMetaField)`
+
+### Editor modes
+Extend the popup edit state to support explicit editor modes:
+```js
+{
+  fieldKey: '',
+  editorType: 'single-select' | 'multi-select' | 'transition-select' | 'user-search' | 'issue-search',
+  inputValue: '',
+  options: [],
+  selectedOptionId: '',
+  selectedOptionIds: [],
+  selectedOptions: [],
+  loadingOptions: false,
+  saving: false,
+  errorMessage: '',
+  hasChanges: false,
+  selectionStart: 0,
+  selectionEnd: 0
+}
+```
+
+### Template updates
+Update popup rendering to support:
+- header-level edit affordance for assignee avatar
+- row-chip edit affordances for priority / status / parent
+- option rows with optional icons / avatars / meta text
+- explicit Save / Discard row for multi-select and search-backed editors when needed
+
+### Search providers
+Add debounced query providers with small in-memory caches:
+- assignee search cache by query prefix + project / issue context
+- issue search cache by query prefix + project key + linkage mode
+- keep result sizes bounded
+
+### Refresh strategy
+After any successful write:
+- invalidate issue cache
+- invalidate related editmeta cache for the issue
+- invalidate any field-option cache that depends on issue project / context when needed
+- refetch issue payload and rerender popup
+
+## Recommended Delivery Order
+### Track 1: strong next candidates
+1. Add `editmeta` fetch + cache + capability helpers
+2. Implement Priority from `editmeta.allowedValues`
+3. Implement Status from transitions API
+4. Implement Assignee with avatar-anchored popover and user search
+
+### Track 2: linkage editing
+5. Split current combined `epicOrParent` display into explicit linkage metadata
+6. Implement Parent / Epic Link editing only for the linkage model we can resolve safely per issue
+7. Add same-project issue search with debounce and result caching
+
+### Track 3: conditional expansions
+8. Investigate whether labels have a reliable suggestion endpoint on the target Jira instance
+9. If yes, implement existing-label-only multi-select
+10. Add `editmeta`-driven custom-field support for an allowlisted subset of field schemas
+
+### Separate spike
+11. Investigate Issue Type editing as a move-style workflow, not as a normal inline field edit
+
+## Detailed Implementation Steps
+### Phase 1: capability groundwork
+1. Introduce `editmeta` retrieval and cache invalidation alongside existing issue refresh logic
+2. Build a field capability map for standard fields:
+   - priority
+   - assignee
+   - labels
+   - supported custom fields
+3. Add editor-type discrimination so field definitions can request:
+   - bounded single-select
+   - bounded multi-select
+   - transitions
+   - user search
+   - issue search
+
+### Phase 2: priority
+1. Read `priority` capability from `editmeta`
+2. Convert the current static priority chip to an editable chip when allowed
+3. Render allowed priorities with icon support if available
+4. Save selected priority and refresh popup state
+
+### Phase 3: status transitions
+1. Add transition fetch helper for the hovered issue
+2. Map transitions into dropdown options with labels that are understandable in the popup
+3. Convert the status chip to transition-backed edit mode only when transitions are available
+4. POST selected transition and refresh popup state
+5. Handle workflow validation errors cleanly
+
+### Phase 4: assignee
+1. Add an assignee edit affordance in the header avatar region
+2. Resolve search API shape for the target Jira instance
+3. Implement debounced user search and result rendering with avatars
+4. Save via assignee endpoint using instance-appropriate identifier shape
+5. Support clearing assignee when permitted
+
+### Phase 5: parent / epic linkage
+1. Split current combined display logic into explicit linkage resolution
+2. Detect whether current issue should edit `parent` or Epic-style field
+3. Implement debounced issue search scoped to same project by default
+4. Save selected issue key to the resolved linkage field
+5. Refresh and rerender the linked issue summary
+
+### Phase 6: labels, only if source is reliable
+1. Confirm existing-label suggestion endpoint exists and behaves well enough
+2. Implement bounded multi-select labels editor
+3. Explicitly block freeform creation in V1
+4. Save full label array replacement and refresh popup state
+
+### Phase 7: supported custom fields
+1. Read configured custom fields from existing settings
+2. Join configured fields with `editmeta` capabilities
+3. Map each supported custom field to one of the existing editor types
+4. Hide unsupported custom-field editors instead of half-supporting them
+5. Add schema-specific save payload builders
+
+## Testing
+### Priority
+- editable issue with allowed priorities -> update succeeds
+- field not editable in `editmeta` -> no edit affordance
+- permission failure -> editor stays open with error
+
+### Status
+- one or more transitions available -> chosen transition succeeds
+- no transitions available -> no edit affordance
+- transition validation failure -> error shown, popup stays open
+
+### Assignee
+- assign to another user succeeds
+- unassign succeeds when allowed
+- search with no matches shows empty state
+- instance identifier mismatch is handled without breaking popup state
+
+### Parent / Epic Link
+- sub-task style parent update succeeds when supported
+- Epic-style linkage update succeeds when field id is resolvable
+- ambiguous linkage model -> edit hidden
+- search returns too many results -> list stays bounded and responsive
+
+### Labels
+- existing label add/remove succeeds when suggestion source is confirmed
+- freeform unknown label is blocked in V1
+- no suggestion support -> feature remains disabled
+
+### Custom Fields
+- supported single-select field with allowed values updates correctly
+- supported multi-select field updates correctly
+- unsupported schema never renders edit affordance
+- field editable in config but not in `editmeta` stays read-only
+
+## Open Questions / Assumptions
+Assumptions for planning:
+- background JSON write support is already good enough for additional PUT / POST field writes
+- target Jira instance is Server / Data Center-like enough that `/rest/api/2/...` remains the primary integration surface
+- we will prefer per-field correctness over forcing every field into the same editor UI
+
+Questions to resolve during implementation, not before planning:
+- which assignee suggestion endpoint is available on the target instance
+- whether labels have a reliable bounded suggestion source on the target instance
+- whether parent editing should initially support only one linkage model instead of both
+
+## Recommendation
+Recommended next implementation order:
+- Priority
+- Status via transitions
+- Assignee
+- Parent / Epic Link
+
+Do not start with:
+- Issue Type
+- generic custom fields
+- labels without first confirming suggestion support

--- a/plans/environment-row3-plan.md
+++ b/plans/environment-row3-plan.md
@@ -1,0 +1,58 @@
+# Environment Field Plan
+
+## Goal
+- Display Jira `environment` in popup row 3.
+- Allow editing it from the popup with explicit `Save` / `Discard`.
+
+## Scope
+- Add built-in display-field support for `environment` in row 3.
+- Fetch the field in issue metadata.
+- Reuse existing field edit lifecycle where possible.
+- Add a free-text editor variant for multiline values.
+
+## Jira API
+- Read from `fields.environment`.
+- Check editability from `GET /rest/api/2/issue/{key}/editmeta` via `fields.environment`.
+- Save with:
+
+```json
+{
+  "fields": {
+    "environment": "new text"
+  }
+}
+```
+
+to `PUT /rest/api/2/issue/{key}`.
+
+## Code Areas
+- `jira-plugin/src/content.jsx`
+  - include `environment` in issue fetch
+  - add row-3 chip builder
+  - add `environment` editor definition
+  - add free-text editor support
+- `jira-plugin/resources/annotation.html`
+  - support textarea editor rendering
+- `jira-plugin/src/content.scss`
+  - style textarea editor
+- `jira-plugin/options/config.js`
+  - add `displayFields.environment`
+- `jira-plugin/options/options.jsx`
+  - expose Environment under row 3
+
+## UX
+- Show `Environment: --` when empty.
+- Truncate long display text in row 3.
+- Use multiline editor in popup, not inline chip text entry.
+
+## Risks
+- Some Jira instances may hide the built-in field from edit screens.
+- A custom field named Environment may exist separately; v1 should support built-in `environment` only unless fallback is explicitly required.
+- Current edit architecture is optimized for select/search, not free text.
+
+## Tests
+- options page shows Environment in row 3 settings
+- popup renders Environment when enabled
+- edit affordance only shows when `editmeta` allows it
+- save refreshes popup state
+- failed save preserves draft and shows inline error

--- a/plans/playwright-test-plan.md
+++ b/plans/playwright-test-plan.md
@@ -1,0 +1,248 @@
+# Playwright Test Plan
+
+## Goal
+
+Build a reliable Playwright-based automation suite for Jira HotLinker that covers:
+
+- extension configuration flows
+- content-script activation behavior
+- hover and popup interactions
+- mocked Jira read and write flows
+- failure modes such as unreachable Jira, unauthenticated Jira, and anonymous read-only access
+- optional public Jira smoke coverage
+- future private Jira coverage with real authentication
+
+## Test Strategy
+
+The suite uses a hybrid approach:
+
+1. Mocked integration tests are the primary source of truth for feature coverage.
+2. Public Jira tests are lightweight smoke tests only.
+3. Private Jira tests remain opt-in and env-driven for later.
+
+This keeps the suite deterministic while still allowing live verification against real Jira pages.
+
+## Scope
+
+### In Scope
+
+- options page validation and persistence
+- allowed-page and inactive-page behavior
+- exact, shallow, and deep hover detection
+- modifier-key-triggered popup behavior
+- popup rendering for issue metadata, comments, attachments, pull requests, and custom fields
+- popup controls such as pin, close, copy link, and image preview
+- mocked edit and quick-action flows
+- mocked comment and mention flows
+- network/auth failure scenarios
+
+### Out of Scope For Initial Suite
+
+- broad cross-browser matrix beyond Chromium extension execution
+- visual regression baselines
+- full accessibility scanning
+- true mutation tests against a private Jira instance
+- every Jira field permutation in one pass
+
+## Test Environments
+
+### `extension`
+
+Primary suite. Runs against:
+
+- unpacked Chromium extension
+- local fixture pages
+- local mocked Jira server
+
+### `public-jira`
+
+Optional smoke suite. Disabled by default unless:
+
+- `RUN_PUBLIC_JIRA_TESTS=1`
+
+Target:
+
+- `https://jira.atlassian.com/browse/JRACLOUD-97846`
+
+### `live-jira`
+
+Placeholder for future authenticated tests. Enabled later with env vars such as:
+
+- `JIRA_LIVE_INSTANCE_URL`
+- `JIRA_LIVE_PROJECT_KEYS`
+- `JIRA_LIVE_ISSUE_KEYS`
+- `JIRA_LIVE_STORAGE_STATE`
+
+Current live-scope rule:
+
+- live tests only operate on issues explicitly listed in `JIRA_LIVE_ISSUE_KEYS`
+- each listed issue must also belong to a project listed in `JIRA_LIVE_PROJECT_KEYS`
+- if that scope is not configured, the `live-jira` project skips entirely
+- authenticated live smoke tests additionally require `JIRA_LIVE_STORAGE_STATE`
+
+## Current Spec Inventory
+
+### `tests/e2e/options.spec.js`
+
+- empty Jira URL validation
+- custom field ID validation and Jira metadata lookup
+- persistence of hover and display settings
+- optional host permission denial handling
+
+### `tests/e2e/hover-and-popup.spec.js`
+
+- injection only on configured domains
+- exact vs shallow vs deep hover behavior
+- modifier-key requirement
+- pin and close behavior
+
+### `tests/e2e/mock-jira-flows.spec.js`
+
+- issue metadata rendering
+- comments, attachments, PRs, and custom field rendering
+- copy-link and image preview behavior
+- mocked quick actions and inline edits
+- mocked mentions and comment creation
+
+### `tests/e2e/advanced-mock-flows.spec.js`
+
+- assignee and parent search editor coverage
+- explicit unassigned-assignee option coverage
+- sprint, affects version, and fix version edit coverage
+- quick-action grouping and sprint action visibility
+- no-quick-actions edge case coverage
+- attachment / PR display-toggle coverage
+
+### `tests/e2e/partial-failures.spec.js`
+
+- pull request endpoint failure tolerance
+- malformed pull request payload tolerance
+- label suggestion support fallback behavior
+- issue-search editor failure handling
+- comment save failure handling
+- mention search failure handling
+- comment discard flow coverage
+
+### `tests/e2e/error-states.spec.js`
+
+- unreachable Jira / wrong URL
+- Jira 401 / not logged in
+- anonymous read-only Jira behavior
+
+### `tests/e2e/public-jira.spec.js`
+
+- optional public Atlassian issue smoke test
+- optional public Atlassian search-results smoke test
+
+### `tests/e2e/live-jira.spec.js`
+
+- live-scope config guard
+- allowed-issue popup smoke test
+- authenticated allowed-issue popup smoke test using storage state
+
+## Current Coverage Summary
+
+Covered now:
+
+- options UI core flows
+- extension activation gating
+- popup lifecycle basics
+- key mocked read flows
+- several mocked write flows
+- editor search surfaces for assignee and parent link
+- quick-action edge cases and unassigned editor option coverage
+- comment mention failure and draft discard coverage
+- partial endpoint failure tolerance for PRs, issue search, and comments
+- primary negative-path connection/auth scenarios
+
+Not yet covered deeply enough:
+
+- more field editor permutations: assignee search branches, sprint variants, versions/fixVersions permutations, parent/epic link branches, more custom field editors
+- additional quick-action permutations
+- drag interaction assertions
+- malformed Jira payloads and partial endpoint failures
+- upload failure paths
+- more than one public Jira smoke path
+- private Jira authenticated paths
+
+## Execution Commands
+
+Run the stable mocked suite:
+
+```bash
+npm run test:e2e:extension
+```
+
+Run the public smoke suite:
+
+```bash
+RUN_PUBLIC_JIRA_TESTS=1 npm run test:e2e:public
+```
+
+Run the private Jira suite later:
+
+```bash
+npm run test:e2e:live
+```
+
+Example live scope config:
+
+```bash
+export JIRA_LIVE_INSTANCE_URL="https://yourcompany.atlassian.net"
+export JIRA_LIVE_PROJECT_KEYS="E2E,QA"
+export JIRA_LIVE_ISSUE_KEYS="E2E-101,E2E-102"
+export JIRA_LIVE_STORAGE_STATE="tests/.auth/jira-live.json"
+```
+
+Open the latest report:
+
+```bash
+npm run test:e2e:show-report
+```
+
+## Reporting
+
+- merged HTML report: `tests/output/playwright/report/index.html`
+- accumulated blob reports: `tests/output/playwright/blob-report`
+- run artifacts: `tests/output/playwright/test-results`
+
+The merged HTML report now lives at `tests/output/playwright/report/index.html`.
+
+Each environment run now writes a uniquely named blob report zip into `output/playwright/blob-report` and then regenerates one merged HTML report from all stored runs. This allows separate `extension`, `public-jira`, and future `live-jira` runs to appear in one combined report instead of overwriting each other.
+
+Useful commands:
+
+```bash
+npm run test:e2e:merge-report
+npm run test:e2e:reset-report-data
+```
+
+## Risks And Stability Notes
+
+- extension tests require Chromium because they load an unpacked extension
+- live public Jira content can drift, so public tests must stay lightweight
+- mocked Jira must remain aligned with extension expectations as features evolve
+- brittle selectors should be reduced over time by introducing more stable test hooks where appropriate
+
+## Recommended Next Wave
+
+1. Add more mocked field-editor coverage for assignee, sprint, affects versions, fix versions, and parent/epic link flows.
+2. Add malformed-response and partial-failure tests for comments, PRs, labels, and attachments.
+3. Add drag-behavior and multi-key-page popup interaction tests.
+4. Add pasted-image upload happy-path and failure-path coverage once a stable Playwright clipboard-image strategy is in place.
+5. Add private Jira auth fixtures and real-instance smoke coverage once credentials/project access are available.
+
+## Skill Guidance
+
+The installed Playwright CLI skill is useful for browser control and debugging.
+
+The `wshobson-agents-e2e-testing-patterns` skill is also useful, but in a different way:
+
+- it is stronger on test-design standards than browser control
+- it reinforces selector hygiene, mocking strategy, test layering, retries, and CI patterns
+- it is especially helpful for expanding this suite cleanly rather than merely getting the browser to run
+
+Recommended use here:
+
+- use the Playwright CLI skill for interactive browser debugging
+- use the E2E testing patterns skill as a standards/reference guide while expanding the suite

--- a/plans/quick-actions-poc-plan.md
+++ b/plans/quick-actions-poc-plan.md
@@ -1,0 +1,119 @@
+# Quick Actions POC Plan
+## Branch
+poc/quick-actions
+## Goal
+Add low-friction one-click Jira actions to the hover popup, with success/error feedback and in-place state refresh.
+## Recommended Initial Scope
+Implement only these actions in V1:
+- Assign to me
+- Move to current sprint
+- Start progress
+Do not include workflow-heavy or ambiguous actions yet:
+- resolve/close
+- arbitrary transitions
+- add/remove labels
+## UX
+Default placement:
+- header-level Actions dropdown near the copy button
+Behavior:
+- click Actions
+- open small menu listing currently available actions
+- click action
+- action shows loading state
+- on success, refresh popup issue state and rerender
+- on failure, show error and keep popup open
+Future option:
+- settings toggle for Menu vs Inline row
+## Jira/API Strategy
+### Assign to me
+Likely endpoint:
+- PUT /rest/api/2/issue/{issueKey}/assignee
+Payload:
+- Jira Server/DC may accept current username or account identifier depending on deployment
+- first discover current user from Jira session API or issue/self context
+### Move to current sprint
+Needs:
+- sprint custom field id
+- current active sprint id
+Likely steps:
+1. resolve sprint custom field id from /rest/api/2/field
+2. resolve active sprint from Agile API or configured board context
+3. PUT /rest/api/2/issue/{issueKey} with sprint field update
+Risk:
+- current sprint is board-dependent
+- may require board selection logic or fallback to the single active sprint if only one exists
+### Start progress
+Needs:
+- transition lookup, not direct status field update
+Likely steps:
+1. GET /rest/api/2/issue/{issueKey}/transitions
+2. find transition matching In Progress or similar configured target
+3. POST /rest/api/2/issue/{issueKey}/transitions
+Risk:
+- workflow names differ across projects
+- transition availability depends on current status and permissions
+## Architecture Changes
+### Background layer
+Extend [background.js](/D:/Jira-HotLinker/jira-plugin/src/background.js):
+- add generic authenticated request handler for POST and PUT
+- support JSON body
+- preserve Jira-origin restriction
+Suggested message shape:
+`js
+{ action: 'requestJson', method: 'PUT', url, body }
+`
+### Content layer
+Extend [content.jsx](/D:/Jira-HotLinker/jira-plugin/src/content.jsx):
+- add popup-local action state
+- add capability resolver for which actions are available for the current issue
+- add click handlers for action execution
+- add efreshIssueData(issueKey) path to refetch and rerender popup after success
+### Template/CSS
+Update:
+- [annotation.html](/D:/Jira-HotLinker/jira-plugin/resources/annotation.html)
+- [content.scss](/D:/Jira-HotLinker/jira-plugin/src/content.scss)
+Need:
+- header dropdown button
+- actions menu
+- per-action loading state
+- inline error/success notice or snackbar integration
+## State Model
+Suggested runtime state in content script:
+`js
+{
+  actionsOpen: false,
+  actionLoadingKey: '',
+  actionError: '',
+  lastActionSuccess: ''
+}
+`
+## Success Criteria
+- popup stays open after action
+- updated assignee/sprint/status is visible immediately after refresh
+- failures do not close popup
+- unavailable actions are hidden or disabled
+## Implementation Order
+1. Add generic write request support in background
+2. Implement Assign to me
+3. Add popup refresh-after-write
+4. Implement Start progress
+5. Implement Move to current sprint
+6. Add dropdown polish and availability filtering
+## Testing
+### Assign to me
+- issue unassigned -> becomes assigned to current user
+- issue assigned to someone else -> changes correctly
+- permission failure -> error shown, popup remains usable
+### Start progress
+- available transition exists -> status updates
+- transition missing -> action hidden or disabled
+- workflow blocks transition -> error shown
+### Move to current sprint
+- one active sprint exists -> issue added successfully
+- no active sprint -> action hidden or disabled
+- multiple active sprints / ambiguous board context -> action not offered in V1
+## Notes
+This is the best first write-action POC because it avoids inline editing complexity while proving:
+- authenticated write calls
+- popup state refresh
+- reusable action execution framework

--- a/plans/time-tracking-plan.md
+++ b/plans/time-tracking-plan.md
@@ -1,0 +1,77 @@
+# Time Tracking Plan
+
+## Goal
+- Display and edit Original Estimate and Remaining Estimate.
+- Allow Time Spent only through adding a new worklog entry.
+- Use one explicit `Save` button for the section.
+
+## Recommendation
+- Implement as a dedicated section below row 3, not as field chips.
+
+## Jira API
+- Read from `fields.timetracking`.
+- Check estimate editability with `editmeta.fields.timetracking`.
+- Update estimates with `PUT /rest/api/2/issue/{key}`:
+
+```json
+{
+  "fields": {
+    "timetracking": {
+      "originalEstimate": "1w 2d",
+      "remainingEstimate": "3h 30m"
+    }
+  }
+}
+```
+
+- Add spent time with:
+  - `POST /rest/api/2/issue/{key}/worklog?adjustEstimate=leave`
+
+```json
+{
+  "timeSpent": "1h 30m"
+}
+```
+
+## UX
+- Keep current total Time Spent read-only.
+- Provide inputs for:
+  - Original Estimate
+  - Remaining Estimate
+  - Add Time Spent
+- Enable `Save` only when a valid change exists.
+
+## Preferred Mockup
+```text
+Time Tracking
+Original estimate   [ 1w 2d ]
+Remaining estimate  [ 3d 4h ]
+Log work            [ 30m   ]  Adds to Time Spent
+Time Spent: 6h 15m                      [Save]
+```
+
+## State Model
+- separate `timeTrackingEditState` from existing single-field `editState`
+- keep original values, current inputs, saving flag, and error state
+- support mixed saves where worklog and estimates may both be submitted
+
+## Risks
+- Estimate edit permission and worklog permission may differ.
+- Shared Save can partially succeed.
+- Jira duration parsing varies by instance, so client validation should be permissive.
+
+## Code Areas
+- `jira-plugin/src/content.jsx`
+  - fetch/build timetracking display data
+  - add section-level state and save handler
+- `jira-plugin/resources/annotation.html`
+  - render section under row 3
+- `jira-plugin/src/content.scss`
+  - compact form layout
+
+## Tests
+- section renders when timetracking exists
+- save disabled when nothing changed
+- estimate-only save works
+- worklog-only save works
+- combined save handles success and failure cleanly

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,43 @@
+const path = require('path');
+
+const testResultsDir = process.env.PLAYWRIGHT_OUTPUT_DIR
+  ? path.resolve(__dirname, process.env.PLAYWRIGHT_OUTPUT_DIR)
+  : path.join(__dirname, 'tests/output/playwright/test-results');
+
+module.exports = {
+  testDir: path.join(__dirname, 'tests/e2e'),
+  timeout: 90 * 1000,
+  expect: {
+    timeout: 10 * 1000,
+  },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [
+    ['list'],
+    ['blob', {outputDir: path.join(__dirname, 'tests/output/playwright/blob-report')}],
+  ],
+  outputDir: testResultsDir,
+  use: {
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 10 * 1000,
+    navigationTimeout: 30 * 1000,
+  },
+  globalSetup: path.join(__dirname, 'tests/e2e/helpers/global-setup.js'),
+  projects: [
+    {
+      name: 'extension',
+      testIgnore: /(?:^|\/)public-jira\.spec\.js$|(?:^|\/)live-jira\.spec\.js$/,
+    },
+    {
+      name: 'public-jira',
+      grep: /@public/,
+    },
+    {
+      name: 'live-jira',
+      grep: /@live/,
+    },
+  ],
+};

--- a/scripts/playwright/capture-live-auth.js
+++ b/scripts/playwright/capture-live-auth.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const {chromium} = require('@playwright/test');
+
+function ask(question) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise(resolve => {
+    rl.question(question, answer => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+async function main() {
+  const instanceUrl = String(process.env.JIRA_LIVE_INSTANCE_URL || '').trim();
+  if (!instanceUrl) {
+    throw new Error('Set JIRA_LIVE_INSTANCE_URL before capturing live Jira auth state.');
+  }
+
+  const repoRoot = path.resolve(__dirname, '../..');
+  const authDir = path.join(repoRoot, 'tests/.auth');
+  const storageStatePath = path.resolve(
+    process.env.JIRA_LIVE_STORAGE_STATE || path.join(authDir, 'jira-live.json')
+  );
+
+  fs.mkdirSync(path.dirname(storageStatePath), {recursive: true});
+
+  const browser = await chromium.launch({headless: false, channel: 'chromium'});
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  console.log(`Opening ${instanceUrl} in a real browser window.`);
+  console.log('Log in with your dedicated Jira test account, then return here.');
+  await page.goto(instanceUrl, {waitUntil: 'domcontentloaded'});
+
+  await ask('Press Enter after Jira is fully logged in and ready to save session state... ');
+  await context.storageState({path: storageStatePath});
+  await browser.close();
+
+  console.log(`Saved live Jira storage state to ${storageStatePath}`);
+  console.log('Treat this file like a session secret and keep it out of git.');
+}
+
+main().catch(error => {
+  console.error(error.message || String(error));
+  process.exit(1);
+});

--- a/scripts/playwright/merge-reports.js
+++ b/scripts/playwright/merge-reports.js
@@ -1,0 +1,30 @@
+const {spawnSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '../..');
+const blobDir = path.join(repoRoot, 'tests/output/playwright/blob-report');
+const reportDir = path.join(repoRoot, 'tests/output/playwright/report');
+
+if (!fs.existsSync(blobDir)) {
+  process.exit(0);
+}
+
+const blobFiles = fs.readdirSync(blobDir).filter(fileName => fileName.endsWith('.zip'));
+if (!blobFiles.length) {
+  process.exit(0);
+}
+
+const env = {
+  ...process.env,
+  PLAYWRIGHT_HTML_OUTPUT_DIR: reportDir,
+  PLAYWRIGHT_HTML_OPEN: 'never',
+};
+
+const result = spawnSync('npx', ['playwright', 'merge-reports', '--reporter', 'html', blobDir], {
+  cwd: repoRoot,
+  env,
+  stdio: 'inherit',
+});
+
+process.exit(result.status || 0);

--- a/scripts/playwright/reset-reports.js
+++ b/scripts/playwright/reset-reports.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '../..');
+const targets = [
+  path.join(repoRoot, 'tests/output/playwright/blob-report'),
+  path.join(repoRoot, 'tests/output/playwright/report'),
+  path.join(repoRoot, 'tests/output/playwright/test-results'),
+];
+
+for (const target of targets) {
+  fs.rmSync(target, {recursive: true, force: true});
+}
+
+console.log('Cleared Playwright report data.');

--- a/scripts/playwright/run-with-blob.js
+++ b/scripts/playwright/run-with-blob.js
@@ -1,0 +1,57 @@
+const {spawnSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '../..');
+const blobDir = path.join(repoRoot, 'tests/output/playwright/blob-report');
+const mergeScript = path.join(repoRoot, 'scripts/playwright/merge-reports.js');
+const args = process.argv.slice(2);
+
+function detectLabel(cliArgs) {
+  const projectArg = cliArgs.find(arg => arg.startsWith('--project='));
+  if (projectArg) {
+    return projectArg.split('=')[1];
+  }
+  const projectIndex = cliArgs.indexOf('--project');
+  if (projectIndex >= 0 && cliArgs[projectIndex + 1]) {
+    return cliArgs[projectIndex + 1];
+  }
+  return 'all-projects';
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+fs.mkdirSync(blobDir, {recursive: true});
+
+const label = detectLabel(args).replace(/[^a-zA-Z0-9_-]+/g, '-');
+const runId = `${label}-${timestamp()}`;
+const outputName = `${runId}.zip`;
+const env = {
+  ...process.env,
+  PLAYWRIGHT_BLOB_OUTPUT_DIR: blobDir,
+  PLAYWRIGHT_BLOB_OUTPUT_NAME: outputName,
+  PLAYWRIGHT_OUTPUT_DIR: path.join('tests/output/playwright/test-results', runId),
+  PWTEST_BLOB_DO_NOT_REMOVE: '1',
+};
+
+const testResult = spawnSync('npx', ['playwright', 'test', ...args], {
+  cwd: repoRoot,
+  env,
+  stdio: 'inherit',
+});
+
+const mergeResult = spawnSync(process.execPath, [mergeScript], {
+  cwd: repoRoot,
+  env: process.env,
+  stdio: 'inherit',
+});
+
+if (testResult.status !== 0) {
+  process.exit(testResult.status || 1);
+}
+
+if (mergeResult.status !== 0) {
+  process.exit(mergeResult.status || 1);
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,209 @@
+# Test Automation Guide
+
+This folder contains the Playwright automation setup for Jira HotLinker.
+
+## What Lives Here
+
+- `tests/e2e/` - Playwright specs and helpers
+- `tests/.auth/` - local-only authenticated session files for private Jira testing
+- `tests/output/` - generated reports, traces, screenshots, and run artifacts
+
+Both `tests/.auth/` and `tests/output/` are ignored by git.
+
+## Test Modes
+
+### Mocked extension tests
+
+These are the main automated tests. They use:
+
+- the unpacked Chromium extension
+- local fixture pages
+- a mocked Jira backend
+
+Run them with:
+
+```bash
+npm run test:e2e:extension
+```
+
+### Public Jira smoke tests
+
+These are lightweight live checks against Atlassian's public Jira pages.
+
+Run them with:
+
+```bash
+RUN_PUBLIC_JIRA_TESTS=1 npm run test:e2e:public
+```
+
+### Private Jira live tests
+
+These are opt-in and only run when all required environment variables are configured.
+
+Required environment variables:
+
+```bash
+export JIRA_LIVE_INSTANCE_URL="https://yourcompany.atlassian.net"
+export JIRA_LIVE_PROJECT_KEYS="E2E,QA"
+export JIRA_LIVE_ISSUE_KEYS="E2E-101,E2E-102"
+export JIRA_LIVE_STORAGE_STATE="tests/.auth/jira-live.json"
+```
+
+Run them with:
+
+```bash
+npm run test:e2e:live
+```
+
+## Private Jira Safety Scope
+
+The live suite intentionally refuses to run outside the allowed scope.
+
+Rules:
+
+- `JIRA_LIVE_ISSUE_KEYS` is the exact allowlist of issues the tests may touch
+- each issue key must belong to a project listed in `JIRA_LIVE_PROJECT_KEYS`
+- if that configuration is missing, the live suite skips instead of guessing
+
+Example:
+
+```bash
+export JIRA_LIVE_INSTANCE_URL="https://yourcompany.atlassian.net"
+export JIRA_LIVE_PROJECT_KEYS="E2E,QA"
+export JIRA_LIVE_ISSUE_KEYS="E2E-101,E2E-102"
+```
+
+That means live tests may target `E2E-101` and `E2E-102`, but not any other issue.
+
+## Auth Storage State
+
+Private Jira tests reuse a Playwright storage-state file so they do not need to automate login every time.
+
+What the storage-state file contains:
+
+- session cookies
+- relevant local storage for logged-in browser state
+
+What that means:
+
+- it is sensitive
+- it should be treated like a session secret
+- it should only be created with a dedicated low-privilege Jira test account
+
+Recommended location:
+
+```bash
+tests/.auth/jira-live.json
+```
+
+### Capture a new authenticated session
+
+1. Set your Jira instance URL.
+2. Run the auth capture script.
+3. Log in in the opened browser window.
+4. Return to the terminal and press Enter.
+
+Command:
+
+```bash
+export JIRA_LIVE_INSTANCE_URL="https://yourcompany.atlassian.net"
+npm run test:e2e:auth:live
+```
+
+If you want a custom path:
+
+```bash
+export JIRA_LIVE_INSTANCE_URL="https://yourcompany.atlassian.net"
+export JIRA_LIVE_STORAGE_STATE="tests/.auth/jira-live.json"
+npm run test:e2e:auth:live
+```
+
+## Reports And Artifacts
+
+All generated Playwright output now lives under `tests/output/playwright/`.
+
+Important paths:
+
+- merged HTML report: `tests/output/playwright/report/index.html`
+- accumulated blob reports: `tests/output/playwright/blob-report`
+- run artifacts: `tests/output/playwright/test-results`
+
+Open the merged report with:
+
+```bash
+npm run test:e2e:show-report
+```
+
+The report is cumulative across runs because each environment writes a blob report and the HTML report is rebuilt from all saved blobs.
+
+If you want a clean report before the next run:
+
+```bash
+npm run test:e2e:reset-report-data
+```
+
+## Useful Commands
+
+Run the default suite:
+
+```bash
+npm test
+```
+
+Run everything configured by Playwright:
+
+```bash
+npm run test:e2e:all
+```
+
+Run the extension suite in headed mode:
+
+```bash
+npm run test:e2e:headed
+```
+
+Open Playwright UI mode:
+
+```bash
+npm run test:e2e:ui
+```
+
+Merge reports again without rerunning tests:
+
+```bash
+npm run test:e2e:merge-report
+```
+
+Reset saved reports and artifacts:
+
+```bash
+npm run test:e2e:reset-report-data
+```
+
+## Current Coverage Areas
+
+The suite currently covers:
+
+- options page validation and persistence
+- activation on allowed pages only
+- hover depth and modifier behavior
+- popup rendering for issue data, comments, attachments, PRs, and custom fields
+- quick actions and several inline editors in mocked mode
+- anonymous, unauthorized, and unreachable Jira scenarios
+- public Jira smoke checks
+- live Jira scope-gated smoke checks
+
+## Current Known Gap
+
+One remaining area is intentionally not in the passing suite yet:
+
+- pasted-image upload flows in Playwright
+
+The extension supports them, and the mocked backend supports the scenarios, but stable clipboard-image simulation inside this extension context still needs a more reliable approach before those tests should be considered trustworthy.
+
+## Recommended Practices
+
+- use a dedicated Jira test account for `tests/.auth/jira-live.json`
+- keep live test issues restricted to explicit safe issue keys
+- reset report data before producing a clean report for review
+- prefer mocked tests for broad feature coverage and live tests for smoke validation

--- a/tests/e2e/advanced-mock-flows.spec.js
+++ b/tests/e2e/advanced-mock-flows.spec.js
@@ -1,0 +1,127 @@
+const {test, expect, configureExtension, hoverIssueKey, injectContentScript} = require('./helpers/extension-fixtures');
+
+function baseConfig(servers, overrides = {}) {
+  return {
+    instanceUrl: servers.jira.origin,
+    domains: [servers.allowedPage.origin],
+    hoverDepth: 'shallow',
+    hoverModifierKey: 'none',
+    customFields: [{fieldId: 'customfield_12345', row: 2}],
+    ...overrides,
+  };
+}
+
+async function openPopup(extensionApp, servers, route = '/popup-actions') {
+  const page = await extensionApp.context.newPage();
+  await page.goto(`${servers.allowedPage.origin}${route}`);
+  await injectContentScript(extensionApp, page);
+  await expect.poll(async () => page.locator('._JX_container').count()).toBe(1);
+  await hoverIssueKey(page, '#popup-key');
+  await expect(page.locator('._JX_container')).toContainText('JRACLOUD-97846');
+  return page;
+}
+
+test('shows assignee and parent search results inside their editors', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('editable');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+
+  await page.locator('._JX_assignee_edit_button').click();
+  await page.locator('._JX_edit_input[data-field-key="assignee"]').fill('Morgan');
+  await expect(page.locator('._JX_edit_option[data-field-key="assignee"][data-option-id="user-me"]')).toBeVisible();
+  await expect(page.locator('._JX_edit_option[data-field-key="assignee"][data-option-id="user-me"]')).toContainText('Morgan Agent');
+  await page.locator('._JX_edit_cancel[data-field-key="assignee"]').click();
+
+  await page.locator('._JX_field_chip_edit[data-field-key="parentLink"]').click();
+  await page.locator('._JX_edit_input[data-field-key="parentLink"]').fill('98123');
+  await expect(page.locator('._JX_edit_option[data-field-key="parentLink"][data-option-id="JRACLOUD-98123"]')).toBeVisible();
+  await expect(page.locator('._JX_edit_option[data-field-key="parentLink"][data-option-id="JRACLOUD-98123"]')).toContainText('Improve slash command cursor stability');
+
+  await page.close();
+});
+
+test('updates sprint and version fields through edit popovers', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('editable');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  const popup = page.locator('._JX_container');
+
+  await page.locator('._JX_field_chip_edit[data-field-key="sprint"]').click();
+  await page.locator('._JX_edit_option[data-field-key="sprint"][data-option-id="43"]').click();
+  await page.locator('._JX_edit_input[data-field-key="sprint"]').press('Enter');
+  await expect(popup).toContainText('Sprint set to Sprint 43 (FUTURE)');
+  await expect(popup).toContainText('Sprint 43');
+
+  await page.locator('._JX_field_chip_edit[data-field-key="versions"]').click();
+  await page.locator('._JX_edit_option[data-field-key="versions"][data-option-id="302"]').click();
+  await page.locator('._JX_edit_save[data-field-key="versions"]').click();
+  await expect(popup).toContainText('Affects versions updated');
+  await expect(popup).toContainText('2026.05');
+
+  await page.locator('._JX_field_chip_edit[data-field-key="fixVersions"]').click();
+  await page.locator('._JX_edit_option[data-field-key="fixVersions"][data-option-id="402"]').click();
+  await page.locator('._JX_edit_save[data-field-key="fixVersions"]').click();
+  await expect(popup).toContainText('Fix versions updated');
+  await expect(popup).toContainText('2026.06');
+
+  await page.close();
+});
+
+test('shows grouped quick actions for assignment, transition, and sprint moves', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('editable');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  await page.locator('._JX_actions_toggle').click();
+
+  await expect(page.locator('._JX_action_item[data-action-key="assign-to-me"]')).toContainText('Assign to me');
+  await expect(page.locator('._JX_action_item[data-action-key="start-progress"]')).toContainText(/Start|Move to In Progress/);
+  await expect(page.locator('._JX_action_item[data-action-key="move-to-sprint-43"]')).toContainText('Move to Sprint Sprint 43 (NEXT)');
+  await expect(page.locator('._JX_action_divider')).toHaveCount(1);
+
+  await page.close();
+});
+
+test('offers an explicit unassigned option in the assignee editor', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('editable');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+
+  await page.locator('._JX_assignee_edit_button').click();
+  const unassignedOption = page.locator('._JX_edit_option[data-field-key="assignee"][data-option-id="__unassigned__"]');
+  await expect(unassignedOption).toBeVisible();
+  await expect(unassignedOption).toContainText('Clear assignee');
+  await page.close();
+});
+
+test('hides quick actions when the issue is already assigned, already in progress, and has no sprint move targets', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('in-progress-no-sprint-actions');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  await expect(page.locator('._JX_actions_toggle')).toHaveCount(0);
+  await page.close();
+});
+
+test('hides attachment and pull request sections when those display settings are disabled', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('editable');
+  await configureExtension(optionsPage, baseConfig(servers, {
+    displayFields: {
+      comments: false,
+      attachments: false,
+      pullRequests: false,
+    },
+  }), true);
+
+  const page = await openPopup(extensionApp, servers);
+  const popup = page.locator('._JX_container');
+
+  await expect(popup).not.toContainText('Attachments');
+  await expect(popup).not.toContainText('Pull Requests');
+  await expect(popup).toContainText('📎 0');
+  await expect(popup).toContainText('🔀 0');
+  await page.close();
+});

--- a/tests/e2e/error-states.spec.js
+++ b/tests/e2e/error-states.spec.js
@@ -1,0 +1,61 @@
+const {test, expect, configureExtension, hoverIssueKey, injectContentScript} = require('./helpers/extension-fixtures');
+
+function unreachableConfig(servers) {
+  return {
+    instanceUrl: 'http://127.0.0.1:9/',
+    domains: [servers.allowedPage.origin],
+    hoverDepth: 'shallow',
+    hoverModifierKey: 'none',
+    customFields: [],
+  };
+}
+
+function reachableConfig(servers) {
+  return {
+    instanceUrl: servers.jira.origin,
+    domains: [servers.allowedPage.origin],
+    hoverDepth: 'shallow',
+    hoverModifierKey: 'none',
+    customFields: [],
+  };
+}
+
+async function openAllowedPage(extensionApp, servers) {
+  const page = await extensionApp.context.newPage();
+  await page.goto(`${servers.allowedPage.origin}/popup-actions`);
+  await injectContentScript(extensionApp, page);
+  await expect.poll(async () => page.locator('._JX_container').count()).toBe(1);
+  return page;
+}
+
+test('surfaces a connection error when Jira is unreachable', async ({extensionApp, optionsPage, servers}) => {
+  await configureExtension(optionsPage, unreachableConfig(servers), true);
+  const page = await openAllowedPage(extensionApp, servers);
+
+  await hoverIssueKey(page, '#popup-key');
+  await expect(page.locator('body')).toContainText('Could not reach Jira');
+  await page.close();
+});
+
+test('does not render a popup when the user is not logged in and Jira returns 401', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('unauthorized');
+  await configureExtension(optionsPage, reachableConfig(servers), true);
+  const page = await openAllowedPage(extensionApp, servers);
+
+  await hoverIssueKey(page, '#popup-key');
+  await expect(page.locator('._JX_container')).toBeEmpty();
+  await page.close();
+});
+
+test('falls back to a read-only popup when Jira is viewable anonymously', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('anonymous-readonly');
+  await configureExtension(optionsPage, reachableConfig(servers), true);
+  const page = await openAllowedPage(extensionApp, servers);
+
+  await hoverIssueKey(page, '#popup-key');
+  const popup = page.locator('._JX_container');
+  await expect(popup).toContainText('JRACLOUD-97846');
+  await expect(page.locator('._JX_actions_toggle')).toHaveCount(0);
+  await expect(page.locator('button[data-field-key="priority"]')).toHaveCount(0);
+  await page.close();
+});

--- a/tests/e2e/helpers/extension-fixtures.js
+++ b/tests/e2e/helpers/extension-fixtures.js
@@ -1,0 +1,204 @@
+const fs = require('fs/promises');
+const os = require('os');
+const path = require('path');
+const {test: base, expect, chromium} = require('@playwright/test');
+const {createMockJiraServer} = require('./mock-jira-server');
+const {createFixtureServer} = require('./fixture-server');
+
+const extensionPath = path.resolve(__dirname, '../../../jira-plugin');
+
+async function readStorageStateFile() {
+  const storageStatePath = String(process.env.JIRA_LIVE_STORAGE_STATE || '').trim();
+  if (!storageStatePath) {
+    return null;
+  }
+  const raw = await fs.readFile(path.resolve(storageStatePath), 'utf8');
+  return JSON.parse(raw);
+}
+
+async function applyStorageState(context, storageState) {
+  if (!storageState) {
+    return;
+  }
+
+  if (Array.isArray(storageState.cookies) && storageState.cookies.length) {
+    await context.addCookies(storageState.cookies);
+  }
+
+  const origins = Array.isArray(storageState.origins) ? storageState.origins : [];
+  if (origins.length) {
+    await context.addInitScript(({entries}) => {
+      const currentOrigin = window.location.origin;
+      const match = entries.find(entry => entry.origin === currentOrigin);
+      if (!match || !Array.isArray(match.localStorage)) {
+        return;
+      }
+      for (const item of match.localStorage) {
+        window.localStorage.setItem(item.name, item.value);
+      }
+    }, {entries: origins});
+  }
+}
+
+async function createTestExtensionCopy() {
+  const extensionDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jira-hot-linker-extension-'));
+  await fs.cp(extensionPath, extensionDir, {recursive: true});
+  const manifestPath = path.join(extensionDir, 'manifest.json');
+  const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+  manifest.permissions = Array.from(new Set([...(manifest.permissions || []), 'scripting']));
+  manifest.host_permissions = ['<all_urls>'];
+  manifest.optional_host_permissions = ['<all_urls>'];
+  await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  return extensionDir;
+}
+
+async function launchExtensionContext() {
+  const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jira-hot-linker-playwright-'));
+  const testExtensionPath = await createTestExtensionCopy();
+  const storageState = await readStorageStateFile();
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    channel: 'chromium',
+    headless: true,
+    args: [
+      `--disable-extensions-except=${testExtensionPath}`,
+      `--load-extension=${testExtensionPath}`,
+    ],
+  });
+  await applyStorageState(context, storageState);
+  return {context, userDataDir, testExtensionPath};
+}
+
+async function getExtensionId(context) {
+  let [serviceWorker] = context.serviceWorkers();
+  if (!serviceWorker) {
+    serviceWorker = await context.waitForEvent('serviceworker');
+  }
+  return serviceWorker.url().split('/')[2];
+}
+
+async function configureExtension(optionsPage, config, permissionOverride) {
+  if (typeof permissionOverride === 'boolean') {
+    await optionsPage.evaluate(result => {
+      const original = chrome.permissions.request.bind(chrome.permissions);
+      chrome.permissions.request = (permissions, callback) => {
+        window.__lastPermissionRequest = permissions;
+        callback(result);
+      };
+      window.__restorePermissionsRequest = () => {
+        chrome.permissions.request = original;
+      };
+    }, permissionOverride);
+  }
+
+  await optionsPage.getByLabel('Jira instance URL').fill(config.instanceUrl);
+  await optionsPage.getByLabel('Allowed pages').fill(config.domains.join(', '));
+
+  if (config.hoverDepth) {
+    await optionsPage.getByLabel('Trigger depth').selectOption(config.hoverDepth);
+  }
+  if (config.hoverModifierKey) {
+    await optionsPage.getByLabel('Modifier key').selectOption(config.hoverModifierKey);
+  }
+
+  if (config.displayFields) {
+    for (const [key, checked] of Object.entries(config.displayFields)) {
+      await optionsPage.locator(`#displayField_${key}`).setChecked(checked);
+    }
+  }
+
+  if (Array.isArray(config.customFields)) {
+    const addButton = optionsPage.getByRole('button', {name: 'Add another field'});
+    for (let index = 0; index < config.customFields.length; index += 1) {
+      const existingRows = await optionsPage.locator('.customFieldRow').count();
+      if (existingRows <= index) {
+        await addButton.click();
+      }
+      const row = optionsPage.locator('.customFieldRow').nth(index);
+      await row.getByLabel('Field ID').fill(config.customFields[index].fieldId);
+      await row.getByLabel('Location').selectOption(String(config.customFields[index].row));
+    }
+  }
+
+  await optionsPage.getByRole('button', {name: 'Save changes'}).click();
+}
+
+async function hoverIssueKey(page, selector, modifier) {
+  if (modifier) {
+    await page.keyboard.down(modifier);
+  }
+  await page.locator(selector).hover();
+  if (modifier) {
+    await page.keyboard.up(modifier);
+  }
+}
+
+async function injectContentScript(extensionApp, page) {
+  const serviceWorker = extensionApp.context.serviceWorkers()[0] || await extensionApp.context.waitForEvent('serviceworker');
+  const pageUrl = page.url();
+  await serviceWorker.evaluate(async targetUrl => {
+    const tabs = await new Promise(resolve => {
+      chrome.tabs.query({}, resolve);
+    });
+    const tab = tabs.find(candidate => candidate.url === targetUrl);
+    if (!tab?.id) {
+      throw new Error(`Could not find tab for ${targetUrl}`);
+    }
+    await chrome.scripting.executeScript({
+      target: {tabId: tab.id},
+      files: ['build/main.js'],
+    });
+  }, pageUrl);
+}
+
+const test = base.extend({
+  servers: [async ({browserName}, use) => {
+    void browserName;
+    const jira = await createMockJiraServer();
+    const allowedPage = await createFixtureServer();
+    const disallowedPage = await createFixtureServer();
+    await use({jira, allowedPage, disallowedPage});
+    await Promise.all([jira.close(), allowedPage.close(), disallowedPage.close()]);
+  }, {scope: 'worker'}],
+
+  extensionApp: async ({browserName}, use) => {
+    void browserName;
+    const {context, userDataDir, testExtensionPath} = await launchExtensionContext();
+    try {
+      const extensionId = await getExtensionId(context);
+      await use({context, extensionId, userDataDir, testExtensionPath});
+    } finally {
+      await context.close();
+      await fs.rm(userDataDir, {recursive: true, force: true});
+      await fs.rm(testExtensionPath, {recursive: true, force: true});
+    }
+  },
+
+  optionsPage: async ({extensionApp}, use) => {
+    const optionsUrl = `chrome-extension://${extensionApp.extensionId}/options/options.html`;
+    const page = extensionApp.context.pages().find(candidate => candidate.url().startsWith(optionsUrl)) || await extensionApp.context.newPage();
+    if (!page.url().startsWith(optionsUrl)) {
+      try {
+        await page.goto(optionsUrl, {waitUntil: 'domcontentloaded'});
+      } catch (error) {
+        if (!String(error?.message || '').includes('interrupted')) {
+          throw error;
+        }
+        await page.waitForURL(new RegExp(`^${optionsUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      }
+    } else {
+      await page.waitForLoadState('domcontentloaded');
+    }
+    await use(page);
+    if (!page.isClosed()) {
+      await page.close();
+    }
+  },
+});
+
+module.exports = {
+  test,
+  expect,
+  configureExtension,
+  hoverIssueKey,
+  injectContentScript,
+};

--- a/tests/e2e/helpers/fixture-server.js
+++ b/tests/e2e/helpers/fixture-server.js
@@ -1,0 +1,106 @@
+const http = require('http');
+
+function createHtml(title, body) {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${title}</title>
+    <style>
+      body { font-family: sans-serif; margin: 24px; line-height: 1.5; }
+      main { max-width: 960px; }
+      .card { border: 1px solid #ccd; border-radius: 12px; padding: 16px; margin-bottom: 16px; }
+      .stack { display: grid; gap: 12px; }
+      .deep-1, .deep-2, .deep-3, .deep-4, .deep-5 { padding: 6px; border: 1px dashed #ccd; }
+      .target { display: inline-block; padding: 6px 10px; border-radius: 8px; background: #eef3ff; }
+      .marker { font-weight: 700; color: #0b5fff; }
+      img.demo-image { width: 80px; height: 80px; object-fit: cover; border-radius: 8px; }
+    </style>
+  </head>
+  <body>
+    <main>${body}</main>
+  </body>
+</html>`;
+}
+
+function defaultRouteContent(origin) {
+  return {
+    '/': createHtml('HotLinker Fixture', `
+      <h1>Jira HotLinker Fixture</h1>
+      <div class="card">
+        <p id="issue-inline">Release review references <span class="marker">JRACLOUD-97846</span> directly in the text.</p>
+        <p id="issue-link"><a href="${origin}/browse/JRACLOUD-97846">Linked ticket JRACLOUD-97846</a></p>
+      </div>
+    `),
+    '/hover-depth': createHtml('Hover Depth Fixture', `
+      <h1>Hover Depth</h1>
+      <div class="stack">
+        <div class="card">
+          <div id="exact-target" class="target">JRACLOUD-97846</div>
+        </div>
+        <div class="card" id="shallow-parent">
+          Shallow parent contains JRACLOUD-97846
+          <span id="shallow-child" class="target">hover child</span>
+        </div>
+        <div class="card deep-1" id="deep-parent">Deep ancestor contains JRACLOUD-97846
+          <div class="deep-2">
+            <div class="deep-3">
+              <div class="deep-4">
+                <span id="deep-child" class="target">hover deep child</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `),
+    '/popup-actions': createHtml('Popup Actions Fixture', `
+      <h1>Popup Actions</h1>
+      <div class="card">
+        <p>Hover <span id="popup-key" class="marker">JRACLOUD-97846</span> to load the mock issue.</p>
+      </div>
+    `),
+    '/multi-key': createHtml('Multi Key Fixture', `
+      <h1>Multiple Jira Keys</h1>
+      <div class="stack">
+        <div class="card" style="min-height: 140px;">
+          <p>First mention: <span id="multi-key-first" class="marker">JRACLOUD-97846</span></p>
+        </div>
+        <div class="card" style="min-height: 280px; margin-top: 180px;">
+          <p>Second mention: <span id="multi-key-second" class="marker">JRACLOUD-97846</span></p>
+        </div>
+      </div>
+    `),
+  };
+}
+
+async function createFixtureServer() {
+  let origin = '';
+  let routes = {};
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, origin);
+    const content = routes[url.pathname];
+    if (!content) {
+      res.writeHead(404, {'content-type': 'text/plain; charset=utf-8'});
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200, {'content-type': 'text/html; charset=utf-8'});
+    res.end(content);
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  origin = `http://127.0.0.1:${address.port}`;
+  routes = defaultRouteContent(origin);
+
+  return {
+    origin,
+    close: () => new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve())),
+  };
+}
+
+module.exports = {
+  createFixtureServer,
+};

--- a/tests/e2e/helpers/global-setup.js
+++ b/tests/e2e/helpers/global-setup.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+const {execFileSync} = require('child_process');
+
+module.exports = async () => {
+  const repoRoot = path.resolve(__dirname, '../../..');
+  const outputDir = path.join(repoRoot, 'tests/output/playwright');
+  fs.mkdirSync(outputDir, {recursive: true});
+  execFileSync('npx', ['webpack', '--mode=development'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+};

--- a/tests/e2e/helpers/live-jira.js
+++ b/tests/e2e/helpers/live-jira.js
@@ -1,0 +1,57 @@
+function parseCsvEnv(name) {
+  return String(process.env[name] || '')
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean);
+}
+
+function getLiveJiraConfig() {
+  const instanceUrl = String(process.env.JIRA_LIVE_INSTANCE_URL || '').trim();
+  const projectKeys = parseCsvEnv('JIRA_LIVE_PROJECT_KEYS');
+  const issueKeys = parseCsvEnv('JIRA_LIVE_ISSUE_KEYS');
+  const storageStatePath = String(process.env.JIRA_LIVE_STORAGE_STATE || '').trim();
+
+  return {
+    instanceUrl,
+    projectKeys,
+    issueKeys,
+    storageStatePath,
+    isConfigured: !!instanceUrl && projectKeys.length > 0 && issueKeys.length > 0,
+    hasAuth: !!storageStatePath,
+  };
+}
+
+function getIssueProjectKey(issueKey) {
+  return String(issueKey || '').split('-')[0] || '';
+}
+
+function assertAllowedLiveIssue(issueKey, config = getLiveJiraConfig()) {
+  if (!config.instanceUrl) {
+    throw new Error('Missing JIRA_LIVE_INSTANCE_URL');
+  }
+  if (!config.projectKeys.length) {
+    throw new Error('Missing JIRA_LIVE_PROJECT_KEYS');
+  }
+  if (!config.issueKeys.length) {
+    throw new Error('Missing JIRA_LIVE_ISSUE_KEYS');
+  }
+  if (!config.issueKeys.includes(issueKey)) {
+    throw new Error(`Issue ${issueKey} is outside JIRA_LIVE_ISSUE_KEYS`);
+  }
+
+  const projectKey = getIssueProjectKey(issueKey);
+  if (!config.projectKeys.includes(projectKey)) {
+    throw new Error(`Issue ${issueKey} is outside JIRA_LIVE_PROJECT_KEYS`);
+  }
+}
+
+function getAllowedLiveIssueKeys(config = getLiveJiraConfig()) {
+  return config.issueKeys.filter(issueKey => config.projectKeys.includes(getIssueProjectKey(issueKey)));
+}
+
+module.exports = {
+  assertAllowedLiveIssue,
+  getAllowedLiveIssueKeys,
+  getIssueProjectKey,
+  getLiveJiraConfig,
+};

--- a/tests/e2e/helpers/mock-jira-server.js
+++ b/tests/e2e/helpers/mock-jira-server.js
@@ -1,0 +1,677 @@
+const http = require('http');
+
+const PNG_BUFFER = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////fwAJ+wP9KobjigAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+function json(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    'access-control-allow-origin': '*',
+    'content-type': 'application/json; charset=utf-8',
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function text(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    'access-control-allow-origin': '*',
+    'content-type': 'text/plain; charset=utf-8',
+  });
+  res.end(payload);
+}
+
+function noContent(res) {
+  res.writeHead(204, {'access-control-allow-origin': '*'});
+  res.end();
+}
+
+function issueDescriptionHtml(origin) {
+  return `
+    <p>The mock issue exercises rich rendering, quick actions, and edit flows.</p>
+    <p><a href="${origin}/browse/JRACLOUD-97846">Open issue</a></p>
+    <p><img src="${origin}/assets/inline-image.png" alt="inline evidence" /></p>
+  `;
+}
+
+function createState(origin) {
+  const now = new Date('2026-03-18T10:00:00.000Z').toISOString();
+  return {
+    scenario: 'editable',
+    currentUser: {
+      accountId: 'user-me',
+      name: 'me',
+      key: 'me',
+      displayName: 'Morgan Agent',
+      avatarUrls: {'48x48': `${origin}/assets/avatar-me.png`},
+    },
+    assignableUsers: [
+      {
+        accountId: 'user-me',
+        name: 'me',
+        key: 'me',
+        displayName: 'Morgan Agent',
+        emailAddress: 'morgan@example.com',
+        avatarUrls: {'48x48': `${origin}/assets/avatar-me.png`},
+      },
+      {
+        accountId: 'user-alex',
+        name: 'alex',
+        key: 'alex',
+        displayName: 'Alex Reviewer',
+        emailAddress: 'alex@example.com',
+        avatarUrls: {'48x48': `${origin}/assets/avatar-alex.png`},
+      },
+    ],
+    labels: ['needs-triage', 'ux-bug', 'release-candidate'],
+    boards: [{id: 77, name: 'Mock Board'}],
+    sprints: [
+      {id: 42, name: 'Sprint 42', state: 'active'},
+      {id: 43, name: 'Sprint 43', state: 'future'},
+    ],
+    issue: {
+      id: '10001',
+      key: 'JRACLOUD-97846',
+      summary: 'Pressing END removes non-command text starting with "/" in multi line text fields',
+      issuetype: {
+        id: '1',
+        name: 'Bug',
+        description: 'A problem which impairs product behavior.',
+        iconUrl: `${origin}/assets/issuetype-bug.png`,
+      },
+      status: {
+        id: '10000',
+        name: 'To Do',
+        iconUrl: `${origin}/assets/status-todo.png`,
+        statusCategory: {key: 'new', name: 'To Do'},
+      },
+      priority: {
+        id: '2',
+        name: 'Medium',
+        iconUrl: `${origin}/assets/priority-medium.png`,
+      },
+      reporter: {
+        accountId: 'user-reporter',
+        name: 'reporter',
+        key: 'reporter',
+        displayName: 'Riley Reporter',
+        avatarUrls: {'48x48': `${origin}/assets/avatar-reporter.png`},
+      },
+      assignee: {
+        accountId: 'user-alex',
+        name: 'alex',
+        key: 'alex',
+        displayName: 'Alex Reviewer',
+        avatarUrls: {'48x48': `${origin}/assets/avatar-alex.png`},
+      },
+      labels: ['needs-triage', 'ux-bug'],
+      versions: [{id: '301', name: '2026.03'}],
+      fixVersions: [{id: '401', name: '2026.04'}],
+      parent: {key: 'JRACLOUD-97000', fields: {summary: 'Editor backlog umbrella'}},
+      sprintEntries: [{id: 42, name: 'Sprint 42', state: 'active', boardId: 77}],
+      attachments: [
+        {
+          id: '900',
+          filename: 'evidence.png',
+          mimeType: 'image/png',
+          content: `${origin}/assets/evidence.png`,
+          thumbnail: `${origin}/assets/evidence.png`,
+        },
+      ],
+      comments: [
+        {
+          id: '5001',
+          author: {
+            displayName: 'Casey Commenter',
+            avatarUrls: {'48x48': `${origin}/assets/avatar-commenter.png`},
+          },
+          created: now,
+          body: 'Initial comment with a link https://example.com/docs',
+          renderedBody: '<p>Initial comment with a link <a href="https://example.com/docs">https://example.com/docs</a></p>',
+        },
+      ],
+      customFields: {
+        customfield_12345: 'Customer impact: High',
+      },
+    },
+    issueSearchCatalog: [
+      {
+        id: '10002',
+        key: 'JRACLOUD-97000',
+        fields: {
+          summary: 'Editor backlog umbrella',
+          issuetype: {
+            id: '2',
+            name: 'Task',
+            iconUrl: `${origin}/assets/issuetype-task.png`,
+          },
+          status: {
+            id: '3',
+            name: 'In Progress',
+            iconUrl: `${origin}/assets/status-in-progress.png`,
+          },
+        },
+      },
+      {
+        id: '10003',
+        key: 'JRACLOUD-98123',
+        fields: {
+          summary: 'Improve slash command cursor stability',
+          issuetype: {
+            id: '1',
+            name: 'Bug',
+            iconUrl: `${origin}/assets/issuetype-bug.png`,
+          },
+          status: {
+            id: '10000',
+            name: 'To Do',
+            iconUrl: `${origin}/assets/status-todo.png`,
+          },
+        },
+      },
+    ],
+    transitions: [
+      {
+        id: '31',
+        name: 'Start progress',
+        to: {
+          id: '3',
+          name: 'In Progress',
+          iconUrl: `${origin}/assets/status-in-progress.png`,
+          statusCategory: {key: 'indeterminate', name: 'In Progress'},
+        },
+      },
+      {
+        id: '41',
+        name: 'Done',
+        to: {
+          id: '5',
+          name: 'Done',
+          iconUrl: `${origin}/assets/status-done.png`,
+          statusCategory: {key: 'done', name: 'Done'},
+        },
+      },
+    ],
+    uploadedAttachments: [],
+  };
+}
+
+function buildIssueResponse(origin, state) {
+  const issue = state.issue;
+  const names = {
+    customfield_10020: 'Sprint',
+    customfield_12345: 'Customer Impact',
+  };
+  const fields = {
+    id: issue.id,
+    project: {key: 'JRACLOUD', id: '10000'},
+    summary: issue.summary,
+    description: issue.description,
+    reporter: issue.reporter,
+    assignee: issue.assignee,
+    issuetype: issue.issuetype,
+    status: issue.status,
+    priority: issue.priority,
+    labels: issue.labels,
+    versions: issue.versions,
+    fixVersions: issue.fixVersions,
+    parent: issue.parent,
+    attachment: issue.attachments.concat(state.uploadedAttachments),
+    comment: {comments: issue.comments.map(comment => ({
+      id: comment.id,
+      author: comment.author,
+      created: comment.created,
+      body: comment.body,
+    }))},
+    customfield_10020: issue.sprintEntries,
+    customfield_12345: issue.customFields.customfield_12345,
+  };
+  return {
+    id: issue.id,
+    key: issue.key,
+    fields,
+    names,
+    renderedFields: {
+      description: issueDescriptionHtml(origin),
+      comment: {
+        comments: issue.comments.map(comment => ({id: comment.id, body: comment.renderedBody})),
+      },
+    },
+  };
+}
+
+function buildEditmeta(state) {
+  if (state.scenario === 'readonly' || state.scenario === 'anonymous-readonly') {
+    return {fields: {}};
+  }
+  return {
+    fields: {
+      assignee: {
+        name: 'Assignee',
+        operations: ['set'],
+        schema: {type: 'user'},
+      },
+      priority: {
+        name: 'Priority',
+        operations: ['set'],
+        allowedValues: [
+          {id: '1', name: 'Highest', iconUrl: `${state.origin}/assets/priority-highest.png`},
+          {id: '2', name: 'Medium', iconUrl: `${state.origin}/assets/priority-medium.png`},
+        ],
+      },
+      issuetype: {
+        name: 'Issue Type',
+        operations: ['set'],
+        allowedValues: [
+          {id: '1', name: 'Bug', description: 'Bug', iconUrl: `${state.origin}/assets/issuetype-bug.png`},
+          {id: '2', name: 'Task', description: 'Task', iconUrl: `${state.origin}/assets/issuetype-task.png`},
+        ],
+      },
+      parent: {
+        name: 'Parent',
+        operations: ['set'],
+        schema: {type: 'issuelink'},
+      },
+      labels: {
+        name: 'Labels',
+        operations: ['set'],
+      },
+      versions: {
+        name: 'Affects versions',
+        operations: ['set'],
+      },
+      fixVersions: {
+        name: 'Fix versions',
+        operations: ['set'],
+      },
+      customfield_10020: {
+        name: 'Sprint',
+        operations: ['set'],
+        schema: {custom: 'com.pyxis.greenhopper.jira:gh-sprint', type: 'array'},
+      },
+    },
+  };
+}
+
+function parseJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      if (!body) {
+        resolve(null);
+        return;
+      }
+      try {
+        resolve(JSON.parse(body));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+async function createMockJiraServer() {
+  let origin = '';
+  const state = {};
+
+  const reset = scenario => {
+    const next = createState(origin);
+    next.origin = origin;
+    next.scenario = scenario || 'editable';
+    Object.keys(state).forEach(key => {
+      delete state[key];
+    });
+    Object.assign(state, next);
+    if (state.scenario === 'anonymous-readonly') {
+      state.issue.assignee = null;
+      state.boards = [];
+      state.sprints = state.issue.sprintEntries.map(entry => ({
+        id: entry.id,
+        name: entry.name,
+        state: entry.state,
+      }));
+    }
+    if (state.scenario === 'readonly') {
+      state.boards = [];
+    }
+    if (state.scenario === 'already-assigned-to-me') {
+      state.issue.assignee = {...state.currentUser};
+    }
+    if (state.scenario === 'in-progress-no-sprint-actions') {
+      state.issue.assignee = {...state.currentUser};
+      state.issue.status = {
+        id: '3',
+        name: 'In Progress',
+        iconUrl: `${origin}/assets/status-in-progress.png`,
+        statusCategory: {key: 'indeterminate', name: 'In Progress'},
+      };
+      state.transitions = [{
+        id: '41',
+        name: 'Done',
+        to: {
+          id: '5',
+          name: 'Done',
+          iconUrl: `${origin}/assets/status-done.png`,
+          statusCategory: {key: 'done', name: 'Done'},
+        },
+      }];
+      state.boards = [];
+      state.sprints = state.issue.sprintEntries.map(entry => ({
+        id: entry.id,
+        name: entry.name,
+        state: entry.state,
+      }));
+    }
+  };
+
+  const scenarioIn = (...names) => names.includes(state.scenario);
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, origin);
+    const pathname = url.pathname;
+
+    if (pathname.startsWith('/assets/')) {
+      res.writeHead(200, {
+        'access-control-allow-origin': '*',
+        'content-type': 'image/png',
+      });
+      res.end(PNG_BUFFER);
+      return;
+    }
+
+    if (pathname === '/__scenario' && req.method === 'POST') {
+      const body = await parseJsonBody(req).catch(() => null);
+      reset(body?.scenario || 'editable');
+      json(res, 200, {ok: true, scenario: state.scenario});
+      return;
+    }
+
+    if (pathname === '/rest/api/2/project' && req.method === 'GET') {
+      json(res, 200, [{id: '10000', key: 'JRACLOUD', name: 'Jira Cloud'}]);
+      return;
+    }
+
+    if (pathname === '/rest/api/2/field' && req.method === 'GET') {
+      json(res, 200, [
+        {id: 'customfield_10020', name: 'Sprint', schema: {custom: 'com.pyxis.greenhopper.jira:gh-sprint', type: 'array'}},
+        {id: 'customfield_12345', name: 'Customer Impact'},
+      ]);
+      return;
+    }
+
+    if (pathname === '/rest/api/2/myself' && req.method === 'GET') {
+      if (state.scenario === 'anonymous-readonly' || state.scenario === 'logged-out' || state.scenario === 'unauthorized') {
+        json(res, 401, {errorMessages: ['Not logged in']});
+        return;
+      }
+      json(res, 200, state.currentUser);
+      return;
+    }
+
+    if (pathname === '/rest/auth/1/session' && req.method === 'GET') {
+      if (state.scenario === 'anonymous-readonly' || state.scenario === 'logged-out' || state.scenario === 'unauthorized') {
+        json(res, 401, {errorMessages: ['Not logged in']});
+        return;
+      }
+      json(res, 200, {user: state.currentUser});
+      return;
+    }
+
+    if (pathname === `/rest/api/2/issue/${state.issue.key}` && req.method === 'GET') {
+      if (state.scenario === 'unauthorized') {
+        json(res, 401, {errorMessages: ['Unauthorized']});
+        return;
+      }
+      json(res, 200, buildIssueResponse(origin, state));
+      return;
+    }
+
+    if (pathname === `/rest/api/2/issue/${state.issue.key}/editmeta` && req.method === 'GET') {
+      json(res, 200, buildEditmeta(state));
+      return;
+    }
+
+    if (pathname === `/rest/api/2/issue/${state.issue.key}/transitions` && req.method === 'GET') {
+      if (state.scenario === 'readonly' || state.scenario === 'anonymous-readonly') {
+        json(res, 200, {transitions: []});
+        return;
+      }
+      json(res, 200, {transitions: state.transitions});
+      return;
+    }
+
+    if (pathname === `/rest/api/2/issue/${state.issue.key}/transitions` && req.method === 'POST') {
+      const body = await parseJsonBody(req);
+      const transitionId = body?.transition?.id;
+      const transition = state.transitions.find(candidate => candidate.id === transitionId);
+      if (!transition) {
+        json(res, 400, {errorMessages: ['Unknown transition']});
+        return;
+      }
+      state.issue.status = transition.to;
+      noContent(res);
+      return;
+    }
+
+    if (pathname === `/rest/api/2/issue/${state.issue.key}/assignee` && req.method === 'PUT') {
+      const body = await parseJsonBody(req);
+      const nextAssignee = state.assignableUsers.find(user => {
+        return user.accountId === body?.accountId || user.name === body?.name || user.key === body?.key;
+      }) || null;
+      state.issue.assignee = nextAssignee;
+      noContent(res);
+      return;
+    }
+
+    if (pathname === `/rest/api/2/issue/${state.issue.key}/comment` && req.method === 'POST') {
+      if (state.scenario === 'anonymous-readonly' || state.scenario === 'logged-out') {
+        json(res, 401, {errorMessages: ['Login required']});
+        return;
+      }
+      if (scenarioIn('comment-save-fails')) {
+        json(res, 500, {errorMessages: ['Could not save comment']});
+        return;
+      }
+      const body = await parseJsonBody(req);
+      const newComment = {
+        id: `comment-${Date.now()}`,
+        author: {displayName: state.currentUser.displayName},
+        created: new Date().toISOString(),
+        body: body?.body || '',
+        renderedBody: `<p>${String(body?.body || '').replace(/\n/g, '<br/>')}</p>`,
+      };
+      state.issue.comments.push(newComment);
+      json(res, 201, {id: newComment.id});
+      return;
+    }
+
+    if (pathname === `/rest/api/2/issue/${state.issue.key}/attachments` && req.method === 'POST') {
+      if (state.scenario === 'anonymous-readonly' || state.scenario === 'logged-out') {
+        json(res, 401, {errorMessages: ['Login required']});
+        return;
+      }
+      if (scenarioIn('attachment-upload-fails')) {
+        json(res, 500, {errorMessages: ['Could not upload pasted image']});
+        return;
+      }
+      const attachment = {
+        id: `attachment-${Date.now()}`,
+        filename: 'pasted-image.png',
+        mimeType: 'image/png',
+        content: `${origin}/assets/uploaded-image.png`,
+        thumbnail: `${origin}/assets/uploaded-image.png`,
+      };
+      state.uploadedAttachments.push(attachment);
+      json(res, 200, [attachment]);
+      return;
+    }
+
+    if (pathname.startsWith('/rest/api/2/attachment/') && req.method === 'DELETE') {
+      const attachmentId = pathname.split('/').pop();
+      state.uploadedAttachments = state.uploadedAttachments.filter(attachment => attachment.id !== attachmentId);
+      noContent(res);
+      return;
+    }
+
+    if (pathname === `/rest/api/2/issue/${state.issue.key}` && req.method === 'PUT') {
+      const body = await parseJsonBody(req);
+      const fields = body?.fields || {};
+      if (fields.priority?.id) {
+        state.issue.priority = {
+          id: String(fields.priority.id),
+          name: fields.priority.id === '1' ? 'Highest' : 'Medium',
+          iconUrl: fields.priority.id === '1' ? `${origin}/assets/priority-highest.png` : `${origin}/assets/priority-medium.png`,
+        };
+      }
+      if (fields.issuetype?.id) {
+        state.issue.issuetype = {
+          id: String(fields.issuetype.id),
+          name: fields.issuetype.id === '2' ? 'Task' : 'Bug',
+          description: fields.issuetype.id === '2' ? 'Task' : 'Bug',
+          iconUrl: fields.issuetype.id === '2' ? `${origin}/assets/issuetype-task.png` : `${origin}/assets/issuetype-bug.png`,
+        };
+      }
+      if (Array.isArray(fields.labels)) {
+        state.issue.labels = fields.labels;
+      }
+      if (Object.prototype.hasOwnProperty.call(fields, 'customfield_10020')) {
+        const sprintId = Number(fields.customfield_10020);
+        state.issue.sprintEntries = sprintId
+          ? state.sprints.filter(sprint => sprint.id === sprintId).map(sprint => ({...sprint, boardId: 77}))
+          : [];
+      }
+      if (Array.isArray(fields.versions)) {
+        state.issue.versions = fields.versions.map(entry => ({id: String(entry.id), name: entry.id === '302' ? '2026.05' : '2026.03'}));
+      }
+      if (Array.isArray(fields.fixVersions)) {
+        state.issue.fixVersions = fields.fixVersions.map(entry => ({id: String(entry.id), name: entry.id === '402' ? '2026.06' : '2026.04'}));
+      }
+      if (fields.parent?.key) {
+        const match = state.issueSearchCatalog.find(issue => issue.key === fields.parent.key);
+        state.issue.parent = match
+          ? {key: match.key, fields: {summary: match.fields.summary}}
+          : {key: fields.parent.key, fields: {summary: fields.parent.key}};
+      }
+      noContent(res);
+      return;
+    }
+
+    if (pathname === '/rest/api/2/user/assignable/search' && req.method === 'GET') {
+      const query = String(url.searchParams.get('query') || url.searchParams.get('username') || '').toLowerCase();
+      const users = state.assignableUsers.filter(user => !query || user.displayName.toLowerCase().includes(query) || user.name.toLowerCase().includes(query));
+      json(res, 200, users);
+      return;
+    }
+
+    if (pathname === '/rest/api/2/user/picker' && req.method === 'GET') {
+      if (scenarioIn('mention-search-fails')) {
+        json(res, 500, {errorMessages: ['Could not load people']});
+        return;
+      }
+      const query = String(url.searchParams.get('query') || '').toLowerCase();
+      const users = state.assignableUsers.filter(user => !query || user.displayName.toLowerCase().includes(query) || user.name.toLowerCase().includes(query));
+      json(res, 200, {users});
+      return;
+    }
+
+    if (pathname === '/rest/api/2/jql/autocompletedata/suggestions' && req.method === 'GET') {
+      if (scenarioIn('label-search-fails')) {
+        json(res, 500, {errorMessages: ['Could not load labels']});
+        return;
+      }
+      const query = String(url.searchParams.get('fieldValue') || '').toLowerCase();
+      const labels = state.labels.filter(label => !query || label.toLowerCase().includes(query));
+      json(res, 200, labels);
+      return;
+    }
+
+    if (pathname === '/rest/api/2/search' && req.method === 'GET') {
+      if (scenarioIn('issue-search-fails')) {
+        json(res, 500, {errorMessages: ['Could not search issues']});
+        return;
+      }
+      json(res, 200, {issues: state.issueSearchCatalog});
+      return;
+    }
+
+    if (pathname === '/rest/api/2/project/JRACLOUD/versions' && req.method === 'GET') {
+      json(res, 200, [
+        {id: '301', name: '2026.03'},
+        {id: '302', name: '2026.05'},
+        {id: '401', name: '2026.04'},
+        {id: '402', name: '2026.06'},
+      ]);
+      return;
+    }
+
+    if (pathname === '/rest/agile/1.0/board' && req.method === 'GET') {
+      json(res, 200, {values: state.boards});
+      return;
+    }
+
+    if (pathname === '/rest/agile/1.0/board/77/sprint' && req.method === 'GET') {
+      json(res, 200, {values: state.sprints});
+      return;
+    }
+
+    if (pathname === '/rest/dev-status/1.0/issue/detail' && req.method === 'GET') {
+      if (scenarioIn('pr-data-fails')) {
+        json(res, 500, {errorMessages: ['Dev status unavailable']});
+        return;
+      }
+      if (scenarioIn('pr-data-malformed')) {
+        json(res, 200, {detail: [{pullRequests: [{id: 'pr-1'}]}]});
+        return;
+      }
+      json(res, 200, {
+        detail: [{
+          pullRequests: [{
+            id: 'pr-1',
+            url: 'https://github.com/dgebaei/Jira-Hot-Linker/pull/1',
+            name: 'Fix slash command cursor behavior',
+            author: {name: 'Morgan Agent'},
+            source: {branch: 'fix/slash-command-end-key'},
+            status: 'OPEN',
+          }],
+        }],
+      });
+      return;
+    }
+
+    if (pathname === '/rest/dev-status/1.0/issue/summary' && req.method === 'GET') {
+      if (scenarioIn('pr-data-fails')) {
+        json(res, 500, {errorMessages: ['Dev status unavailable']});
+        return;
+      }
+      if (scenarioIn('pr-data-malformed')) {
+        json(res, 200, {summary: []});
+        return;
+      }
+      json(res, 200, {summary: [{pullrequest: {overall: {count: 1}}}]});
+      return;
+    }
+
+    text(res, 404, `Unhandled ${req.method} ${pathname}`);
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  origin = `http://127.0.0.1:${address.port}/`;
+  reset('editable');
+
+  return {
+    origin,
+    setScenario: async scenario => {
+      reset(scenario);
+    },
+    close: () => new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve())),
+  };
+}
+
+module.exports = {
+  createMockJiraServer,
+};

--- a/tests/e2e/hover-and-popup.spec.js
+++ b/tests/e2e/hover-and-popup.spec.js
@@ -1,0 +1,92 @@
+const {test, expect, configureExtension, hoverIssueKey, injectContentScript} = require('./helpers/extension-fixtures');
+
+function baseConfig(servers, overrides = {}) {
+  return {
+    instanceUrl: servers.jira.origin,
+    domains: [servers.allowedPage.origin],
+    hoverDepth: 'shallow',
+    hoverModifierKey: 'none',
+    customFields: [{fieldId: 'customfield_12345', row: 2}],
+    ...overrides,
+  };
+}
+
+async function openAllowedPage(extensionApp, servers, route = '/popup-actions') {
+  const page = await extensionApp.context.newPage();
+  await page.goto(`${servers.allowedPage.origin}${route}`);
+  await injectContentScript(extensionApp, page);
+  await expect.poll(async () => page.locator('._JX_container').count()).toBe(1);
+  return page;
+}
+
+test('injects only on configured domains', async ({extensionApp, optionsPage, servers}) => {
+  await configureExtension(optionsPage, baseConfig(servers), true);
+  await expect(optionsPage.locator('.saveNotice')).toContainText('Options saved successfully.');
+
+  const allowed = await openAllowedPage(extensionApp, servers, '/');
+  const disallowed = await extensionApp.context.newPage();
+  await disallowed.goto(`${servers.disallowedPage.origin}/`);
+
+  await expect.poll(async () => allowed.locator('._JX_container').count()).toBe(1);
+  await expect.poll(async () => disallowed.locator('._JX_container').count()).toBe(0);
+
+  await allowed.close();
+  await disallowed.close();
+});
+
+test('respects exact, shallow, and deep hover detection modes', async ({extensionApp, optionsPage, servers}) => {
+  await configureExtension(optionsPage, baseConfig(servers, {hoverDepth: 'exact'}), true);
+  let page = await openAllowedPage(extensionApp, servers, '/hover-depth');
+  await hoverIssueKey(page, '#exact-target');
+  await expect(page.locator('._JX_container')).toContainText('JRACLOUD-97846');
+  await page.keyboard.press('Escape');
+  await hoverIssueKey(page, '#shallow-child');
+  await expect(page.locator('._JX_container')).toBeEmpty();
+  await page.close();
+
+  await optionsPage.goto(`chrome-extension://${extensionApp.extensionId}/options/options.html`);
+  await configureExtension(optionsPage, baseConfig(servers, {hoverDepth: 'shallow'}), true);
+  page = await openAllowedPage(extensionApp, servers, '/hover-depth');
+  await hoverIssueKey(page, '#shallow-child');
+  await expect(page.locator('._JX_container')).toContainText('JRACLOUD-97846');
+  await page.keyboard.press('Escape');
+  await page.close();
+
+  await optionsPage.goto(`chrome-extension://${extensionApp.extensionId}/options/options.html`);
+  await configureExtension(optionsPage, baseConfig(servers, {hoverDepth: 'deep'}), true);
+  page = await openAllowedPage(extensionApp, servers, '/hover-depth');
+  await hoverIssueKey(page, '#deep-child');
+  await expect(page.locator('._JX_container')).toContainText('JRACLOUD-97846');
+  await page.close();
+});
+
+test('requires the configured modifier key before opening the popup', async ({extensionApp, optionsPage, servers}) => {
+  await configureExtension(optionsPage, baseConfig(servers, {hoverModifierKey: 'shift'}), true);
+  const page = await openAllowedPage(extensionApp, servers, '/popup-actions');
+
+  await hoverIssueKey(page, '#popup-key');
+  await expect(page.locator('._JX_container')).toBeEmpty();
+
+  await hoverIssueKey(page, '#popup-key', 'Shift');
+  await expect(page.locator('._JX_container')).toContainText('JRACLOUD-97846');
+  await page.close();
+});
+
+test('supports pinning and closing the popup', async ({extensionApp, optionsPage, servers}) => {
+  await configureExtension(optionsPage, baseConfig(servers), true);
+  const page = await openAllowedPage(extensionApp, servers, '/popup-actions');
+
+  await hoverIssueKey(page, '#popup-key');
+  const popup = page.locator('._JX_container');
+  await expect(popup).toContainText('JRACLOUD-97846');
+
+  await page.locator('._JX_pin_button').click();
+  await expect(page.locator('body')).toContainText(/Pinned/i);
+
+  await page.mouse.move(5, 5);
+  await expect(popup).toBeVisible();
+
+  await page.keyboard.press('Escape');
+  await expect(popup).toBeEmpty();
+  await page.close();
+});

--- a/tests/e2e/live-jira.spec.js
+++ b/tests/e2e/live-jira.spec.js
@@ -1,0 +1,76 @@
+const {test, expect, configureExtension, hoverIssueKey, injectContentScript} = require('./helpers/extension-fixtures');
+const {assertAllowedLiveIssue, getAllowedLiveIssueKeys, getLiveJiraConfig} = require('./helpers/live-jira');
+
+function requireLiveConfig() {
+  const config = getLiveJiraConfig();
+  test.skip(!config.isConfigured, 'Set JIRA_LIVE_INSTANCE_URL, JIRA_LIVE_PROJECT_KEYS, and JIRA_LIVE_ISSUE_KEYS to enable private Jira tests.');
+  return config;
+}
+
+function requireLiveAuthConfig() {
+  const config = requireLiveConfig();
+  test.skip(!config.hasAuth, 'Set JIRA_LIVE_STORAGE_STATE to enable authenticated private Jira tests.');
+  return config;
+}
+
+async function openLiveIssuePage(extensionApp, issueUrl) {
+  const page = await extensionApp.context.newPage();
+  await page.goto(issueUrl, {waitUntil: 'domcontentloaded'});
+  await injectContentScript(extensionApp, page);
+  await expect.poll(async () => page.locator('._JX_container').count()).toBe(1);
+  return page;
+}
+
+test('enforces the configured live Jira issue scope before running @live', async () => {
+  const config = requireLiveConfig();
+  const allowedIssueKeys = getAllowedLiveIssueKeys(config);
+
+  expect(allowedIssueKeys.length).toBeGreaterThan(0);
+  for (const issueKey of allowedIssueKeys) {
+    expect(() => assertAllowedLiveIssue(issueKey, config)).not.toThrow();
+  }
+});
+
+test('loads a popup only for explicitly allowed live Jira issues @live', async ({extensionApp, optionsPage}) => {
+  const config = requireLiveAuthConfig();
+  const allowedIssueKeys = getAllowedLiveIssueKeys(config);
+  const issueKey = allowedIssueKeys[0];
+
+  assertAllowedLiveIssue(issueKey, config);
+
+  await configureExtension(optionsPage, {
+    instanceUrl: config.instanceUrl,
+    domains: [config.instanceUrl],
+    hoverDepth: 'shallow',
+    hoverModifierKey: 'none',
+    customFields: [],
+  }, true);
+
+  const page = await openLiveIssuePage(extensionApp, `${config.instanceUrl.replace(/\/$/, '')}/browse/${issueKey}`);
+  await hoverIssueKey(page, `text=${issueKey}`);
+  await expect(page.locator('._JX_container')).toContainText(issueKey);
+  await page.close();
+});
+
+test('uses authenticated storage state on an allowed live Jira issue @live', async ({extensionApp, optionsPage}) => {
+  const config = requireLiveAuthConfig();
+  const allowedIssueKeys = getAllowedLiveIssueKeys(config);
+  const issueKey = allowedIssueKeys[0];
+
+  assertAllowedLiveIssue(issueKey, config);
+
+  await configureExtension(optionsPage, {
+    instanceUrl: config.instanceUrl,
+    domains: [config.instanceUrl],
+    hoverDepth: 'shallow',
+    hoverModifierKey: 'none',
+    customFields: [],
+  }, true);
+
+  const page = await openLiveIssuePage(extensionApp, `${config.instanceUrl.replace(/\/$/, '')}/browse/${issueKey}`);
+  await expect(page.locator('text=/Log in|Sign in/i')).toHaveCount(0);
+  await hoverIssueKey(page, `text=${issueKey}`);
+  await expect(page.locator('._JX_container')).toContainText(issueKey);
+  await expect(page.locator('._JX_container')).not.toContainText('Not logged in');
+  await page.close();
+});

--- a/tests/e2e/mock-jira-flows.spec.js
+++ b/tests/e2e/mock-jira-flows.spec.js
@@ -1,0 +1,107 @@
+const {test, expect, configureExtension, hoverIssueKey, injectContentScript} = require('./helpers/extension-fixtures');
+
+function baseConfig(servers) {
+  return {
+    instanceUrl: servers.jira.origin,
+    domains: [servers.allowedPage.origin],
+    hoverDepth: 'shallow',
+    hoverModifierKey: 'none',
+    customFields: [{fieldId: 'customfield_12345', row: 2}],
+  };
+}
+
+async function openPopup(extensionApp, servers) {
+  const page = await extensionApp.context.newPage();
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write'], {origin: servers.allowedPage.origin});
+  await page.goto(`${servers.allowedPage.origin}/popup-actions`);
+  await injectContentScript(extensionApp, page);
+  await expect.poll(async () => page.locator('._JX_container').count()).toBe(1);
+  await hoverIssueKey(page, '#popup-key');
+  await expect(page.locator('._JX_container')).toContainText('JRACLOUD-97846');
+  return page;
+}
+
+test('renders Jira metadata, comments, attachments, pull requests, and custom fields', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('editable');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  const popup = page.locator('._JX_container');
+
+  await expect(popup).toContainText('Pressing END removes non-command text');
+  await expect(popup).toContainText('Medium');
+  await expect(popup).toContainText('Sprint 42');
+  await expect(popup).toContainText('Customer impact: High');
+  await expect(popup).toContainText('Initial comment with a link');
+  await expect(popup).toContainText('Fix slash command cursor behavior');
+  await expect(page.locator('._JX_thumb')).toHaveCount(1);
+  await page.close();
+});
+
+test('copies the Jira issue link and previews attachment images', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('editable');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  await page.locator('._JX_title_copy').click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toContain('browse/JRACLOUD-97846');
+
+  await page.locator('._JX_previewable').first().click();
+  await expect(page.locator('._JX_preview_overlay')).toHaveClass(/is-open/);
+  await expect(page.locator('._JX_preview_image')).toHaveAttribute('src', /assets\//);
+  await page.keyboard.press('Escape');
+  await page.close();
+});
+
+test('supports quick actions and inline edits against mocked Jira APIs', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('editable');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  const popup = page.locator('._JX_container');
+
+  await page.locator('._JX_actions_toggle').click();
+  await page.locator('._JX_action_item[data-action-key="assign-to-me"]').click();
+  await expect(popup).toContainText('Assigned to you');
+  await expect(page.locator('._JX_title_assignee_slot [title="Assignee: Morgan Agent"]')).toHaveCount(1);
+
+  await page.locator('._JX_field_chip_edit[data-field-key="priority"]').click();
+  await page.locator('._JX_edit_option[data-field-key="priority"][data-option-id="1"]').click();
+  await page.locator('._JX_edit_input[data-field-key="priority"]').press('Enter');
+  await expect(popup).toContainText('Priority set to Highest');
+  await expect(popup).toContainText('Highest');
+
+  await page.locator('._JX_field_chip_edit[data-field-key="labels"]').click();
+  const labelInput = page.locator('._JX_edit_input[data-field-key="labels"]');
+  await labelInput.fill('release-candidate');
+  await page.locator('._JX_edit_option[data-field-key="labels"][data-option-id="release-candidate"]').click();
+  await page.locator('._JX_edit_save[data-field-key="labels"]').click();
+  await expect(popup).toContainText('Labels updated');
+  await expect(popup).toContainText('release-candidate');
+
+  await page.locator('._JX_field_chip_edit[data-field-key="status"]').click();
+  await page.locator('._JX_edit_option[data-field-key="status"][data-option-id="31"]').click();
+  await expect(popup).toContainText('Status moved to In Progress');
+  await expect(popup).toContainText('In Progress');
+
+  await page.close();
+});
+
+test('supports mentions and saving new comments in mocked mode', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('editable');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  const commentInput = page.locator('._JX_comment_input');
+  await commentInput.fill('@mor');
+  await expect(page.locator('._JX_comment_mention_option')).toContainText('Morgan Agent');
+  await commentInput.press('ArrowDown');
+  await commentInput.press('Enter');
+  await commentInput.type(' Investigated and reproduced locally.');
+  await page.locator('._JX_comment_save').click();
+
+  const newestComment = page.locator('._JX_comment').last();
+  await expect(newestComment).toContainText('Morgan Agent');
+  await expect(newestComment).toContainText('Investigated and reproduced locally.');
+  await page.close();
+});

--- a/tests/e2e/options.spec.js
+++ b/tests/e2e/options.spec.js
@@ -1,0 +1,65 @@
+const {test, expect, configureExtension} = require('./helpers/extension-fixtures');
+
+function baseConfig(servers) {
+  return {
+    instanceUrl: servers.jira.origin,
+    domains: [servers.allowedPage.origin],
+    hoverDepth: 'shallow',
+    hoverModifierKey: 'none',
+    customFields: [],
+  };
+}
+
+test('shows validation for an empty Jira instance URL', async ({optionsPage}) => {
+  await optionsPage.getByLabel('Jira instance URL').fill('');
+  await optionsPage.getByRole('button', {name: 'Save changes'}).click();
+  await expect(optionsPage.locator('.saveNotice')).toContainText('You must provide your Jira instance URL.');
+});
+
+test('validates custom field ids and resolves their names from Jira metadata', async ({optionsPage, servers}) => {
+  await configureExtension(optionsPage, baseConfig(servers), true);
+  await expect(optionsPage.locator('.saveNotice')).toContainText('Options saved successfully.');
+  await optionsPage.reload();
+
+  await optionsPage.getByRole('button', {name: 'Add another field'}).click();
+  const row = optionsPage.locator('.customFieldRow').first();
+
+  await row.getByLabel('Field ID').fill('impact');
+  await expect(row.getByText('Use a Jira custom field ID in the form customfield_12345.')).toBeVisible();
+  await expect(optionsPage.getByRole('button', {name: 'Save changes'})).toBeDisabled();
+
+  await row.getByLabel('Field ID').fill('customfield_12345');
+  await expect(row.locator('.customFieldMeta')).toContainText(/Resolved field name:|Waiting for Jira field metadata\./);
+  await expect(optionsPage.getByRole('button', {name: 'Save changes'})).toBeEnabled();
+});
+
+test('persists hover behavior and layout settings through the options page', async ({optionsPage, servers}) => {
+  await configureExtension(optionsPage, baseConfig(servers), true);
+  await expect(optionsPage.locator('.saveNotice')).toContainText('Options saved successfully.');
+  await optionsPage.reload();
+
+  await configureExtension(optionsPage, {
+    ...baseConfig(servers),
+    hoverDepth: 'deep',
+    hoverModifierKey: 'shift',
+    displayFields: {
+      comments: false,
+      pullRequests: false,
+    },
+    customFields: [{fieldId: 'customfield_12345', row: 2}],
+  }, true);
+
+  await expect(optionsPage.locator('.saveNotice')).toContainText('Options saved successfully.');
+  await optionsPage.reload();
+
+  await expect(optionsPage.getByLabel('Trigger depth')).toHaveValue('deep');
+  await expect(optionsPage.getByLabel('Modifier key')).toHaveValue('shift');
+  await expect(optionsPage.locator('#displayField_comments')).not.toBeChecked();
+  await expect(optionsPage.locator('#displayField_pullRequests')).not.toBeChecked();
+  await expect(optionsPage.locator('.customFieldRow').first().getByLabel('Field ID')).toHaveValue('customfield_12345');
+});
+
+test('shows an error when optional host permissions are denied', async ({optionsPage, servers}) => {
+  await configureExtension(optionsPage, baseConfig(servers), false);
+  await expect(optionsPage.locator('.saveNotice')).toContainText('Options not saved.');
+});

--- a/tests/e2e/partial-failures.spec.js
+++ b/tests/e2e/partial-failures.spec.js
@@ -1,0 +1,105 @@
+const {test, expect, configureExtension, hoverIssueKey, injectContentScript} = require('./helpers/extension-fixtures');
+
+function baseConfig(servers) {
+  return {
+    instanceUrl: servers.jira.origin,
+    domains: [servers.allowedPage.origin],
+    hoverDepth: 'shallow',
+    hoverModifierKey: 'none',
+    customFields: [{fieldId: 'customfield_12345', row: 2}],
+  };
+}
+
+async function openPopup(extensionApp, servers) {
+  const page = await extensionApp.context.newPage();
+  await page.goto(`${servers.allowedPage.origin}/popup-actions`);
+  await injectContentScript(extensionApp, page);
+  await expect.poll(async () => page.locator('._JX_container').count()).toBe(1);
+  await hoverIssueKey(page, '#popup-key');
+  await expect(page.locator('._JX_container')).toContainText('JRACLOUD-97846');
+  return page;
+}
+
+test('keeps core issue rendering when pull request endpoints fail', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('pr-data-fails');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  const popup = page.locator('._JX_container');
+  await expect(popup).toContainText('Pressing END removes non-command text');
+  await expect(popup).not.toContainText('Fix slash command cursor behavior');
+  await expect(page.locator('._JX_related_pr')).toHaveCount(0);
+  await page.close();
+});
+
+test('keeps the popup usable when pull request payloads are malformed', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('pr-data-malformed');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  const popup = page.locator('._JX_container');
+  await expect(popup).toContainText('Initial comment with a link');
+  await expect(popup).not.toContainText('Fix slash command cursor behavior');
+  await page.close();
+});
+
+test('falls back to a non-editable labels chip when label suggestions are unavailable', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('label-search-fails');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  await expect(page.locator('._JX_field_chip_edit[data-field-key="labels"]')).toHaveCount(0);
+  await expect(page.locator('body')).toContainText('Labels: needs-triage, ux-bug');
+  await page.close();
+});
+
+test('shows an inline editor error when issue search fails for parent selection', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('issue-search-fails');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  await page.locator('._JX_field_chip_edit[data-field-key="parentLink"]').click();
+  await page.locator('._JX_edit_input[data-field-key="parentLink"]').fill('98123');
+  await expect(page.locator('._JX_edit_hint')).toContainText('Searching parent');
+  await expect.poll(async () => (await page.locator('._JX_edit_error').textContent()) || '', {timeout: 15000}).toMatch(/\S+/);
+  await page.close();
+});
+
+test('shows a composer error when saving a comment fails', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('comment-save-fails');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  const commentInput = page.locator('._JX_comment_input');
+  await commentInput.fill('This should fail to save');
+  await expect(page.locator('._JX_comment_save')).toBeEnabled();
+  await page.locator('._JX_comment_save').click();
+  await expect.poll(async () => (await page.locator('._JX_comment_error').textContent()) || '').toContain('HTTP 500 - Internal Server Error');
+  await page.close();
+});
+
+test('shows a mention lookup error when people search fails', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('mention-search-fails');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  const commentInput = page.locator('._JX_comment_input');
+  await commentInput.fill('@mor');
+  await expect(page.locator('._JX_comment_mentions')).toContainText('Could not load people.');
+  await page.close();
+});
+
+test('discards comment drafts and clears the composer state', async ({extensionApp, optionsPage, servers}) => {
+  await servers.jira.setScenario('editable');
+  await configureExtension(optionsPage, baseConfig(servers), true);
+
+  const page = await openPopup(extensionApp, servers);
+  const commentInput = page.locator('._JX_comment_input');
+  await commentInput.fill('Draft comment');
+  await expect(page.locator('._JX_comment_save')).toBeEnabled();
+  await page.locator('._JX_comment_discard').click();
+  await expect(commentInput).toHaveValue('');
+  await expect(page.locator('._JX_comment_error')).toHaveText('');
+  await expect(page.locator('._JX_comment_save')).toBeDisabled();
+  await page.close();
+});

--- a/tests/e2e/public-jira.spec.js
+++ b/tests/e2e/public-jira.spec.js
@@ -1,0 +1,44 @@
+const {test, expect, configureExtension, hoverIssueKey, injectContentScript} = require('./helpers/extension-fixtures');
+
+async function openPublicPage(extensionApp, url) {
+  const page = await extensionApp.context.newPage();
+  await page.goto(url, {waitUntil: 'domcontentloaded'});
+  await injectContentScript(extensionApp, page);
+  await expect.poll(async () => page.locator('._JX_container').count()).toBe(1);
+  return page;
+}
+
+test('loads a popup on the public Atlassian issue page @public', async ({extensionApp, optionsPage}) => {
+  test.skip(process.env.RUN_PUBLIC_JIRA_TESTS !== '1', 'Set RUN_PUBLIC_JIRA_TESTS=1 to run live public Jira smoke tests.');
+
+  await configureExtension(optionsPage, {
+    instanceUrl: 'https://jira.atlassian.com/',
+    domains: ['https://jira.atlassian.com/'],
+    hoverDepth: 'shallow',
+    hoverModifierKey: 'none',
+    customFields: [],
+  }, true);
+
+  const page = await openPublicPage(extensionApp, 'https://jira.atlassian.com/browse/JRACLOUD-97846');
+
+  await hoverIssueKey(page, 'text=JRACLOUD-97846');
+  await expect(page.locator('._JX_container')).toContainText('JRACLOUD-97846');
+  await page.close();
+});
+
+test('loads a popup from the public Atlassian search results page @public', async ({extensionApp, optionsPage}) => {
+  test.skip(process.env.RUN_PUBLIC_JIRA_TESTS !== '1', 'Set RUN_PUBLIC_JIRA_TESTS=1 to run live public Jira smoke tests.');
+
+  await configureExtension(optionsPage, {
+    instanceUrl: 'https://jira.atlassian.com/',
+    domains: ['https://jira.atlassian.com/'],
+    hoverDepth: 'shallow',
+    hoverModifierKey: 'none',
+    customFields: [],
+  }, true);
+
+  const page = await openPublicPage(extensionApp, 'https://jira.atlassian.com/issues/?jql=project%3DJRACLOUD%20AND%20type%3DBug%20AND%20statusCategory!%3DDone%20ORDER%20BY%20updated');
+  await hoverIssueKey(page, 'text=JRACLOUD-97846');
+  await expect(page.locator('._JX_container')).toContainText('JRACLOUD-97846');
+  await page.close();
+});


### PR DESCRIPTION
## Summary
- add a Playwright-based end-to-end suite for Jira HotLinker with mocked extension coverage for options, activation, hover behavior, popup rendering, inline edits, and failure states
- add public and private Jira smoke-test scaffolding with report merging, live issue-scope guardrails, and authenticated storage-state support for safe future runs
- document the test strategy and usage with a dedicated test plan, auth capture helper, and `tests/README.md`

## Testing
- npm run test:e2e:extension
- npm run test:e2e:live